### PR TITLE
Invalid memory size on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Invalid memory size on iOS ([#250](https://github.com/getsentry/sentry-unity/pull/250))
+
 ## 0.3.3
 
 ### Fixes

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -108,7 +108,8 @@ namespace Sentry.Unity
 
             // This is the approximate amount of system memory in megabytes.
             // This function is not supported on Windows Store Apps and will always return 0.
-            if (SystemInfo.systemMemorySize != 0)
+            // Additionally: iOS issue with reporting negative memory size https://issuetracker.unity3d.com/issues/ios-if-memory-of-device-is-2gb-over-systeminfo-dot-systemmemorysize-is-returned-wrong-value-on-ios
+            if (SystemInfo.systemMemorySize > 0)
             {
                 device.MemorySize = SystemInfo.systemMemorySize * 1048576L; // Sentry device mem is in Bytes
             }


### PR DESCRIPTION
> contexts.device.memory_size: Discard invalid value expected an unsigned integer
> -334495744

On versions older than [2019.4.23 iOS seems to report memory sizes bigger than 2GB](https://issuetracker.unity3d.com/issues/ios-if-memory-of-device-is-2gb-over-systeminfo-dot-systemmemorysize-is-returned-wrong-value-on-ios) as some negative integer.

Check if memory size is > 0 before adding to the context.

Fixed with Unity 2019.4.23 onwards.
