### PR TITLE
build log only on failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
   pull_request:
     paths:
+    - '.github/**/*.yaml'
     - 'src/**'
     - 'sample/**'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,12 +86,6 @@ jobs:
         run: |
           unity -quit -batchmode -nographics -logFile - -projectPath samples/unity-of-bugs -buildWindows64Player ../../artifacts/build/game.exe | Out-Default
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: Build output
-          path: artifacts/build
-
       # The working directory must be set because the project uses
       # relative paths for certain things.
       # Also, we need to provide the path to Unity because
@@ -204,6 +198,13 @@ jobs:
 
           # Create zip
           Compress-Archive "package-release/*" -DestinationPath "package-release.zip" -Force
+
+      - name: Upload build artifacts if build failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: Build output
+          path: artifacts/build
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
#skip-changelog

This build log is huge:
![image](https://user-images.githubusercontent.com/1633368/116160853-c4c35780-a6c0-11eb-861a-8ee05c6c67c2.png)


Also, shaves off a whole **16ms** off of the build time 😎 