### PR TITLE
feat/dotnet 3.8.0 persistent session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## Unreleased
-
-- Main thread data ([#245](https://github.com/getsentry/sentry-unity/pull/245))
-
 ### Features
 
+- Main thread data ([#245](https://github.com/getsentry/sentry-unity/pull/245))
 - New config window ([#243](https://github.com/getsentry/sentry-unity/pull/243))
+- Bump Sentry .NET SDK 3.8.0 ([#218](https://github.com/getsentry/sentry-unity/pull/255))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#380)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.5.0...3.8.0)
 
 ## 0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Main thread data ([#245](https://github.com/getsentry/sentry-unity/pull/245))
 - New config window ([#243](https://github.com/getsentry/sentry-unity/pull/243))
-- Bump Sentry .NET SDK 3.8.0 ([#218](https://github.com/getsentry/sentry-unity/pull/255))
+- Bump Sentry .NET SDK 3.8.0 ([#255](https://github.com/getsentry/sentry-unity/pull/255))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#380)
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.5.0...3.8.0)
 


### PR DESCRIPTION
Mainly because of https://github.com/getsentry/sentry-dotnet/pull/1105

With this addition we should see sessions ending as `Abnormal` if there wasn't a clean exit: at least the session being put on the backgrund (aka: paused).