### PR TITLE
Fix: Programmatic config - logger attachment

### DIFF
--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -25,6 +25,9 @@ namespace Sentry.Unity
         /// <param name="unitySentryOptions">The options object.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Init(SentryUnityOptions unitySentryOptions)
-            => SentrySdk.Init(unitySentryOptions);
+        {
+            unitySentryOptions.TryAttachLogger();
+            SentrySdk.Init(unitySentryOptions);
+        }
     }
 }

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -106,7 +106,8 @@ namespace Sentry.Unity
         // Can't rely on Unity's OnEnable() hook.
         public SentryUnityOptions TryAttachLogger()
         {
-            DiagnosticLogger = Debug
+            DiagnosticLogger = DiagnosticLogger is null
+                               && Debug
                                && (!DebugOnlyInEditor || Application.isEditor) // TODO: Should we move it out and use via IApplication something?
                 ? new UnityLogger(DiagnosticLevel)
                 : null;


### PR DESCRIPTION
When the sdk gets configured programmatically we attach the logger just before we initialize the SDK itself.
#skip-changelog