### PR TITLE
Force 'Auto' from sentry window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Force 'Auto' from sentry window ([#219](https://github.com/getsentry/sentry-unity/pull/219))
+
 ### Features
 
 - Offline caching ([#208](https://github.com/getsentry/sentry-unity/pull/208))

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -120,9 +120,6 @@ namespace Sentry.Unity.Editor
                 new GUIContent("Event Sample Rate", "What random sample rate to apply. 1.0 captures everything, 0.7 captures 70%."),
                 Options.SampleRate ?? 1.0f, 0.01f, 1);
 
-            // 'Optimal' and 'Fastest' don't work on IL2CPP. Forcing 'Auto'.
-            Options.RequestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
-
             Options.AttachStacktrace = EditorGUILayout.Toggle(
                 new GUIContent("Stacktrace For Logs", "Whether to include a stack trace for non error events like logs. " +
                                                       "Even when Unity didn't include and no Exception was thrown.."),

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -120,11 +120,8 @@ namespace Sentry.Unity.Editor
                 new GUIContent("Event Sample Rate", "What random sample rate to apply. 1.0 captures everything, 0.7 captures 70%."),
                 Options.SampleRate ?? 1.0f, 0.01f, 1);
 
-            var requestCompression = CompressionLevelWithAuto.Auto;
-            EditorGUILayout.LabelField(
-                new GUIContent("Compress Payload", "The level of which to compress the Sentry event before sending to Sentry."),
-                new GUIContent(requestCompression.ToString(), "il2cpp supported."));
-            Options.RequestBodyCompressionLevel = requestCompression;
+            // 'Optimal' and 'Fastest' don't work on IL2CPP. Forcing 'Auto'.
+            Options.RequestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
 
             Options.AttachStacktrace = EditorGUILayout.Toggle(
                 new GUIContent("Stacktrace For Logs", "Whether to include a stack trace for non error events like logs. " +

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -120,9 +120,11 @@ namespace Sentry.Unity.Editor
                 new GUIContent("Event Sample Rate", "What random sample rate to apply. 1.0 captures everything, 0.7 captures 70%."),
                 Options.SampleRate ?? 1.0f, 0.01f, 1);
 
-            Options.RequestBodyCompressionLevel = (CompressionLevelWithAuto)EditorGUILayout.EnumPopup(
+            var requestCompression = CompressionLevelWithAuto.Auto;
+            EditorGUILayout.LabelField(
                 new GUIContent("Compress Payload", "The level of which to compress the Sentry event before sending to Sentry."),
-                Options.RequestBodyCompressionLevel);
+                new GUIContent(requestCompression.ToString(), "il2cpp supported."));
+            Options.RequestBodyCompressionLevel = requestCompression;
 
             Options.AttachStacktrace = EditorGUILayout.Toggle(
                 new GUIContent("Stacktrace For Logs", "Whether to include a stack trace for non error events like logs. " +

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -9,6 +9,9 @@ namespace Sentry.Unity
         {
             application ??= ApplicationAdapter.Instance;
 
+            // 'Optimal' and 'Fastest' don't work on IL2CPP. Forcing 'Auto'.
+            options.RequestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
+
             SetRelease(options, application);
             SetEnvironment(options, application);
             SetCacheDirectoryPath(options, application);

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -9,8 +9,8 @@ namespace Sentry.Unity
         {
             application ??= ApplicationAdapter.Instance;
 
-            // 'Optimal' and 'Fastest' don't work on IL2CPP. Forcing 'Auto'.
-            options.RequestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
+            // 'Optimal' and 'Fastest' don't work on IL2CPP. Forcing 'NoCompression'.
+            options.RequestBodyCompressionLevel = CompressionLevelWithAuto.NoCompression;
 
             SetRelease(options, application);
             SetEnvironment(options, application);

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -203,12 +203,12 @@ namespace Sentry.Unity
         Auto = -1,
         /// <summary>
         /// The compression operation should be optimally compressed, even if the operation takes a longer time (and CPU) to complete.
-        /// Not supported on il2cpp.
+        /// Not supported on IL2CPP.
         /// </summary>
         Optimal = CompressionLevel.Optimal,
         /// <summary>
         /// The compression operation should complete as quickly as possible, even if the resulting data is not optimally compressed.
-        /// Not supported on il2cpp.
+        /// Not supported on IL2CPP.
         /// </summary>
         Fastest = CompressionLevel.Fastest,
         /// <summary>

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -203,10 +203,12 @@ namespace Sentry.Unity
         Auto = -1,
         /// <summary>
         /// The compression operation should be optimally compressed, even if the operation takes a longer time (and CPU) to complete.
+        /// Not supported on il2cpp.
         /// </summary>
         Optimal = CompressionLevel.Optimal,
         /// <summary>
         /// The compression operation should complete as quickly as possible, even if the resulting data is not optimally compressed.
+        /// Not supported on il2cpp.
         /// </summary>
         Fastest = CompressionLevel.Fastest,
         /// <summary>


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-unity/issues/217

I decided to force `Auto` if you configure from sentry window. We can differentiate between scripting backends with the following code

```csharp
PlayerSettings.GetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup) == ScriptingImplementation.IL2CPP
```

but it's available only in `Unity.Editor.dll`. We could do that logic not on options level, but on window level itself.

Which path should we take?

**PS**. Please notice, I didn't include tests as I'm trying to understand which approach we take.