### PR TITLE
Ci build caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
     paths:
     - 'src/**'
     - 'sample/**'
-    - '.github/workflows/ci.yaml'
 
 env:
   # Download links are sourced from here: https://unity3d.com/unity/whats-new/2019.4.21
@@ -87,7 +86,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: artifacts/build
-          key: test-key
+          key: ${{ env.UNITY_DOWNLOAD_URL }}-${{ env.UNITY_TARGET_DOWNLOAD_URL }}
 
       - name: Build project
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
     paths:
     - 'src/**'
     - 'sample/**'
+    - '.github/workflows/ci.yaml'
 
 env:
   # Download links are sourced from here: https://unity3d.com/unity/whats-new/2019.4.21

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,12 @@ jobs:
             Write-Host "::error ::Failed to activate license after multiple attempts."
           }
 
+      - name: Restore previous build
+        uses: actions/cache@v2
+        with:
+          path: artifacts/build
+          key: test-key
+
       - name: Build project
         run: |
           unity -quit -batchmode -nographics -logFile - -projectPath samples/unity-of-bugs -buildWindows64Player ../../artifacts/build/game.exe | Out-Default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- CI build caching to speed up build times (#)
 - UPM meta updated (#124)
 
 ## 0.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- CI build caching to speed up build times (#)
 - UPM meta updated (#124)
 - Bump dotnet 3.3.4 (#132)
   - https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#334


### PR DESCRIPTION
This is just a temporary thing to test if the build-times are indeed sped up by caching the build. Proper key/naming follows if it works.

#skip-changelog