### PR TITLE
Fix: Copy missing .meta files from package/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,7 +190,9 @@ jobs:
           Copy-Item "package/package.json" -Destination "package-release/package.json"
           Copy-Item "package/README.md" -Destination "package-release/README.md"
           Copy-Item "CHANGELOG.md" -Destination "package-release/CHANGELOG.md"
+          Copy-Item "package/CHANGELOG.md.meta" -Destination "package-release/CHANGELOG.md.meta"
           Copy-Item "LICENSE.md" -Destination "package-release/LICENSE.md"
+          Copy-Item "package/LICENSE.md.meta" -Destination "package-release/LICENSE.md.meta"
           New-Item -Type dir "package-release/Editor/" -Force
           Get-ChildItem "package/Editor/" -Include "*.asmdef", "*.asmdef.meta" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Editor/" }
           New-Item -Type dir "package-release/Runtime/" -Force


### PR DESCRIPTION
- CHANGELOG.md & LICENSE.md get copied from the root
- .meta files live inside package/

So when we copy them into package-release we need to fetch their meta files too.

#skip-changelog
