### PR TITLE
try to silence the warning

### DIFF
--- a/package-dev/Runtime/io.sentry.unity.dev.runtime.asmdef
+++ b/package-dev/Runtime/io.sentry.unity.dev.runtime.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry.unity.dev.runtime",
-    "references": [],
+    "references": [""],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,


### PR DESCRIPTION
Try to silence "Assembly for Assembly Definition File 'Packages/io.sentry.unity.dev/Runtime/io.sentry.unity.dev.runtime.asmdef' will not be compiled, because it has no scripts associated with it."

#skip-changelog