### PR TITLE
Fix: SDK version format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- SDK version format correction (#120)
+
 ## 0.0.13
 
 - Missing meta files warnings (#146)

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using Sentry.Extensibility;
 using Sentry.Protocol;
+using Sentry.Reflection;
 using UnityEngine;
 using DeviceOrientation = Sentry.Protocol.DeviceOrientation;
 
@@ -11,8 +12,7 @@ namespace Sentry.Unity
 {
     internal static class UnitySdkInfo
     {
-        public static string Version { get; } = typeof(UnitySdkInfo).Assembly.GetName().Version.ToString();
-
+        public static string Version { get; } = typeof(UnitySdkInfo).Assembly.GetNameAndVersion().Version ?? "0.0.0";
 
         public const string Name = "sentry.dotnet.unity";
         public const string PackageName = "upm:sentry.unity";


### PR DESCRIPTION
Accessing version via assembly extension: Assembly.GetNameAndVersion().
Fallback to "0.0.0"