### PR TITLE
Fix: Set default before invoking options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Unreleased
 
+### Features 
+
 - Offline caching ([#208](https://github.com/getsentry/sentry-unity/pull/208))
 - Breadcrumb categories added ([#206](https://github.com/getsentry/sentry-unity/pull/206))
+
+### Fixes
+
+- Set default before invoking options ([#211](https://github.com/getsentry/sentry-unity/pull/211))
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 ### Features 
-### Features
 
 - Offline caching ([#208](https://github.com/getsentry/sentry-unity/pull/208))
 - Breadcrumb categories added ([#206](https://github.com/getsentry/sentry-unity/pull/206))

--- a/src/Sentry.Unity.Editor/SentryTestWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryTestWindow.cs
@@ -14,7 +14,7 @@ namespace Sentry.Unity.Editor
         public void Dispose()
         {
             Close(); // calls 'OnLostFocus' implicitly
-            File.Delete(SentryUnityOptions.GetConfigPath(SentryOptionsAssetName));
+            // File.Delete(SentryUnityOptions.GetConfigPath(SentryOptionsAssetName));
             AssetDatabase.Refresh();
         }
     }

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+
+namespace Sentry.Unity
+{
+    public class ScriptableSentryUnityOptions : ScriptableObject
+    {
+        /// <summary>
+        /// Relative to Assets/Resources
+        /// </summary>
+        public const string ConfigRootFolder = "Sentry";
+
+        /// <summary>
+        /// Main Sentry config name for Unity
+        /// </summary>
+        public const string ConfigName = "SentryOptions";
+
+        /// <summary>
+        /// Path for the config for Unity
+        /// </summary>
+        internal static string GetConfigPath(string? notDefaultConfigName = null)
+            => $"Assets/Resources/{ConfigRootFolder}/{notDefaultConfigName ?? ConfigName}.asset";
+
+        [field: SerializeField]
+        public bool Enabled { get; set; }
+
+        [field: SerializeField]
+        public bool CaptureInEditor { get; set; }
+
+        [field: SerializeField]
+        public string Dsn { get; set; } = "";
+        
+        [field: SerializeField]
+        public float SampleRate { get; set; } = 1.0f;
+        [field: SerializeField]
+        public CompressionLevelWithAuto RequestBodyCompressionLevel { get; set; } = CompressionLevelWithAuto.Auto;
+
+        [field: SerializeField]
+        public bool AttachStacktrace { get; set; }
+        [field: SerializeField]
+        public string ReleaseOverride { get; set; } = "";
+        [field: SerializeField]
+        public string EnvironmentOverride { get; set; } = "";
+        [field: SerializeField]
+        public bool EnableOfflineCaching { get; set; }
+
+        [field: SerializeField]
+        public bool Debug { get; set; }
+        [field: SerializeField]
+        public bool DebugOnlyInEditor { get; set; }
+        [field: SerializeField]
+        public SentryLevel DiagnosticLevel { get; set; }
+
+        public static SentryUnityOptions? LoadSentryUnityOptions()
+        {
+            var scriptableOptions = Resources.Load<ScriptableSentryUnityOptions>($"{ConfigRootFolder}/{ConfigName}");
+            if (scriptableOptions == null)
+            {
+                return null;
+            }
+
+            var options = new SentryUnityOptions();
+            SentryOptionsUtility.SetDefaults(options);
+
+            options.Enabled = scriptableOptions.Enabled;
+            options.CaptureInEditor = scriptableOptions.CaptureInEditor;
+            options.Dsn = scriptableOptions.Dsn;
+            options.SampleRate = scriptableOptions.SampleRate;
+            options.RequestBodyCompressionLevel = scriptableOptions.RequestBodyCompressionLevel;
+            options.AttachStacktrace = scriptableOptions.AttachStacktrace;
+
+            if (!string.IsNullOrEmpty(scriptableOptions.ReleaseOverride))
+            {
+                options.Release = scriptableOptions.ReleaseOverride;
+            }
+
+            if (!string.IsNullOrEmpty(scriptableOptions.EnvironmentOverride))
+            {
+                options.Environment = scriptableOptions.EnvironmentOverride;
+            }
+
+            if (!scriptableOptions.EnableOfflineCaching)
+            {
+                options.CacheDirectoryPath = null;
+            }
+
+            options.Debug = scriptableOptions.Debug;
+            options.DebugOnlyInEditor = scriptableOptions.DebugOnlyInEditor;
+            options.DiagnosticLevel = scriptableOptions.DiagnosticLevel;
+
+            return options;
+        }
+    }
+}

--- a/src/Sentry.Unity/SentryInitialization.cs
+++ b/src/Sentry.Unity/SentryInitialization.cs
@@ -12,10 +12,11 @@ namespace Sentry.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
-            var options = SentryUnityOptions.LoadFromUnity();
+            var options = ScriptableSentryUnityOptions.LoadSentryUnityOptions();
             if (options == null)
             {
-                new UnityLogger(SentryLevel.Warning).Log(SentryLevel.Warning, "Sentry has not been configured. You can do that through the editor: Tools -> Sentry");
+                new UnityLogger(SentryLevel.Warning).Log(SentryLevel.Warning,
+                    "Sentry has not been configured. You can do that through the editor: Tools -> Sentry");
                 return;
             }
 
@@ -36,7 +37,6 @@ namespace Sentry.Unity
                 return;
             }
 
-            SentryOptionsUtility.SetDefaults(options);
             SentryUnity.Init(options);
         }
     }

--- a/src/Sentry.Unity/SentryInitialization.cs
+++ b/src/Sentry.Unity/SentryInitialization.cs
@@ -35,6 +35,7 @@ namespace Sentry.Unity
                 return;
             }
 
+            SentryOptionsUtility.SetDefaults(options);
             SentryUnity.Init(options);
         }
     }

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -1,5 +1,6 @@
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
+using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -24,9 +25,17 @@ namespace Sentry.Unity
                 return;
             }
 
-            Log(logger, "Release", options.Release);
-            Log(logger, "Environment", options.Environment);
-            Log(logger, "Cache Directory", options.CacheDirectoryPath);
+            LogOption(logger, "Release", options.Release);
+            LogOption(logger, "Environment", options.Environment);
+
+            if (options.CacheDirectoryPath == null)
+            {
+                logger.Log(SentryLevel.Debug, "Offline Caching disabled.");
+            }
+            else
+            {
+                LogOption(logger, "Cache Directory", options.CacheDirectoryPath);
+            }
         }
 
         private static void SetRelease(SentryUnityOptions options, IApplication application)
@@ -47,7 +56,7 @@ namespace Sentry.Unity
             options.CacheDirectoryPath ??= application.PersistentDataPath;
         }
 
