### PR TITLE
Allow user to capture any kind of event

### DIFF
--- a/Assets/Sentry/Scripts/SentrySdk.cs
+++ b/Assets/Sentry/Scripts/SentrySdk.cs
@@ -84,7 +84,7 @@ public class SentrySdk : MonoBehaviour
         _instance.DoCaptureMessage(message);
     }
 
-    public static void CaptureEvent(SentryEvent @event)
+    public static void CaptureEvent<T>(T @event) where T : SentryEvent
     {
         if (_instance == null)
         {


### PR DESCRIPTION
With this change, we can now capture `SentryExceptionEvent` proceduraly. Which allow better error handling.