### PR TITLE
SentryEvent.ServerName forced to 'null'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Check/create directory before saving ([#196](https://github.com/getsentry/sentry-unity/pull/196))
 - Exclude SentryOptions.json from release package ([#195](https://github.com/getsentry/sentry-unity/pull/195))
 - default env and version ([#199](https://github.com/getsentry/sentry-unity/pull/199))
+- SentryEvent.ServerName forced to 'null' ([#201](https://github.com/getsentry/sentry-unity/pull/201))
 
 ## 0.0.14
 

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -30,7 +30,6 @@ namespace Sentry.Unity
 
         public SentryEvent Process(SentryEvent @event)
         {
-            @event.ServerName = null;
             @event.Sdk.AddPackage(UnitySdkInfo.PackageName, UnitySdkInfo.Version);
             @event.Sdk.Name = UnitySdkInfo.Name;
             @event.Sdk.Version = UnitySdkInfo.Version;
@@ -46,6 +45,7 @@ namespace Sentry.Unity
             }
 
             @event.Release = Application.version;
+            @event.ServerName = null;
 
             // This is the approximate amount of system memory in megabytes.
             // This function is not supported on Windows Store Apps and will always return 0.

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -30,6 +30,7 @@ namespace Sentry.Unity
 
         public SentryEvent Process(SentryEvent @event)
         {
+            @event.ServerName = null;
             @event.Sdk.AddPackage(UnitySdkInfo.PackageName, UnitySdkInfo.Version);
             @event.Sdk.Name = UnitySdkInfo.Name;
             @event.Sdk.Version = UnitySdkInfo.Version;

--- a/test/Sentry.Unity.Tests/UnityEventExceptionProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventExceptionProcessorTests.cs
@@ -72,5 +72,19 @@ namespace Sentry.Unity.Tests
             new object[] { true, true },
             new object[] { false, null! },
         };
+
+        [Test]
+        public void Process_ServerName_IsNull()
+        {
+            // arrange
+            var unityEventProcessor = new UnityEventProcessor();
+            var sentryEvent = new SentryEvent();
+
+            // act
+            unityEventProcessor.Process(sentryEvent);
+
+            // assert
+            Assert.IsNull(sentryEvent.ServerName);
+        }
     }
 }


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-unity/issues/165