### PR TITLE
Typo in method AddBreadcrumb

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ run headless. There are two important APIs that are worth considering.
 * collecting breadcrumbs
 
   ```C#
-  SentrySdk.AddBreadcrump(string)
+  SentrySdk.AddBreadcrumb(string)
   ```
 
   will collect a breadcrumb.


### PR DESCRIPTION
Just doing my civic duty, saw this when I came across the SDK for the first time.