### PR TITLE
fix: SentryInitialization prevents codestripping of Init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- Added attribute to SentryInitialization to prevent codestripping of Init ([#285](https://github.com/getsentry/sentry-unity/pull/285))
 - Fixed stuck traces sample rate slider ([#276](https://github.com/getsentry/sentry-unity/pull/276))
 - Fixed selected input field tab glitches ([#276](https://github.com/getsentry/sentry-unity/pull/276))
 - Bump Sentry .NET SDK 3.8.3 ([#269](https://github.com/getsentry/sentry-unity/pull/269))

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -1,4 +1,7 @@
 using UnityEngine;
+using UnityEngine.Scripting;
+
+[assembly: AlwaysLinkAssembly]
 
 namespace Sentry.Unity
 {
@@ -7,9 +10,11 @@ namespace Sentry.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
+            Debug.Log("Trying to Initialize");
             var options = ScriptableSentryUnityOptions.LoadSentryUnityOptions();
             if (options.ShouldInitializeSdk())
             {
+                Debug.Log("Initializing");
                 SentryUnity.Init(options);
             }
         }

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -10,11 +10,9 @@ namespace Sentry.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
-            Debug.Log("Trying to Initialize");
             var options = ScriptableSentryUnityOptions.LoadSentryUnityOptions();
             if (options.ShouldInitializeSdk())
             {
-                Debug.Log("Initializing");
                 SentryUnity.Init(options);
             }
         }


### PR DESCRIPTION
Because we moved SentryInitialization out of our DLL to compile with the game and it was not covered by our link.xml the code stripper just gets rid of ot.