### PR TITLE
Fix: Exclude SentryOptions.json from release package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           New-Item "package-release" -ItemType Directory
 
           # Copy `package-dev` stuff
-          Copy-Item "package-dev/*" -Destination "package-release/" -Exclude "README.md", "package.json", "Tests", "Tests.meta", "*.asmdef", "*.asmdef.meta" -Recurse
+          Copy-Item "package-dev/*" -Destination "package-release/" -Exclude "README.md", "package.json", "Tests", "Tests.meta", "*.asmdef", "*.asmdef.meta", "SentryOptions.json*" -Recurse
 
           # Copy `package` stuff
           Copy-Item "package/package.json" -Destination "package-release/package.json"


### PR DESCRIPTION
We just don't copy it from the dev package.