### PR TITLE
use relative URL for sentry-dotnet submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sentry-dotnet"]
 	path = src/sentry-dotnet-unity/sentry-dotnet
-	url = ../sentry-dotnet.git
+	url = ../../sentry-dotnet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sentry-dotnet"]
 	path = src/sentry-dotnet-unity/sentry-dotnet
-	url = git@github.com:getsentry/sentry-dotnet.git
+	url = ../sentry-dotnet.git


### PR DESCRIPTION
Allows either HTTPS or SSH recursive cloning to work without switching protocols.