### PR TITLE
native crash in sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Native crash in sample ([#270](https://github.com/getsentry/sentry-unity/pull/270))
+
 ### Fixes
 
 - Bump Sentry .NET SDK 3.8.3 ([#269](https://github.com/getsentry/sentry-unity/pull/269))

--- a/samples/unity-of-bugs/Assets/Plugins/NativeExample.c
+++ b/samples/unity-of-bugs/Assets/Plugins/NativeExample.c
@@ -1,0 +1,4 @@
+void crash() {
+    char *ptr = 0;
+    *ptr += 1;
+}

--- a/samples/unity-of-bugs/Assets/Plugins/NativeExample.c.meta
+++ b/samples/unity-of-bugs/Assets/Plugins/NativeExample.c.meta
@@ -1,0 +1,101 @@
+fileFormatVersion: 2
+guid: da6fc370b3c04436ebac11741d509c29
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux64: 0
+        Exclude Lumin: 0
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 0
+        Exclude Win: 0
+        Exclude Win64: 0
+        Exclude iOS: 0
+        Exclude tvOS: 0
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Lumin: Lumin
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/samples/unity-of-bugs/Assets/Scripts/BugFarm.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/BugFarm.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -99,9 +100,18 @@ public class BugFarm : MonoBehaviour
 
     public void CrashNative()
     {
-        // The method definition is missing
-        //crash();
+#if !UNITY_EDITOR
+        crash();
+#else
+        Debug.Log("Requires IL2CPP. Try this on a native player.");
+#endif
     }
+
+#if !UNITY_EDITOR
+    // NativeExample.c
+    [DllImport("__Internal")]
+    private static extern void crash();
+#endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void MethodA() => throw new InvalidOperationException("Exception from A lady beetle 🐞");
@@ -109,10 +119,6 @@ public class BugFarm : MonoBehaviour
     // IL2CPP inlines this anyway
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void MethodB() => MethodA();
-
-    // The method definition is missing
-    //[DllImport("__Internal")]
-    //private static extern void crash();
 }
 
 public class CustomException : System.Exception

--- a/samples/unity-of-bugs/ProjectSettings/GraphicsSettings.asset
+++ b/samples/unity-of-bugs/ProjectSettings/GraphicsSettings.asset
@@ -34,6 +34,7 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
Tested locally and:

* in the editor it prints; 
![image](https://user-images.githubusercontent.com/1633368/127245109-9b9e0dd6-e99a-404b-b575-851135ac9eb5.png)
* Built an IL2CPP macOS player and it crashed as expected.