### PR TITLE
bump dotnet 3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Bump Sentry .NET SDK 3.8.3 ([#269](https://github.com/getsentry/sentry-unity/pull/269))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#383)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.8.3...3.8.3)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.8.2...3.8.3)
 
 ## 0.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Bump Sentry .NET SDK 3.8.3 ([#269](https://github.com/getsentry/sentry-unity/pull/269))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#383)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.8.3...3.8.3)
+
 ## 0.4.3
 
 ### Features

--- a/samples/unity-of-bugs/ProjectSettings/GraphicsSettings.asset
+++ b/samples/unity-of-bugs/ProjectSettings/GraphicsSettings.asset
@@ -34,7 +34,6 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
Mainly because of:

> Don't cancel cache flushing on init #1139


https://github.com/getsentry/sentry-dotnet/pull/1139