### PR TITLE
Fix: Fallback for missing/empty product name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fallback for missing/empty product name ([#205](https://github.com/getsentry/sentry-unity/pull/205))
 - Add product name to release as default ([#202](https://github.com/getsentry/sentry-unity/pull/202))
 - normalize line endings ([#204](https://github.com/getsentry/sentry-unity/pull/204))
 

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -32,7 +32,7 @@ namespace Sentry.Unity
             // Uses the game `version` as Release unless the user defined one via the Options
             if (unitySentryOptions.Release == null)
             {
-                unitySentryOptions.Release = String.IsNullOrWhiteSpace(Application.productName)
+                unitySentryOptions.Release = string.IsNullOrWhiteSpace(Application.productName)
                     ? $"{Application.version}"
                     : $"{Application.productName}@{Application.version}";
 

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -32,7 +32,9 @@ namespace Sentry.Unity
             // Uses the game `version` as Release unless the user defined one via the Options
             if (unitySentryOptions.Release == null)
             {
-                unitySentryOptions.Release = $"{Application.productName}@{Application.version}";
+                unitySentryOptions.Release = String.IsNullOrWhiteSpace(Application.productName)
+                    ? $"{Application.version}"
+                    : $"{Application.productName}@{Application.version}";
 
                 unitySentryOptions.DiagnosticLogger?.Log(SentryLevel.Debug,
                     "Setting Sentry Release to Unity App.Version: {0}",

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -32,9 +32,10 @@ namespace Sentry.Unity
             // Uses the game `version` as Release unless the user defined one via the Options
             if (unitySentryOptions.Release == null)
             {
-                unitySentryOptions.Release = string.IsNullOrWhiteSpace(Application.productName)
-                    ? $"{Application.version}"
-                    : $"{Application.productName}@{Application.version}";
+                unitySentryOptions.Release = Application.productName is string productName
+                    && !string.IsNullOrWhiteSpace(productName)
+                        ? $"{productName}@{Application.version}"
+                        : $"{Application.version}";
 
                 unitySentryOptions.DiagnosticLogger?.Log(SentryLevel.Debug,
                     "Setting Sentry Release to Unity App.Version: {0}",


### PR DESCRIPTION
If for some reason the product name is missing / just whitespace we just use the version as release.