### PR TITLE
feat: messages "info" level instead of "error"

### DIFF
--- a/Assets/Sentry/Scripts/Sentry.cs
+++ b/Assets/Sentry/Scripts/Sentry.cs
@@ -384,6 +384,7 @@ namespace Sentry
         public string message;
         public string timestamp;
         public string logger;
+        public string level;
         public string platform = "csharp";
         public string release;
         public Context contexts;
@@ -398,6 +399,7 @@ namespace Sentry
             this.event_id = Guid.NewGuid().ToString("N");
             this.message = message;
             this.timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH\\:mm\\:ss");
+            this.level = "error";
             this.breadcrumbs = breadcrumbs;
             this.contexts = new Context();
             this.release = Application.version;

--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -262,6 +262,7 @@ public class SentrySdk : MonoBehaviour
 
         var evt = new SentryEvent(message, bcrumbs);
         PrepareEvent(evt);
+        evt.level = "info";
 
         var s = JsonUtility.ToJson(evt);
 


### PR DESCRIPTION
The Unity SDK has no capacity for sending anything other than an error, so I've modified the `CaptureMessage` flow to be a less serious level.