-        private static void Log(IDiagnosticLogger logger, string option, object value)
+        private static void LogOption(IDiagnosticLogger logger, string option, object value)
             => logger.Log(SentryLevel.Debug, "Setting Sentry {0} to: {1}", null, option, value);
     }
 }

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -7,11 +7,26 @@ namespace Sentry.Unity
     {
         public static void SetDefaults(SentryUnityOptions options, IApplication? application = null)
         {
+            options.TryAttachLogger();
+
             application ??= ApplicationAdapter.Instance;
 
             SetRelease(options, application);
             SetEnvironment(options, application);
             SetCacheDirectoryPath(options, application);
+        }
+
+        public static void LogOptions(SentryUnityOptions options)
+        {
+            var logger = options.DiagnosticLogger;
+            if (logger == null)
+            {
+                return;
+            }
+
+            Log(logger, "Release", options.Release);
+            Log(logger, "Environment", options.Environment);
+            Log(logger, "Cache Directory", options.CacheDirectoryPath);
         }
 
         private static void SetRelease(SentryUnityOptions options, IApplication application)
@@ -20,23 +35,19 @@ namespace Sentry.Unity
                 && !string.IsNullOrWhiteSpace(productName)
                     ? $"{productName}@{application.Version}"
                     : $"{application.Version}";
-
-            Log(options.DiagnosticLogger, "Release", options.Release);
         }
 
         private static void SetEnvironment(SentryUnityOptions options, IApplication application)
         {
             options.Environment ??= application.IsEditor ? "editor" : "production";
-            Log(options.DiagnosticLogger, "Environment", options.Environment);
         }
 
         private static void SetCacheDirectoryPath(SentryUnityOptions options, IApplication application)
         {
             options.CacheDirectoryPath ??= application.PersistentDataPath;
-            Log(options.DiagnosticLogger, "Cache Directory", options.CacheDirectoryPath);
         }
 
