### PR TITLE
Handle LogType other than Exception

### DIFF
--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -306,7 +306,7 @@ public class SentrySdk : MonoBehaviour
 #else
             string message = type.ToString() + ": " + condition;
 #endif
-            ScheduleException( message, stackTrace );
+            ScheduleException(message, stackTrace);
         }
     }
 

--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -297,7 +297,7 @@ public class SentrySdk : MonoBehaviour
         _timeLastError = Time.time;
         if (type == LogType.Exception)
         {
-            ScheduleException( condition, stackTrace );
+            ScheduleException (condition, stackTrace);
         }
         else
         {

--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -295,7 +295,7 @@ public class SentrySdk : MonoBehaviour
             return; // silently drop the event on the floor
         }
         _timeLastError = Time.time;
-        if(type == LogType.Exception)
+        if (type == LogType.Exception)
         {
             ScheduleException( condition, stackTrace );
         }
@@ -381,4 +381,3 @@ public class SentrySdk : MonoBehaviour
         }
     }
 }
-

--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -297,7 +297,7 @@ public class SentrySdk : MonoBehaviour
         _timeLastError = Time.time;
         if (type == LogType.Exception)
         {
-            ScheduleException (condition, stackTrace);
+            ScheduleException(condition, stackTrace);
         }
         else
         {

--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -295,7 +295,19 @@ public class SentrySdk : MonoBehaviour
             return; // silently drop the event on the floor
         }
         _timeLastError = Time.time;
-        ScheduleException(condition, stackTrace);
+        if(type == LogType.Exception)
+        {
+            ScheduleException( condition, stackTrace );
+        }
+        else
+        {
+#if NET_4_6
+            string message = $"{type.ToString()}: {condition}";
+#else
+            string message = type.ToString() + ": " + condition;
+#endif
+            ScheduleException( message, stackTrace );
+        }
     }
 
     private void PrepareEvent(SentryEvent @event)


### PR DESCRIPTION
It will help fix the case when we try to log error.
For example when we call ScheduleException with "Error test" as condition it will call IndexOutOfBoundsException here(SendrySdk.cs:177):
`        var exc = condition.Split(new char[] { ':' }, 2); `
`        var excType = exc[0];`
`        var excValue = exc[1].Substring(1); // strip the space`