### PR TITLE
use readme from package dir

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,10 +179,11 @@ jobs:
           New-Item "package-release" -ItemType Directory
 
           # Copy `package-dev` stuff
-          Copy-Item "package-dev/*" -Destination "package-release/" -Exclude "package.json", "Tests", "Tests.meta", "*.asmdef", "*.asmdef.meta" -Recurse
+          Copy-Item "package-dev/*" -Destination "package-release/" -Exclude "README.md", "package.json", "Tests", "Tests.meta", "*.asmdef", "*.asmdef.meta" -Recurse
 
           # Copy `package` stuff
           Copy-Item "package/package.json" -Destination "package-release/package.json"
+          Copy-Item "package/README.md" -Destination "package-release/README.md"
           Get-ChildItem "package/Editor/" -Include "*.asmdef", "*.asmdef.meta" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Editor/" }
           Get-ChildItem "package/Runtime/" -Include "*.asmdef", "*.asmdef.meta" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Runtime/" }
 


### PR DESCRIPTION
The idea here is to use the `README.md` from the 'package template directory'

Possibly better idea is to just copy all files from `package` since it's supposed to be the template directory now (i.e: All files in it will go into the package as-is)

#skip-changelog