### PR TITLE
Fix: Add product name to release as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add product name to release as default ([#202](https://github.com/getsentry/sentry-unity/pull/202))
+
 ## 0.1.0
 
 ### Features

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -32,7 +32,7 @@ namespace Sentry.Unity
             // Uses the game `version` as Release unless the user defined one via the Options
             if (unitySentryOptions.Release == null)
             {
-                unitySentryOptions.Release = Application.version;
+                unitySentryOptions.Release = Application.productName + "@" + Application.version;
                 unitySentryOptions.DiagnosticLogger?.Log(SentryLevel.Debug,
                     "Setting Sentry Release to Unity App.Version: {0}",
                     null, unitySentryOptions.Release);

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -32,7 +32,8 @@ namespace Sentry.Unity
             // Uses the game `version` as Release unless the user defined one via the Options
             if (unitySentryOptions.Release == null)
             {
-                unitySentryOptions.Release = Application.productName + "@" + Application.version;
+                unitySentryOptions.Release = $"{Application.productName}@{Application.version}";
+
                 unitySentryOptions.DiagnosticLogger?.Log(SentryLevel.Debug,
                     "Setting Sentry Release to Unity App.Version: {0}",
                     null, unitySentryOptions.Release);

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -44,8 +44,6 @@ namespace Sentry.Unity
                 @event.Contexts.Device.BatteryLevel = (short?)(SystemInfo.batteryLevel * 100);
             }
 
-            @event.Release = Application.version;
-
             // This is the approximate amount of system memory in megabytes.
             // This function is not supported on Windows Store Apps and will always return 0.
             @event.Contexts.Device.MemorySize = SystemInfo.systemMemorySize;

--- a/test/Sentry.Unity.Tests/IntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/IntegrationTests.cs
@@ -40,7 +40,7 @@ namespace Sentry.Unity.Tests
         }
 
         [UnityTest]
-        public IEnumerator BugFarmScene_EventCaptured_IncludesApplicationVersionAsRelease()
+        public IEnumerator BugFarmScene_EventCaptured_IncludesApplicationProductNameAtVersionAsRelease()
         {
             yield return SetupSceneCoroutine("1_BugFarmScene");
 
@@ -55,7 +55,28 @@ namespace Sentry.Unity.Tests
             testBehaviour.gameObject.SendMessage(nameof(testBehaviour.TestException));
 
             // assert
-            Assert.AreEqual(Application.version, testEventCapture.Events.First().Release);
+            Assert.AreEqual(Application.productName + "@" + Application.version, testEventCapture.Events.First().Release);
+        }
+
+        [UnityTest]
+        public IEnumerator BugFarmScene_EventCaptured_IncludesCustomRelease()
+        {
+            yield return SetupSceneCoroutine("1_BugFarmScene");
+
+            // arrange
+            var customRelease = "CustomRelease";
+            var testEventCapture = new TestEventCapture();
+            using var _ = InitSentrySdk(o =>
+            {
+                o.Release = customRelease;
+                o.AddIntegration(new UnityApplicationLoggingIntegration(eventCapture: testEventCapture));
+            });
+            var testBehaviour = new GameObject("TestHolder").AddComponent<TestMonoBehaviour>();
+
+            testBehaviour.gameObject.SendMessage(nameof(testBehaviour.TestException));
+
+            // assert
+            Assert.AreEqual(customRelease, testEventCapture.Events.First().Release);
         }
 
         [UnityTest]


### PR DESCRIPTION
Release should be` productName@version` if it's not overwritten by the user.