### PR TITLE
Logger now attaching again 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Logger now attaching again ([#244](https://github.com/getsentry/sentry-unity/pull/244))
+
 ## 0.3.0
 
 ### Features

--- a/src/Sentry.Unity/Json/JsonSentryUnityOptions.cs
+++ b/src/Sentry.Unity/Json/JsonSentryUnityOptions.cs
@@ -65,6 +65,7 @@ namespace Sentry.Unity.Json
                 options.Environment = environment.GetString();
             }
 
+            SentryOptionsUtility.TryAttachLogger(options);
             return options;
         }
 

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -90,6 +90,7 @@ namespace Sentry.Unity
             options.DebugOnlyInEditor = scriptableOptions.DebugOnlyInEditor;
             options.DiagnosticLevel = scriptableOptions.DiagnosticLevel;
 
+            SentryOptionsUtility.TryAttachLogger(options);
             return options;
         }
     }

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -24,8 +24,6 @@ namespace Sentry.Unity
             options.CacheDirectoryPath = application.PersistentDataPath;
 
             options.DebugOnlyInEditor = false;
-
-            TryAttachLogger(options, application);
         }
 
         public static void SetDefaults(ScriptableSentryUnityOptions options)
@@ -54,8 +52,10 @@ namespace Sentry.Unity
 
         private static string Environment(IApplication application) => application.IsEditor ? "editor" : "production";
 
-        private static void TryAttachLogger(SentryUnityOptions options, IApplication application)
+        public static void TryAttachLogger(SentryUnityOptions options, IApplication? application = null)
         {
+            application ??= ApplicationAdapter.Instance;
+
             if (options.DiagnosticLogger is null
                 && options.Debug
                 && (!options.DebugOnlyInEditor || application.IsEditor))

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -20,6 +20,7 @@ namespace Sentry.Unity
 
             unitySentryOptionsConfigure.Invoke(unitySentryOptions);
 
+            SentryOptionsUtility.TryAttachLogger(unitySentryOptions);
             Init(unitySentryOptions);
         }
 


### PR DESCRIPTION
TryAttachLogger got called too early and default `debug = false` so no logging, at all.