### PR TITLE
clean removes all asms

### DIFF
--- a/src/Sentry.Unity/Sentry.Unity.csproj
+++ b/src/Sentry.Unity/Sentry.Unity.csproj
@@ -1,9 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutDir>$(PackageRuntimePath)</OutDir>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
+  <Target Name="CleanDotnetSdkFiles" AfterTargets="Clean">
+    <!-- CopyLocalLockFileAssemblies brings the .NET SDK assemblies to the output dir.
+         For that reason they are not clean by the Sentry project clean Target. -->
+    <ItemGroup>
+        <FilesToDelete Include="$(OutDir)/*.dll"/>
+        <FilesToDelete Include="$(OutDir)/*.xml"/>
+    </ItemGroup>
+    <Delete Files="@(FilesToDelete)" ContinueOnError="true" />
+  </Target>
+
   <ItemGroup>
     <Reference Include="UnityEngine">
       <HintPath>$(UnityManagedPath)\UnityEngine.dll</HintPath>
@@ -15,7 +27,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\sentry-dotnet\src\Sentry\Sentry.csproj" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
`dotnet clean` before:

![image](https://user-images.githubusercontent.com/1633368/117894173-c298f580-b289-11eb-8921-c91ec582b346.png)


`dotnet clean` after:

![image](https://user-images.githubusercontent.com/1633368/117894191-cd538a80-b289-11eb-9799-a266803bb81e.png)

#skip-changelog

This is useful for development so no changelog entry