### PR TITLE
release health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Release Health through Sessions ([#223](https://github.com/getsentry/sentry-unity/pull/223))
 - Offline caching ([#208](https://github.com/getsentry/sentry-unity/pull/208))
 - Breadcrumb categories added ([#206](https://github.com/getsentry/sentry-unity/pull/206))
 - Bump Sentry .NET SDK 3.5.0 ([#218](https://github.com/getsentry/sentry-unity/pull/218))

--- a/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
@@ -75,6 +75,7 @@ namespace Sentry.Unity.Integrations
             // Note: On Windows Store Apps and Windows Phone 8.1 there is no application quit event. Consider using OnApplicationFocus event when focusStatus equals false.
             // Note: On WebGL it is not possible to implement OnApplicationQuit due to nature of the browser tabs closing.
             _application.LogMessageReceived -= OnLogMessageReceived;
+            _hub?.EndSession();
             _hub?.FlushAsync(_sentryOptions?.ShutdownTimeout ?? TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
         }
 

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -32,6 +31,7 @@ namespace Sentry.Unity
             SentryOptionsUtility.SetDefaults(unitySentryOptions);
 
             SentrySdk.Init(unitySentryOptions);
+            SentrySdk.StartSession();
         }
     }
 }


### PR DESCRIPTION
To figure out:

* When do we close the session gracefully? The current approach is limited on iOS
* Add opt-out for auto instrumentation
* Crashed sessions (since unity handles all exceptions)