-        private static void Log(IDiagnosticLogger? logger, string option, object value)
-            => logger?.Log(SentryLevel.Debug, "Setting Sentry {0} to: {1}", null, option, value);
+        private static void Log(IDiagnosticLogger logger, string option, object value)
+            => logger.Log(SentryLevel.Debug, "Setting Sentry {0} to: {1}", null, option, value);
     }
 }

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using UnityEngine;
@@ -8,13 +9,83 @@ namespace Sentry.Unity
     {
         public static void SetDefaults(SentryUnityOptions options, IApplication? application = null)
         {
-            options.TryAttachLogger();
-
             application ??= ApplicationAdapter.Instance;
 
-            SetRelease(options, application);
-            SetEnvironment(options, application);
-            SetCacheDirectoryPath(options, application);
+            options.Enabled = Enabled();
+            options.CaptureInEditor = CaptureInEditor();
+            options.RequestBodyCompressionLevel = RequestBodyCompressionLevel();
+            options.AttachStacktrace = AttackStackTrace();
+            options.StackTraceMode = StackTraceMode();
+            options.SampleRate = SampleRate();
+
+            options.Release = Release(application);
+            options.Environment = Environment(application);
+
+            options.CacheDirectoryPath = application.PersistentDataPath;
+
+            options.Debug = Debug();
+            options.DebugOnlyInEditor = DebugOnlyInEditor();
+            options.DiagnosticLevel = DiagnosticLevel();
+
+            TryAttachLogger(options, application);
+        }
+
+        public static void SetDefaults(ScriptableSentryUnityOptions options)
+        {
+            options.Enabled = Enabled();
+            options.CaptureInEditor = CaptureInEditor();
+            options.Debug = Debug();
+            options.DiagnosticLevel = DiagnosticLevel();
+            options.RequestBodyCompressionLevel = RequestBodyCompressionLevel();
+            options.AttachStacktrace = AttackStackTrace();
+
+            options.SampleRate = SampleRate();
+
+            options.ReleaseOverride = "";
+            options.EnvironmentOverride = "";
+
+            options.EnableOfflineCaching = true;
+
+            options.Debug = Debug();
+            options.DebugOnlyInEditor = DebugOnlyInEditor();
+            options.DiagnosticLevel = DiagnosticLevel();
+        }
+
+        private static bool Enabled() => true;
+        private static bool CaptureInEditor() => true;
+        private static CompressionLevelWithAuto RequestBodyCompressionLevel() => CompressionLevelWithAuto.Auto;
+        private static bool AttackStackTrace() => false;
+        private static StackTraceMode StackTraceMode() => default;
+        private static float SampleRate() => 1.0f;
+
+        private static string Release(IApplication application)
+        {
+            application ??= ApplicationAdapter.Instance;
+
+            return application.ProductName is string productName
+                && !string.IsNullOrWhiteSpace(productName)
+                    ? $"{productName}@{application.Version}"
+                    : $"{application.Version}";
+        }
+
+        private static string Environment(IApplication application)
+        {
+            application ??= ApplicationAdapter.Instance;
+            return application.IsEditor ? "editor" : "production";
+        }
+
+        private static bool Debug() => true;
+        private static bool DebugOnlyInEditor() => true;
+        private static SentryLevel DiagnosticLevel() => SentryLevel.Warning;
+
+        private static void TryAttachLogger(SentryUnityOptions options, IApplication application)
+        {
+            if (options.DiagnosticLogger is null
+                && options.Debug
+                && (!options.DebugOnlyInEditor || application.IsEditor))
+            {
+                options.DiagnosticLogger = new UnityLogger(options.DiagnosticLevel);
+            }
         }
 
         public static void LogOptions(SentryUnityOptions options)
@@ -25,39 +96,18 @@ namespace Sentry.Unity
                 return;
             }
 
