### PR TITLE
Getting started window on installation

### DIFF
--- a/src/Sentry.Unity.Editor/SentryAssetPostprocessor.cs
+++ b/src/Sentry.Unity.Editor/SentryAssetPostprocessor.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Threading;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor
+{
+    public class SentryAssetPostprocessor : AssetPostprocessor
+    {
+        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+        {
+            var imported = importedAssets.Any(path => path.StartsWith("Packages/"));
+            var deleted = deletedAssets.Any(path => path.StartsWith("Packages/"));
+
+            if (imported || deleted)
+            {
+                InitializeOnLoad();
+            }
+        }
+
+        /**
+         * Instead of hooking into AssetPostprocessing we could InitializeOnLoad
+         * But this gets called on domain reload (i.e. enter playmode) and could be disabled by the user.
+         */
+        // [InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
+        {
+            // ASYNC! Fetching all packages the current project depends on
+            var listRequest = Client.List(true);
+            while (!listRequest.IsCompleted)
+            {
+                Thread.Sleep(100);
+            }
+
+            if (listRequest.Error != null)
+            {
+                Debug.Log("Error: " + listRequest.Error.message);
+                return;
+            }
+
+            var packages = listRequest.Result;
+            foreach (var package in packages)
+            {
+                if (package.name.StartsWith("io.sentry"))
+                {
+                    SentryGettingStartedWindow.OpenWindow();
+                }
+            }
+        }
+    }
+}

--- a/src/Sentry.Unity.Editor/SentryGettingStartedWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryGettingStartedWindow.cs
@@ -1,0 +1,39 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor
+{
+    public class SentryGettingStartedWindow : EditorWindow
+    {
+        private string? _dsn;
+
+        [MenuItem("Tools/Sentry/Getting Started")]
+        public static SentryGettingStartedWindow OpenWindow()
+            => (SentryGettingStartedWindow)GetWindow(
+                typeof(SentryGettingStartedWindow), true, "Sentry Getting Started Window");
+
+        private void OnGUI()
+        {
+            EditorGUILayout.Space();
+
+            GUILayout.Label("All that you need to get started is to provide a DSN.");
+
+            EditorGUILayout.Space();
+            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
+            EditorGUILayout.Space();
+
+            _dsn = EditorGUILayout.TextField(
+                new GUIContent("DSN", "The URL to your project inside Sentry. Get yours in Sentry, Project Settings."),
+                _dsn);
+
+            EditorGUILayout.Space();
+            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
+            EditorGUILayout.Space();
+
+            if (GUILayout.Button("Enable"))
+            {
+                this.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Popup after package installation:
We request the user to enter their DSN (maybe even with a link where they'd get it from).
Button to press to activate/enable the SDK & close the window? If no DSN is provided and the window is closed the SDK could just stay silent and disabled?

![Screenshot 2021-06-04 at 13 06 03](https://user-images.githubusercontent.com/25725783/120792920-824e2f80-c536-11eb-8473-b2e52f122e43.png)

#skip-changelog