### PR TITLE
fix: Passing Sentry diagnostic level to iOS native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- Fixed passing Sentry diagnostic level to iOS native layer ([#281](https://github.com/getsentry/sentry-unity/pull/281))
 - Fixed stuck traces sample rate slider ([#276](https://github.com/getsentry/sentry-unity/pull/276))
 - Fixed selected input field tab glitches ([#276](https://github.com/getsentry/sentry-unity/pull/276))
 - Bump Sentry .NET SDK 3.8.3 ([#269](https://github.com/getsentry/sentry-unity/pull/269))

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace Sentry.Unity.Editor.iOS
@@ -25,7 +26,7 @@ static NSDictionary* getSentryOptions()
     NSDictionary* options = @{{
         @""dsn"" : @""{options.Dsn}"",
         @""debug"" : @{ToObjCString(options.Debug)},
-        @""diagnosticLevel"" : @{ToNativeDiagnosticLevel(options.DiagnosticLevel)},
+        @""diagnosticLevel"" : @""{ToNativeDiagnosticLevel(options.DiagnosticLevel)}"",
         @""maxBreadcrumbs"": @{options.MaxBreadcrumbs},
         @""maxCacheItems"": @{options.MaxCacheItems},
         @""enableAutoSessionTracking"": @NO,
@@ -40,13 +41,17 @@ static NSDictionary* getSentryOptions()
 
         private static string ToObjCString(bool b) => b ? "YES" : "NO";
 
-        // Native Diagnostic Level:
-        // None = 0
-        // Debug = 1
-        // Info = 2
-        // Warning = 3
-        // Error = 4
-        // Fatal = 5
-        private static int ToNativeDiagnosticLevel(SentryLevel diagnosticLevel) => (int)diagnosticLevel + 1;
+        private static string ToNativeDiagnosticLevel(SentryLevel sentryLevel)
+        {
+            return sentryLevel switch
+            {
+                SentryLevel.Debug => "debug",
+                SentryLevel.Info => "info",
+                SentryLevel.Warning => "warning",
+                SentryLevel.Error => "error",
+                SentryLevel.Fatal => "fatal",
+                _ => "none"
+            };
+        }
     }
 }

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 
 namespace Sentry.Unity.Editor.iOS


### PR DESCRIPTION
We now pass the level as string to the native options.