-            LogOption(logger, "Release", options.Release);
-            LogOption(logger, "Environment", options.Environment);
+            // TODO: Add missing logs for options of interest
+            logger.LogDebug("Setting Release to: {0}", options.Release);
+            logger.LogDebug("Setting Environment to: {0}", options.Environment);
 
             if (options.CacheDirectoryPath == null)
             {
-                logger.Log(SentryLevel.Debug, "Offline Caching disabled.");
+                logger.LogDebug("Offline Caching: Disabled");
             }
             else
             {
-                LogOption(logger, "Cache Directory", options.CacheDirectoryPath);
+                logger.LogDebug("Setting Cache Directory to: {0}", options.CacheDirectoryPath);
             }
-        }
-
-        private static void SetRelease(SentryUnityOptions options, IApplication application)
-        {
-            options.Release ??= application.ProductName is string productName
-                && !string.IsNullOrWhiteSpace(productName)
-                    ? $"{productName}@{application.Version}"
-                    : $"{application.Version}";
-
-            options.DiagnosticLogger?.LogDebug("option.Release: {0}", options.Release);
-        }
-
-        private static void SetEnvironment(SentryUnityOptions options, IApplication application)
-        {
-            options.Environment ??= application.IsEditor ? "editor" : "production";
-            options.DiagnosticLogger?.LogDebug("option.Environment: {0}", options.Environment);
-        }
-
-        private static void SetCacheDirectoryPath(SentryUnityOptions options, IApplication application)
-        {
-            options.CacheDirectoryPath ??= application.PersistentDataPath;
-            options.DiagnosticLogger?.LogDebug("option.CacheDirectoryPath: {0}", options.CacheDirectoryPath);
         }
     }
 }

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -16,7 +15,10 @@ namespace Sentry.Unity
         public static void Init(Action<SentryUnityOptions> unitySentryOptionsConfigure)
         {
             var unitySentryOptions = new SentryUnityOptions();
+            SentryOptionsUtility.SetDefaults(unitySentryOptions);
+
             unitySentryOptionsConfigure.Invoke(unitySentryOptions);
+
             Init(unitySentryOptions);
         }
 
@@ -25,12 +27,9 @@ namespace Sentry.Unity
         /// </summary>
         /// <param name="unitySentryOptions">The options object.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void Init(SentryUnityOptions unitySentryOptions)
