### PR TITLE
#119 check for options file and disable logger if not found

### DIFF
--- a/src/Sentry.Unity.Editor/SentryTestWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryTestWindow.cs
@@ -14,7 +14,7 @@ namespace Sentry.Unity.Editor
         public void Dispose()
         {
             Close(); // calls 'OnLostFocus' implicitly
-            File.Delete(SentryOptionsAssetPath);
+            File.Delete(UnitySentryOptions.GetConfigPath());
             AssetDatabase.Refresh();
         }
     }

--- a/src/Sentry.Unity.Editor/SentryTestWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryTestWindow.cs
@@ -14,7 +14,7 @@ namespace Sentry.Unity.Editor
         public void Dispose()
         {
             Close(); // calls 'OnLostFocus' implicitly
-            File.Delete(UnitySentryOptions.GetConfigPath());
+            File.Delete(UnitySentryOptions.GetConfigPath(SentryOptionsAssetName));
             AssetDatabase.Refresh();
         }
     }

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -14,10 +14,6 @@ namespace Sentry.Unity.Editor
 
         protected virtual string SentryOptionsAssetName { get; } = UnitySentryOptions.ConfigName;
 
-        // Will be used only from Unity Editor
-        protected string SentryOptionsAssetPath
-            => $"{Application.dataPath}/Resources/{UnitySentryOptions.ConfigRootFolder}/{SentryOptionsAssetName}.json";
-
         public UnitySentryOptions Options { get; set; } = null!; // Set by OnEnable()
 
         public event Action<ValidationError> OnValidationError = _ => { };
@@ -35,7 +31,7 @@ namespace Sentry.Unity.Editor
 
         private UnitySentryOptions LoadUnitySentryOptions()
         {
-            if (File.Exists(SentryOptionsAssetPath))
+            if (File.Exists(UnitySentryOptions.GetConfigPath()))
             {
                 return UnitySentryOptions.LoadFromUnity();
             }
@@ -43,7 +39,7 @@ namespace Sentry.Unity.Editor
             var unitySentryOptions = new UnitySentryOptions { Enabled = true };
             unitySentryOptions
                 .TryAttachLogger()
-                .SaveToUnity(SentryOptionsAssetPath);
+                .SaveToUnity(UnitySentryOptions.GetConfigPath());
 
             return unitySentryOptions;
         }
@@ -98,7 +94,7 @@ namespace Sentry.Unity.Editor
         {
             Validate();
 
-            Options.SaveToUnity(SentryOptionsAssetPath);
+            Options.SaveToUnity(UnitySentryOptions.GetConfigPath());
             AssetDatabase.Refresh();
         }
 

--- a/src/Sentry.Unity/Properties/AssemblyInfo.cs
+++ b/src/Sentry.Unity/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Sentry.Unity.Tests")]
+[assembly: InternalsVisibleTo("Sentry.Unity.Editor")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Editor.Tests")]

--- a/src/Sentry.Unity/SentryInitialization.cs
+++ b/src/Sentry.Unity/SentryInitialization.cs
@@ -32,9 +32,9 @@ namespace Sentry.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
-            if (!File.Exists($"{Application.dataPath}/Resources/{UnitySentryOptions.ConfigRootFolder}/{UnitySentryOptions.ConfigName}.json"))
+            if (!File.Exists(UnitySentryOptions.GetConfigPath()))
             {
-                Debug.LogWarning("Sentry Logging has been disabled.\nSentry has not been configured yet. Please go to Tools/Sentry...");
+                Debug.LogWarning("Couldn't find the configuration file SentryOptions.json. Did you already configure Sentry?\nYou can do that through the editor: Tools -> Sentry");
                 return;
             }
 

--- a/src/Sentry.Unity/SentryInitialization.cs
+++ b/src/Sentry.Unity/SentryInitialization.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -31,6 +32,12 @@ namespace Sentry.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
+            if (!File.Exists($"{Application.dataPath}/Resources/{UnitySentryOptions.ConfigRootFolder}/{UnitySentryOptions.ConfigName}.json"))
+            {
+                Debug.LogWarning("Sentry Logging has been disabled.\nSentry has not been configured yet. Please go to Tools/Sentry...");
+                return;
+            }
+
             var options = UnitySentryOptions.LoadFromUnity();
 
             if (!options.Enabled)

--- a/src/Sentry.Unity/UnitySentryOptions.cs
+++ b/src/Sentry.Unity/UnitySentryOptions.cs
@@ -26,6 +26,9 @@ namespace Sentry.Unity
         /// </summary>
         public const string ConfigName = "SentryOptions";
 
+        public static string GetConfigPath(string? notDefaultConfigName = null)
+            => $"{Application.dataPath}/Resources/{ConfigRootFolder}/{notDefaultConfigName ?? ConfigName}.json";
+
         /// <summary>
         /// UPM name of Sentry Unity SDK (package.json)
         /// </summary>

--- a/src/Sentry.Unity/UnitySentryOptions.cs
+++ b/src/Sentry.Unity/UnitySentryOptions.cs
@@ -1,8 +1,11 @@
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Sentry.Extensibility;
 using UnityEngine;
+
+[assembly: InternalsVisibleTo("Sentry.Unity.Editor")]
 
 namespace Sentry.Unity
 {
@@ -26,7 +29,7 @@ namespace Sentry.Unity
         /// </summary>
         public const string ConfigName = "SentryOptions";
 
-        public static string GetConfigPath(string? notDefaultConfigName = null)
+        internal static string GetConfigPath(string? notDefaultConfigName = null)
             => $"{Application.dataPath}/Resources/{ConfigRootFolder}/{notDefaultConfigName ?? ConfigName}.json";
 
         /// <summary>

--- a/src/Sentry.Unity/UnitySentryOptions.cs
+++ b/src/Sentry.Unity/UnitySentryOptions.cs
@@ -26,7 +26,7 @@ namespace Sentry.Unity
         /// </summary>
         public const string ConfigName = "SentryOptions";
 
-        public static string GetConfigPath(string? notDefaultConfigName = null)
+        internal static string GetConfigPath(string? notDefaultConfigName = null)
             => $"{Application.dataPath}/Resources/{ConfigRootFolder}/{notDefaultConfigName ?? ConfigName}.json";
 
         /// <summary>

--- a/src/Sentry.Unity/UnitySentryOptions.cs
+++ b/src/Sentry.Unity/UnitySentryOptions.cs
@@ -1,11 +1,8 @@
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Sentry.Extensibility;
 using UnityEngine;
-
-[assembly: InternalsVisibleTo("Sentry.Unity.Editor")]
 
 namespace Sentry.Unity
 {

--- a/src/Sentry.Unity/UnitySentryOptions.cs
+++ b/src/Sentry.Unity/UnitySentryOptions.cs
@@ -26,7 +26,7 @@ namespace Sentry.Unity
         /// </summary>
         public const string ConfigName = "SentryOptions";
 
-        internal static string GetConfigPath(string? notDefaultConfigName = null)
+        public static string GetConfigPath(string? notDefaultConfigName = null)
             => $"{Application.dataPath}/Resources/{ConfigRootFolder}/{notDefaultConfigName ?? ConfigName}.json";
 
         /// <summary>


### PR DESCRIPTION
We check for the config file before we try to load them.
If not found -> Print out "What to do" for the user and skip Sentry initilization.

#skip-changelog