### PR TITLE
Json for Sentry config

### DIFF
--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -65,7 +65,7 @@ namespace Sentry.Unity.Editor
                 var emptyOptions = JsonSerializer.Serialize(UnitySentryOptionsDefault, _jsonOptions);
                 File.WriteAllText(SentryOptionsJsonPathFull, emptyOptions);
 
-                // Must be called, otherwise Unity won't be able to load it with the nex call. *.meta should be created for new file
+                // Must be called, otherwise Unity won't be able to load it with the next call. *.meta should be created for new file
                 AssetDatabase.Refresh();
             }
 
@@ -126,6 +126,8 @@ namespace Sentry.Unity.Editor
 
             var text = JsonSerializer.Serialize(Options, _jsonOptions);
             File.WriteAllText(SentryOptionsJsonPathFull, text);
+            // Write is not enough for Unity, must update its asset database.
+            AssetDatabase.Refresh();
 
             /*AssetDatabase.SaveAssets();
             // TODO: This should be gone

--- a/src/Sentry.Unity/SentryInitialization.cs
+++ b/src/Sentry.Unity/SentryInitialization.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using CompressionLevel = System.IO.Compression.CompressionLevel;
@@ -26,15 +28,24 @@ namespace Sentry.Unity
         internal static LogTimeDebounce LogTimeDebounce = new(TimeSpan.FromSeconds(1));
 
         internal static bool IsInit { get; private set; }
+        private static readonly JsonSerializerOptions _jsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        private static string SentryOptionsJsonPath => $"Sentry/SentryOptionsJson";
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
-            if (!(Resources.Load("Sentry/SentryOptions") is UnitySentryOptions options))
+            var sentryOptionsTextAsset = Resources.Load<TextAsset>(SentryOptionsJsonPath);
+            var options = JsonSerializer.Deserialize<UnitySentryOptions>(sentryOptionsTextAsset.text, _jsonOptions)!;
+
+            /*if (!(Resources.Load("Sentry/SentryOptions") is UnitySentryOptions options))
             {
                 Debug.LogWarning("Sentry Options asset not found. Did you configure it on Component/Sentry?");
                 return;
-            }
+            }*/
 
             if (!options.Enabled)
             {

--- a/src/Sentry.Unity/link.xml
+++ b/src/Sentry.Unity/link.xml
@@ -28,6 +28,8 @@
         <type fullname="System.ComponentModel.UInt32Converter" preserve="all"/>
         <type fullname="System.ComponentModel.UInt64Converter" preserve="all"/>
     </assembly>
+    
+    <assembly fullname="System.Text.Json" preserve="all"/>
 
     <!--https://docs.microsoft.com/en-us/dotnet/api/system.linq.expressions.lambdaexpression.name?view=netframework-4.7.2&viewFallbackFrom=netframework-2.0-->
     <assembly fullname="System.Core">

--- a/src/test/Sentry.Unity.Editor.Tests/EditorModeTests.cs
+++ b/src/test/Sentry.Unity.Editor.Tests/EditorModeTests.cs
@@ -9,7 +9,8 @@ namespace Sentry.Unity.Editor.Tests
 {
     public sealed class EditorModeTests
     {
-        [UnitySetUp]
+        // Disabled (json approach)
+        // [UnitySetUp]
         public IEnumerator InitializeOptions()
         {
             // Due to an issue, Sentry doesn't always load UnitySentryOptions, which

--- a/src/test/Sentry.Unity.Tests/PlayModeTests.cs
+++ b/src/test/Sentry.Unity.Tests/PlayModeTests.cs
@@ -11,7 +11,8 @@ namespace Sentry.Unity.Tests
 {
     public sealed class PlayModeTests
     {
-        [UnitySetUp]
+        // Disabled (json approach)
+        // [UnitySetUp]
         public IEnumerator InitializeOptions()
         {
             // Due to an issue, Sentry doesn't always load UnitySentryOptions, which


### PR DESCRIPTION
No `ScriptableObject` for Sentry config. Quick & dirty. `UnitySentryOptions` reused.

* tested on
  * editor
  * Win mono build 
* issues
  *  json doesn't work on `IL2CPP` Win build although I added it to the `lnks.xml`, have I missed something?
  * build for android is around 16m, but until `IL2CPP` works, haven't tried it yet