+        internal static void Init(SentryUnityOptions unitySentryOptions)
         {
-            unitySentryOptions.TryAttachLogger();
-
-            SentryOptionsUtility.SetDefaults(unitySentryOptions);
-
+            SentryOptionsUtility.LogOptions(unitySentryOptions);
             SentrySdk.Init(unitySentryOptions);
         }
     }

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -17,19 +17,6 @@ namespace Sentry.Unity
     public sealed class SentryUnityOptions : SentryOptions
     {
         /// <summary>
-        /// Relative to Assets/Resources
-        /// </summary>
-        public const string ConfigRootFolder = "Sentry";
-
-        /// <summary>
-        /// Main Sentry config name for Unity
-        /// </summary>
-        public const string ConfigName = "SentryOptions";
-
-        internal static string GetConfigPath(string? notDefaultConfigName = null)
-            => $"{Application.dataPath}/Resources/{ConfigRootFolder}/{notDefaultConfigName ?? ConfigName}.json";
-
-        /// <summary>
         /// UPM name of Sentry Unity SDK (package.json)
         /// </summary>
         public const string PackageName = "io.sentry.unity";
@@ -92,103 +79,6 @@ namespace Sentry.Unity
             this.AddIntegration(new UnityApplicationLoggingIntegration());
             this.AddIntegration(new UnityBeforeSceneLoadIntegration());
             this.AddIntegration(new SceneManagerIntegration());
-        }
-
-        // Can't rely on Unity's OnEnable() hook.
-        public SentryUnityOptions TryAttachLogger()
-        {
-            if (DiagnosticLogger is null
-                && Debug
-                // TODO: Move it out and use via IApplication
-                && (!DebugOnlyInEditor || Application.isEditor))
-            {
-                DiagnosticLogger = new UnityLogger(DiagnosticLevel);
-            }
-
-            return this;
-        }
-
-        public void WriteTo(Utf8JsonWriter writer)
-        {
-            writer.WriteStartObject();
-
-            writer.WriteBoolean("enabled", Enabled);
-            writer.WriteBoolean("captureInEditor", CaptureInEditor);
-
-            if (!string.IsNullOrWhiteSpace(Dsn))
-            {
-                writer.WriteString("dsn", Dsn);
-            }
-
-            writer.WriteBoolean("debug", Debug);
-            writer.WriteBoolean("debugOnlyInEditor", DebugOnlyInEditor);
-            writer.WriteNumber("diagnosticLevel", (int)DiagnosticLevel);
-            writer.WriteBoolean("attachStacktrace", AttachStacktrace);
-
-            writer.WriteNumber("requestBodyCompressionLevel", (int)RequestBodyCompressionLevel);
-
-            if (SampleRate != null)
-            {
-                writer.WriteNumber("sampleRate", SampleRate.Value);
-            }
-
-            if (!string.IsNullOrWhiteSpace(Release))
-            {
-                writer.WriteString("release", Release);
-            }
-
-            if (!string.IsNullOrWhiteSpace(Environment))
-            {
-                writer.WriteString("environment", Environment);
-            }
-
-            writer.WriteEndObject();
-            writer.Flush();
-        }
-
-        public static SentryUnityOptions FromJson(JsonElement json)
-            => new()
-            {
-                Enabled = json.GetPropertyOrNull("enabled")?.GetBoolean() ?? true,
-                Dsn = json.GetPropertyOrNull("dsn")?.GetString(),
-                CaptureInEditor = json.GetPropertyOrNull("captureInEditor")?.GetBoolean() ?? false,
-                Debug = json.GetPropertyOrNull("debug")?.GetBoolean() ?? true,
-                DebugOnlyInEditor = json.GetPropertyOrNull("debugOnlyInEditor")?.GetBoolean() ?? true,
-                DiagnosticLevel = json.GetEnumOrNull<SentryLevel>("diagnosticLevel") ?? SentryLevel.Error,
-                RequestBodyCompressionLevel = json.GetEnumOrNull<CompressionLevelWithAuto>("requestBodyCompressionLevel") ?? CompressionLevelWithAuto.Auto,
-                AttachStacktrace = json.GetPropertyOrNull("attachStacktrace")?.GetBoolean() ?? false,
-                SampleRate = json.GetPropertyOrNull("sampleRate")?.GetSingle() ?? 1.0f,
-                Release = json.GetPropertyOrNull("release")?.GetString(),
-                Environment = json.GetPropertyOrNull("environment")?.GetString()
-            };
-
-        /// <summary>
-        /// Try load SentryOptions.json in a platform-agnostic way.
-        /// </summary>
-        public static SentryUnityOptions? LoadFromUnity()
-        {
-            // We should use `TextAsset` for read-only access in runtime. It's platform agnostic.
-            var sentryOptionsTextAsset = Resources.Load<TextAsset>($"{ConfigRootFolder}/{ConfigName}");
-            if (sentryOptionsTextAsset == null)
-            {
-                // Config not found.
-                return null;
-            }
-            using var jsonDocument = JsonDocument.Parse(sentryOptionsTextAsset.bytes);
-            return FromJson(jsonDocument.RootElement).TryAttachLogger();
-        }
-
-        public void SaveToUnity(string path)
-        {
-            var directory = Path.GetDirectoryName(path);
-            if (!Directory.Exists(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
-
-            using var fileStream = new FileStream(path, FileMode.Create);
-            using var writer = new Utf8JsonWriter(fileStream);
-            WriteTo(writer);
         }
     }
 

--- a/test/Sentry.Unity.Tests/IntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/IntegrationTests.cs
@@ -2,9 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
-using Sentry.Protocol;
 using Sentry.Unity.Integrations;
 using Sentry.Unity.Tests.TestBehaviours;
 using UnityEditor;
@@ -86,6 +84,7 @@ namespace Sentry.Unity.Tests
             yield return SetupSceneCoroutine("1_BugFarmScene");
 
             // arrange
+            // var originalProductName = PlayerSettings.productName;
             PlayerSettings.productName = " ";
             var testEventCapture = new TestEventCapture();
             using var _ = InitSentrySdk(o =>
@@ -98,6 +97,8 @@ namespace Sentry.Unity.Tests
 
             // assert
             Assert.AreEqual(Application.version, testEventCapture.Events.First().Release);
+
+            // PlayerSettings.productName = originalProductName;
         }
 
         [UnityTest]
@@ -106,6 +107,7 @@ namespace Sentry.Unity.Tests
             yield return SetupSceneCoroutine("1_BugFarmScene");
 
             // arrange
+            // var originalProductName = PlayerSettings.productName;
             PlayerSettings.productName = null;
             var testEventCapture = new TestEventCapture();
             using var _ = InitSentrySdk(o =>
@@ -118,6 +120,8 @@ namespace Sentry.Unity.Tests
 
             // assert
             Assert.AreEqual(Application.version, testEventCapture.Events.First().Release);
+
+            // PlayerSettings.productName = originalProductName;
         }
 
         [UnityTest]

--- a/test/Sentry.Unity.Tests/SentryOptionsUtilityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryOptionsUtilityTests.cs
@@ -19,17 +19,6 @@ namespace Sentry.Unity.Tests
         }
 
         [Test]
