### PR TITLE
log in single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Features
 
-- Added IsGlobalModeEnabled to SetDefaults ([#260](https://github.com/getsentry/sentry-unity/pull/260))
 - Log in single line ([#262](https://github.com/getsentry/sentry-unity/pull/262))
 
 ## 0.4.2
 
-- No documented changes.
+### Features
+
+- Added IsGlobalModeEnabled to SetDefaults ([#260](https://github.com/getsentry/sentry-unity/pull/260))
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 
 - Added IsGlobalModeEnabled to SetDefaults ([#260](https://github.com/getsentry/sentry-unity/pull/260))
+- Log in single line ([#262](https://github.com/getsentry/sentry-unity/pull/262))
+
 ## 0.4.2
 
 - No documented changes.

--- a/src/Sentry.Unity/UnityLogger.cs
+++ b/src/Sentry.Unity/UnityLogger.cs
@@ -48,9 +48,7 @@ namespace Sentry.Unity
 
             string GetLog()
             {
-                var log = $@"Sentry: {logLevel}
-{Format(message, args)}
-{exception}";
+                var log = $"Sentry: ({logLevel}) {Format(message, args)} {exception}";
                 _interceptor?.Intercept(log);
                 return log;
             }


### PR DESCRIPTION
To better support users who configure console to print a single line which currently shows like this:

![image](https://user-images.githubusercontent.com/1633368/126041692-1d22bf09-f672-496b-a124-4d9228e3c998.png)


![image](https://user-images.githubusercontent.com/1633368/126041679-a3d6d190-f82a-40e1-8961-b5c2bbf3ac57.png)


Looks like this at the end: 
![image](https://user-images.githubusercontent.com/1633368/126042685-4fc6b453-1916-4301-97e5-a8e10cd43e2f.png)
