### PR TITLE
DeviceModel set lazily (~ -20ms Sentry init); tests

### DIFF
--- a/src/Sentry.Unity/MainThreadData.cs
+++ b/src/Sentry.Unity/MainThreadData.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
 namespace Sentry.Unity
 {
@@ -20,7 +21,7 @@ namespace Sentry.Unity
 
         public string? DeviceUniqueIdentifier { get; set; }
 
-        public string? DeviceModel { get; set; }
+        public Lazy<string>? DeviceModel { get; set; }
 
         public int? SystemMemorySize { get; set; }
 

--- a/src/Sentry.Unity/SystemInfoAdapter.cs
+++ b/src/Sentry.Unity/SystemInfoAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using UnityEngine;
 
 namespace Sentry.Unity
@@ -13,7 +14,7 @@ namespace Sentry.Unity
         string? CpuDescription { get; }
         string? DeviceName { get; }
         string? DeviceUniqueIdentifier { get; }
-        string? DeviceModel { get; }
+        Lazy<string>? DeviceModel { get; }
         int? SystemMemorySize { get; }
         int? GraphicsDeviceId { get; }
         string? GraphicsDeviceName { get; }
@@ -48,7 +49,7 @@ namespace Sentry.Unity
         public string? CpuDescription => SystemInfo.processorType;
         public string? DeviceName => SystemInfo.deviceName;
         public string? DeviceUniqueIdentifier => SystemInfo.deviceUniqueIdentifier;
-        public string? DeviceModel => SystemInfo.deviceModel;
+        public Lazy<string> DeviceModel => new(() => SystemInfo.deviceModel);
         /// <summary>
         /// System memory size in megabytes.
         /// </summary>

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Sentry.Extensibility;
 using Sentry.Protocol;
 using Sentry.Reflection;
@@ -94,7 +95,7 @@ namespace Sentry.Unity
             device.Simulator = _application.IsEditor ? true : null;
             device.DeviceUniqueIdentifier = _sentryOptions.SendDefaultPii ? _mainThreadData.DeviceUniqueIdentifier : null;
 
-            var model = _mainThreadData.DeviceModel;
+            var model = _mainThreadData.DeviceModel?.Value;
             if (model != SystemInfo.unsupportedIdentifier
                 // Returned by the editor
                 && model != "System Product Name (System manufacturer)")

--- a/test/Sentry.Unity.Tests/UnityEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventProcessorTests.cs
@@ -184,6 +184,35 @@ namespace Sentry.Unity.Tests
         }
 
         [UnityTest]
+        public IEnumerator Process_DeviceProtocol_Assigned()
+        {
+            const long toByte = 1048576L; // in `UnityEventProcessor.PopulateDevice`
+            _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+            {
+                ProcessorCount = 1,
+                DeviceType = "Console",
+                CpuDescription = "Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz",
+                SupportsVibration = true,
+                DeviceName = "hostname",
+                DeviceModel = new Lazy<string>(() => "Samsung Galaxy S3"),
+                SystemMemorySize = 16000
+            };
+            var sut = new UnityEventProcessor(_sentryOptions, _sentryMonoBehaviourGenerator, _testApplication);
+            var sentryEvent = new SentryEvent();
+
+            yield return _sentryMonoBehaviour.CollectData();
+            sut.Process(sentryEvent);
+
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.ProcessorCount, sentryEvent.Contexts.Device.ProcessorCount);
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceType, sentryEvent.Contexts.Device.DeviceType);
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.CpuDescription, sentryEvent.Contexts.Device.CpuDescription);
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsVibration, sentryEvent.Contexts.Device.SupportsVibration);
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceName, sentryEvent.Contexts.Device.Name);
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceModel?.Value, sentryEvent.Contexts.Device.Model);
+            Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SystemMemorySize * toByte, sentryEvent.Contexts.Device.MemorySize);
+        }
+
+        [UnityTest]
         public IEnumerator Process_GpuProtocol_Assigned()
         {
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
@@ -292,7 +321,7 @@ namespace Sentry.Unity.Tests
         public string? CpuDescription { get; set; }
         public string? DeviceName { get; set; }
         public string? DeviceUniqueIdentifier { get; set; }
-        public string? DeviceModel { get; set; }
+        public Lazy<string>? DeviceModel { get; set; }
         public int? SystemMemorySize { get; set; }
         public int? GraphicsDeviceId { get; set; }
         public string? GraphicsDeviceName { get; set; }


### PR DESCRIPTION
#skip-changelog