### PR TITLE
fix: diagnostic logger rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### Features
+
 - Sentry UnityLogger aligned to Unity Debug API ([#163](https://github.com/getsentry/sentry-unity/pull/163))
 
 ### Fixes
 
-- SDK version format correction (#120)
-- Auto compression option is part of drop down (no extra checkbox) (#160)
+- SDK version format correction ([#120](https://github.com/getsentry/sentry-unity/pull/120))
+- Auto compression option is part of drop down (no extra checkbox) ([#160](https://github.com/getsentry/sentry-unity/pull/160))
+- Rename DiagnosticsLogger to DiagnosticLogger ([#168](https://github.com/getsentry/sentry-unity/pull/168))
 
 ## 0.0.13
 

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -149,10 +149,10 @@ namespace Sentry.Unity.Editor
                     "Only In Editor",
                     "Only print logs when in the editor. Development builds of the player will not include Sentry's SDK diagnostics."),
                 Options.DebugOnlyInEditor);
-            Options.DiagnosticsLevel = (SentryLevel)EditorGUILayout.EnumPopup(
+            Options.DiagnosticLevel = (SentryLevel)EditorGUILayout.EnumPopup(
                 new GUIContent("Verbosity level", "The minimum level allowed to be printed to the console. " +
                                                   "Log messages with a level below this level are dropped."),
-                Options.DiagnosticsLevel);
+                Options.DiagnosticLevel);
             EditorGUILayout.EndToggleGroup();
 
             EditorGUILayout.EndToggleGroup();

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -34,13 +34,30 @@ namespace Sentry.Unity
         /// </summary>
         public const string PackageName = "io.sentry.unity";
 
+        /// <summary>
+        /// Whether the SDK should automatically enable or not.
+        /// </summary>
+        /// <remarks>
+        /// At a minimum, the <see cref="Dsn"/> need to be provided.
+        /// </remarks>
         public bool Enabled { get; set; } = true;
-        public bool CaptureInEditor { get; set; } = true; // Lower entry barrier, likely set to false after initial setup.
+
+        /// <summary>
+        /// Whether Sentry events should be captured while in the Unity Editor.
+        /// </summary>
+        // Lower entry barrier, likely set to false after initial setup.
+        public bool CaptureInEditor { get; set; } = true;
+
+        /// <summary>
+        /// Whether the SDK should be in <see cref="Debug"/> mode only while in the Unity Editor.
+        /// </summary>
         public bool DebugOnlyInEditor { get; set; } = true;
-        public SentryLevel DiagnosticsLevel { get; set; } = SentryLevel.Error; // By default logs out Error or higher.
 
         private CompressionLevelWithAuto _requestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
 
+        /// <summary>
+        /// The level which to compress the request body sent to Sentry.
+        /// </summary>
         public new CompressionLevelWithAuto RequestBodyCompressionLevel
         {
             get => _requestBodyCompressionLevel;
@@ -90,7 +107,7 @@ namespace Sentry.Unity
         {
             DiagnosticLogger = Debug
                                && (!DebugOnlyInEditor || Application.isEditor) // TODO: Should we move it out and use via IApplication something?
-                ? new UnityLogger(DiagnosticsLevel)
+                ? new UnityLogger(DiagnosticLevel)
                 : null;
 
             return this;
@@ -110,7 +127,7 @@ namespace Sentry.Unity
 
             writer.WriteBoolean("debug", Debug);
             writer.WriteBoolean("debugOnlyInEditor", DebugOnlyInEditor);
-            writer.WriteNumber("diagnosticsLevel", (int)DiagnosticsLevel);
+            writer.WriteNumber("diagnosticLevel", (int)DiagnosticLevel);
             writer.WriteBoolean("attachStacktrace", AttachStacktrace);
 
             writer.WriteNumber("requestBodyCompressionLevel", (int)RequestBodyCompressionLevel);
@@ -142,7 +159,7 @@ namespace Sentry.Unity
                 CaptureInEditor = json.GetPropertyOrNull("captureInEditor")?.GetBoolean() ?? false,
                 Debug = json.GetPropertyOrNull("debug")?.GetBoolean() ?? true,
                 DebugOnlyInEditor = json.GetPropertyOrNull("debugOnlyInEditor")?.GetBoolean() ?? true,
-                DiagnosticsLevel = json.GetEnumOrNull<SentryLevel>("diagnosticsLevel") ?? SentryLevel.Error,
+                DiagnosticLevel = json.GetEnumOrNull<SentryLevel>("diagnosticLevel") ?? SentryLevel.Error,
                 RequestBodyCompressionLevel = json.GetEnumOrNull<CompressionLevelWithAuto>("requestBodyCompressionLevel") ?? CompressionLevelWithAuto.Auto,
                 AttachStacktrace = json.GetPropertyOrNull("attachStacktrace")?.GetBoolean() ?? false,
                 SampleRate = json.GetPropertyOrNull("sampleRate")?.GetSingle() ?? 1.0f,

--- a/test/Sentry.Unity.Tests/TestSentryOptions.json
+++ b/test/Sentry.Unity.Tests/TestSentryOptions.json
@@ -1,1 +1,1 @@
-{"enabled":true,"captureInEditor":true,"dsn":"http://test.com","debug":true,"debugOnlyInEditor":true,"diagnosticsLevel":3,"requestBodyCompressionLevel":1,"attachStacktrace":true,"sampleRate":1,"release":"release","environment":"test"}
+{"enabled":true,"captureInEditor":true,"dsn":"http://test.com","debug":true,"debugOnlyInEditor":true,"diagnosticLevel":3,"requestBodyCompressionLevel":1,"attachStacktrace":true,"sampleRate":1,"release":"release","environment":"test"}

--- a/test/Sentry.Unity.Tests/UnitySentryOptionsTest.cs
+++ b/test/Sentry.Unity.Tests/UnitySentryOptionsTest.cs
@@ -34,7 +34,7 @@ namespace Sentry.Unity.Tests
                 CaptureInEditor = true,
                 Debug = true,
                 DebugOnlyInEditor = false,
-                DiagnosticsLevel = SentryLevel.Info,
+                DiagnosticLevel = SentryLevel.Info,
                 RequestBodyCompressionLevel = CompressionLevelWithAuto.NoCompression,
                 AttachStacktrace = true,
                 SampleRate = 1f,
@@ -62,7 +62,7 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(expected.CaptureInEditor, actual.CaptureInEditor);
             Assert.AreEqual(expected.Debug, actual.Debug);
             Assert.AreEqual(expected.DebugOnlyInEditor, actual.DebugOnlyInEditor);
-            Assert.AreEqual(expected.DiagnosticsLevel, actual.DiagnosticsLevel);
+            Assert.AreEqual(expected.DiagnosticLevel, actual.DiagnosticLevel);
             Assert.AreEqual(expected.AttachStacktrace, actual.AttachStacktrace);
             Assert.AreEqual(expected.SampleRate, actual.SampleRate);
             Assert.AreEqual(expected.Release, actual.Release);


### PR DESCRIPTION
The .NET SDK already has an option called `DiagnosticLogger` removing the one defined here in favor of that