### PR TITLE
Moved SentryWindow from 'Component' to 'Tools' menu

### DIFF
--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -7,7 +7,7 @@ namespace Sentry.Unity.Editor
 {
     public class SentryWindow : EditorWindow
     {
-        [MenuItem("Component/Sentry")]
+        [MenuItem("Tools/Sentry")]
         public static SentryWindow OpenSentryWindow()
             => (SentryWindow)GetWindow(typeof(SentryWindow));
 


### PR DESCRIPTION
This change should reflect the purpose of the Sentry menu item better.
The Component menu is generally only used for the attachment of MonoBehaviours

Taken from the Unity [asset store submission guidelines](https://unity3d.com/de/asset-store/sell-assets/submission-guidelines):

> 4.3.1.a Editor extension file menus must be placed under an existing entry. If no existing menus are a good fit, you can place it under a custom menu titled "Tools". This keeps the editor clean and organized.