### PR TITLE
POC: FPS metric

### DIFF
--- a/src/Sentry.Unity/SentryBehavior.cs
+++ b/src/Sentry.Unity/SentryBehavior.cs
@@ -1,18 +1,68 @@
-﻿using Sentry;
+﻿using System;
+using System.Collections;
+using System.Threading;
 using UnityEngine;
-using Sentry.Unity;
-using System;
-using Sentry.Protocol;
 
-public class SentryBehavior : MonoBehaviour
+namespace Sentry.Unity
 {
-    public void Disable()
+    public class SentryBehavior : MonoBehaviour
     {
-  
-    }
+        private int goodFrames;
+        private int slowFrames;
+        private int frozFrames;
 
-    // TODO: Flush events. See note on OnApplicationQuit
-    //private void OnApplicationPause() => 
-    // TODO: Flush events, see note on OnApplicationQuit
-    // private void OnApplicationFocus { if (!focusStatus) Flush events! }
+        private float slowThreshold = 0.02f;
+        private float frozThreshold = 1.0f;
+
+        private float lastTime;
+
+        private void Start()
+        {
+            frozThreshold = Time.maximumDeltaTime;
+        }
+
+        private void Update()
+        {
+            MeasureDeltaTime();
+            CheckFrame();
+
+            if (Input.GetKeyDown(KeyCode.S))
+            {
+                var sleepDuration = Time.maximumDeltaTime + 0.1f;
+                Debug.Log($"<color=red>=========== Sleep for: {sleepDuration}ms ===========</color>");
+                Thread.Sleep((int)(sleepDuration * 1000));
+            }
+        }
+
+        private void MeasureDeltaTime()
+        {
+            var measuredDeltaTime = Time.realtimeSinceStartup - lastTime;
+            lastTime = Time.realtimeSinceStartup;
+            Debug.Log($"Measured delta time: {measuredDeltaTime}");
+        }
+
+        private void CheckFrame()
+        {
+            if (Time.deltaTime >= frozThreshold)
+            {
+                frozFrames++;
+            }
+            else if (Time.deltaTime > slowThreshold)
+            {
+                slowFrames++;
+            }
+            else
+            {
+                goodFrames++;
+            }
+
+            Debug.Log($"Good: {goodFrames} | Slow: {slowFrames} | Frozen: {frozFrames}");
+        }
+
+
+        // TODO: Flush events. See note on OnApplicationQuit
+        //private void OnApplicationPause() =>
+        // TODO: Flush events, see note on OnApplicationQuit
+        // private void OnApplicationFocus { if (!focusStatus) Flush events! }
+    }
 }


### PR DESCRIPTION
Test if we can validate fps:

Metric used here:

- Good frames ( < 20ms )
- Bad frames ( > 20ms but not yet frozen)
- Frozen frames

Frozen frame issue: Unity has a limit on how big delta time can get to preserve continuity for the player experience. We could work around that by calculating the delta time ourselves -> MeasureDeltaTime()
Things to consider for the metrics:

- How often did the game get frozen
- How long was is frozen for

![Screenshot 2021-05-05 at 10 37 48](https://user-images.githubusercontent.com/25725783/117116950-3ff6ce80-ad8f-11eb-8eba-7ba8ae361586.png)
