### PR TITLE
Lowercase true or false for tag value

### DIFF
--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -170,7 +170,7 @@ namespace Sentry.Unity
 
         private void PopulateTags(SentryEvent @event)
         {
-            @event.SetTag("unity.gpu.supports_instancing", SystemInfo.supportsInstancing.ToString());
+            @event.SetTag("unity.gpu.supports_instancing", SystemInfo.supportsInstancing ? "true" : "false");
             @event.SetTag("unity.device.device_type", SystemInfo.deviceType.ToString());
             @event.SetTag("unity.install_mode", Application.installMode.ToString());
 


### PR DESCRIPTION
I decided not to call `.ToLower()`, as in order to do so we need to convert `bool` to `string` first and then call `.ToLower()`.

Benefits: less allocations.

#skip-changelog