-        public void SetDefaults_Release_IsCustomRelease()
-        {
-            var customRelease = "TestRelease";
-            var options = new SentryUnityOptions {Release = customRelease};
-
-            SentryOptionsUtility.SetDefaults(options, new TestApplication());
-
-            Assert.AreEqual(customRelease, options.Release);
-        }
-
-        [Test]
         public void SetDefaults_Environment_IsEditorInEditor()
         {
             var options = new SentryUnityOptions();
@@ -52,17 +41,6 @@ namespace Sentry.Unity.Tests
         }
 
         [Test]
-        public void SetDefaults_Environment_IsCustomEnvironment()
-        {
-            var customEnvironment = "TestEnvironment";
-            var options = new SentryUnityOptions {Environment = customEnvironment};
-
-            SentryOptionsUtility.SetDefaults(options, new TestApplication());
-
-            Assert.AreEqual(customEnvironment, options.Environment);
-        }
-
-        [Test]
         public void SetDefaults_CacheDirectoryPath_IsPersistentDataPath()
         {
             var options = new SentryUnityOptions();
@@ -72,17 +50,6 @@ namespace Sentry.Unity.Tests
             SentryOptionsUtility.SetDefaults(options, application);
 
             Assert.AreEqual(persistentPath, options.CacheDirectoryPath);
-        }
-
-        [Test]
-        public void SetDefaults_CacheDirectoryPath_IsCustomCacheDirectoryPath()
-        {
-            var customCacheDirectoryPath = "custom/cache/directory/path";
-            var options = new SentryUnityOptions { CacheDirectoryPath = customCacheDirectoryPath };
-
-            SentryOptionsUtility.SetDefaults(options, new TestApplication());
-
-            Assert.AreEqual(customCacheDirectoryPath, options.CacheDirectoryPath);
         }
     }
 }

--- a/test/Sentry.Unity.Tests/UnitySentryOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/UnitySentryOptionsTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Sentry.Unity.Tests
 {
@@ -14,11 +15,14 @@ namespace Sentry.Unity.Tests
         public void Options_ReadFromFile_Success()
         {
             var optionsFilePath = GetTestOptionsFilePath();
+            Debug.Log(optionsFilePath);
             Assert.IsTrue(File.Exists(optionsFilePath));
 
+            Debug.Log("file existed");
             var jsonRaw = File.ReadAllText(optionsFilePath);
             using var jsonDocument = JsonDocument.Parse(jsonRaw);
 
+            Debug.Log("parsed");
             SentryUnityOptions.FromJson(jsonDocument.RootElement);
         }
 


### PR DESCRIPTION
Aims to fix two issues: 

1. Setting defaults *before* invoking the options so the user can read/overwrite them properly
2. Log options *after* they have been overwritten so the log output makes sense

