### PR TITLE
Proper sdk name reporting for sentry event; test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Strip zeroes for ill2cpp builds (#108)
-- Proper sdk name reporting for sentry event (#96)
+- Proper sdk name reporting for sentry event (#111)
 
 ## 0.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-- Strip zeroes for ill2cpp builds(#108)
+- Strip zeroes for ill2cpp builds (#108)
+- Proper sdk name reporting for sentry event (#96)
 
 ## 0.0.6
 

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -11,7 +11,8 @@ namespace Sentry.Unity
 {
     internal static class UnitySdkInfo
     {
-        public static string Version { get; } = Assembly.GetCallingAssembly().GetName().Version.ToString();
+        public static string Version { get; } = typeof(UnitySdkInfo).Assembly.GetName().Version.ToString();
+
 
         public const string Name = "sentry.dotnet.unity";
         public const string PackageName = "upm:sentry.unity";

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -8,21 +8,20 @@ using DeviceOrientation = Sentry.Protocol.DeviceOrientation;
 
 namespace Sentry.Unity
 {
+    internal static class UnitySdkInfo
+    {
+        public const string Version = "0.0.1-alpha";
+        public const string Name = "sentry.dotnet.unity";
+        public const string PackageName = "github:sentry.unity";
+    }
+
     internal class UnityEventProcessor : ISentryEventProcessor
     {
-        public SentryEvent? Process(SentryEvent @event)
+        public SentryEvent Process(SentryEvent @event)
         {
-            if (@event is null)
-            {
-                return null;
-            }
-            // Add some Unity specific context:
-
-            var version = "0.0.1-alpha";
-            // TODO Sdk shouldn't be marked as nullable
-            @event.Sdk!.AddPackage("github:sentry.unity", version);
-            @event.Sdk.Name = "sentry.unity";
-            @event.Sdk.Version = version;
+            @event.Sdk.AddPackage(UnitySdkInfo.PackageName, UnitySdkInfo.Version);
+            @event.Sdk.Name = UnitySdkInfo.Name;
+            @event.Sdk.Version = UnitySdkInfo.Version;
 
             @event.Contexts.OperatingSystem.Name = SystemInfo.operatingSystem;
 

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using Sentry.Extensibility;
 using Sentry.Protocol;
 using UnityEngine;
@@ -10,9 +11,10 @@ namespace Sentry.Unity
 {
     internal static class UnitySdkInfo
     {
-        public const string Version = "0.0.1-alpha";
+        public static string Version { get; } = Assembly.GetCallingAssembly().GetName().Version.ToString();
+
         public const string Name = "sentry.dotnet.unity";
-        public const string PackageName = "github:sentry.unity";
+        public const string PackageName = "upm:sentry.unity";
     }
 
     internal class UnityEventProcessor : ISentryEventProcessor

--- a/src/test/Sentry.Unity.Tests/PlayModeTests.cs
+++ b/src/test/Sentry.Unity.Tests/PlayModeTests.cs
@@ -123,6 +123,28 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(string.Empty, sentryExceptionFirstFrame.FileName);
         }
 
+        [UnityTest]
+        public IEnumerator UnityEventProcessor_SdkInfo_Correct()
+        {
+            yield return SetupSceneCoroutine("BugFarmScene");
+
+            // arrange
+            var unityEventProcessor = new UnityEventProcessor();
+            var sentryEvent = new SentryEvent();
+
+            // act
+            unityEventProcessor.Process(sentryEvent);
+
+            // assert
+            Assert.AreEqual(UnitySdkInfo.Name, sentryEvent.Sdk.Name);
+            Assert.AreEqual(UnitySdkInfo.Version, sentryEvent.Sdk.Version);
+
+            var package = sentryEvent.Sdk.Packages.FirstOrDefault();
+            Assert.IsNotNull(package);
+            Assert.AreEqual(UnitySdkInfo.PackageName, package!.Name);
+            Assert.AreEqual(UnitySdkInfo.Version, package!.Version);
+        }
+
         private static IEnumerator SetupSceneCoroutine(string sceneName)
         {
             // load scene with initialized Sentry, SceneManager.LoadSceneAsync(sceneName);


### PR DESCRIPTION
* check version numbers and naming for package too. I guess the version should be different
* removed nullability for `SentryEvent` and `Sdk` based on `dotnet Sentry SDK`, it's still on `ISentryEventProcessor`, but from usage perspective it's **not** nullable

closes #96