### PR TITLE
fix macos il2cpp

### DIFF
--- a/package-dev/Editor/io.sentry.unity.dev.editor.asmdef
+++ b/package-dev/Editor/io.sentry.unity.dev.editor.asmdef
@@ -1,3 +1,29 @@
-﻿{
-	"name": "io.sentry.unity.dev.editor"
+{
+    "name": "io.sentry.unity.dev.editor",
+    "references": [],
+    "includePlatforms": [
+        "Android",
+        "CloudRendering",
+        "iOS",
+        "LinuxStandalone64",
+        "Lumin",
+        "macOSStandalone",
+        "PS4",
+        "Stadia",
+        "Switch",
+        "tvOS",
+        "WSA",
+        "WebGL",
+        "WindowsStandalone32",
+        "WindowsStandalone64",
+        "XboxOne"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/package-dev/Tests/Runtime/io.sentry.unity.dev.runtimeTests.asmdef
+++ b/package-dev/Tests/Runtime/io.sentry.unity.dev.runtimeTests.asmdef
@@ -1,21 +1,23 @@
 {
-  "name": "io.sentry.unity.dev.runtimeTests",
-  "references": [
-    "io.sentry.unity.dev.runtime",
-    "UnityEngine.TestRunner",
-    "UnityEditor.TestRunner"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "nunit.framework.dll"
-  ],
-  "autoReferenced": false,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "io.sentry.unity.dev.runtimeTests",
+    "references": [
+        "io.sentry.unity.dev.runtime",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [
+        "Editor"
+    ],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/samples/unity-of-bugs/Assets/Resources/Sentry.meta
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 577b34925667481458c06344fe8aa4d8
+guid: eeb1470a89ebb4d1b82cf289bffdd747
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/samples/unity-of-bugs/Assets/Scenes/BugFarmScene.unity
+++ b/samples/unity-of-bugs/Assets/Scenes/BugFarmScene.unity
@@ -157,8 +157,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 7.9, y: -150.1}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: -2, y: -103}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8342649
 MonoBehaviour:
@@ -330,8 +330,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 10.7, y: 94.8}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0.19999313, y: 89.79998}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &329485369
 MonoBehaviour:
@@ -460,8 +460,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 11.600004, y: -6.1000214}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0.89999294, y: 10.299986}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &344619856
 MonoBehaviour:
@@ -974,8 +974,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 9.800003, y: -104.00004}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: -0.5000076, y: -66.70001}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &649777090
 MonoBehaviour:
@@ -1104,8 +1104,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 11.400004, y: 146.99997}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0.69999313, y: 130.9}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &655484393
 MonoBehaviour:
@@ -1312,8 +1312,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 8.9, y: -195.5}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: -1.2000065, y: -138.80002}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &783282029
 MonoBehaviour:
@@ -1598,8 +1598,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 9.90001, y: 201.49997}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: -0.40000725, y: 173.79999}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1180987023
 MonoBehaviour:
@@ -1728,8 +1728,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 11.300003, y: -54.200043}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0.69999313, y: -27.500015}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1294977259
 MonoBehaviour:
@@ -2043,8 +2043,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 11.600004, y: 44.999977}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0.89999294, y: 50.599983}
+  m_SizeDelta: {x: 124.551544, y: 23.620224}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1703366544
 MonoBehaviour:

--- a/samples/unity-of-bugs/Packages/manifest.json
+++ b/samples/unity-of-bugs/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.test-framework": "1.1.22",
     "com.unity.textmeshpro": "2.1.1",
+    "com.unity.toolchain.macos-x86_64-linux-x86_64": "0.1.21-preview",
     "com.unity.ugui": "1.0.0",
     "io.sentry.unity.dev": "file:../../../package-dev",
     "com.unity.modules.ai": "1.0.0",

--- a/samples/unity-of-bugs/Packages/packages-lock.json
+++ b/samples/unity-of-bugs/Packages/packages-lock.json
@@ -23,6 +23,22 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "0.1.19-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "0.1.14-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "0.1.18-preview"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.22",
       "depth": 0,
@@ -40,6 +56,16 @@
       "source": "registry",
       "dependencies": {
         "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.macos-x86_64-linux-x86_64": {
+      "version": "0.1.21-preview",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "0.1.19-preview",
+        "com.unity.sysroot.linux-x86_64": "0.1.14-preview"
       },
       "url": "https://packages.unity.com"
     },

--- a/samples/unity-of-bugs/ProjectSettings/GraphicsSettings.asset
+++ b/samples/unity-of-bugs/ProjectSettings/GraphicsSettings.asset
@@ -34,7 +34,7 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 16003, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
Couldn't build a standalone player on macOS with IL2CPP as scripting backend without marking the `Tests/*` files in the package as `Editor` only

#skip-changelog