### PR TITLE
fix: ci and pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,7 @@ on:
 
   pull_request:
     paths:
-    - '.github/**/*.yml'
-    - 'src/**'
-    - 'test/**'
-    - 'samples/**'
-    - 'Directory.Build.props'
-    - '*sln*'
-    - '*NuGet*'
-    - '.gitmodules'
-    - '.craft.yml'
+    - '*'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,33 +188,7 @@ jobs:
 
       - name: Prepare Sentry package for release
         shell: pwsh
-        run: |
-          New-Item "package-release" -ItemType Directory
-
-          # Copy `package-dev` stuff
-          Copy-Item "package-dev/*" -Destination "package-release/" -Exclude "README.md", "package.json", "Tests", "Tests.meta", "*.asmdef", "*.asmdef.meta", "SentryOptions.json*" -Recurse
-
-          # Copy `package` stuff
-          Copy-Item "package/package.json" -Destination "package-release/package.json"
-          Copy-Item "package/README.md" -Destination "package-release/README.md"
-          Copy-Item "CHANGELOG.md" -Destination "package-release/CHANGELOG.md"
-          Copy-Item "package/CHANGELOG.md.meta" -Destination "package-release/CHANGELOG.md.meta"
-          Copy-Item "LICENSE.md" -Destination "package-release/LICENSE.md"
-          Copy-Item "package/LICENSE.md.meta" -Destination "package-release/LICENSE.md.meta"
-          New-Item -Type dir "package-release/Editor/" -Force
-          Get-ChildItem "package/Editor/" -Include "*.asmdef", "*.asmdef.meta" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Editor/" }
-          New-Item -Type dir "package-release/Runtime/" -Force
-          Get-ChildItem "package/Runtime/" -Include "*.asmdef", "*.asmdef.meta" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Runtime/" }
-          # Destination directory need to exist if we're copying a file instead of a directory
-          New-Item -Type dir "package-release/Documentation~/" -Force
-          Get-ChildItem "package/Documentation~/" -Include "*.md" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Documentation~/" }
-
-          # Copy samples
-          Copy-Item "samples/unity-of-bugs/Assets/Scenes" -Destination "package-release/Samples~/unity-of-bugs/Assets/Scenes" -Recurse
-          Copy-Item "samples/unity-of-bugs/Assets/Scripts" -Destination "package-release/Samples~/unity-of-bugs/Assets/Scripts" -Recurse
-
-          # Create zip
-          Compress-Archive "package-release/*" -DestinationPath "package-release.zip" -Force
+        run: ./scripts/pack.ps1
 
       - name: Upload build artifacts if build failed
         if: ${{ failure() }}

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -1,0 +1,22 @@
+New-Item "package-release" -ItemType Directory
+
+# Copy `package-dev` stuff
+Copy-Item "package-dev/*" -Destination "package-release/" -Exclude "README.md", "package.json", "Tests", "Tests.meta", "*.asmdef", "*.asmdef.meta", "SentryOptions.json*" -Recurse
+
+# Copy `package` stuff
+Copy-Item "package/package.json" -Destination "package-release/package.json"
+Copy-Item "package/README.md" -Destination "package-release/README.md"
+Copy-Item "CHANGELOG.md" -Destination "package-release/CHANGELOG.md"
+Copy-Item "package/CHANGELOG.md.meta" -Destination "package-release/CHANGELOG.md.meta"
+Copy-Item "LICENSE.md" -Destination "package-release/LICENSE.md"
+Copy-Item "package/LICENSE.md.meta" -Destination "package-release/LICENSE.md.meta"
+# Destination directory need to exist if we're copying a file instead of a directory
+New-Item -Type dir "package-release/Documentation~/" -Force
+Get-ChildItem "package/Documentation~/" -Include "*.md" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Documentation~/" }
+
+# Copy samples
+Copy-Item "samples/unity-of-bugs/Assets/Scenes" -Destination "package-release/Samples~/unity-of-bugs/Assets/Scenes" -Recurse
+Copy-Item "samples/unity-of-bugs/Assets/Scripts" -Destination "package-release/Samples~/unity-of-bugs/Assets/Scripts" -Recurse
+
+# Create zip
+Compress-Archive "package-release/*" -DestinationPath "package-release.zip" -Force

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -10,6 +10,8 @@ Copy-Item "CHANGELOG.md" -Destination "package-release/CHANGELOG.md"
 Copy-Item "package/CHANGELOG.md.meta" -Destination "package-release/CHANGELOG.md.meta"
 Copy-Item "LICENSE.md" -Destination "package-release/LICENSE.md"
 Copy-Item "package/LICENSE.md.meta" -Destination "package-release/LICENSE.md.meta"
+New-Item -Type dir "package-release/Runtime/" -Force
+Get-ChildItem "package/Runtime/" -Include "*.asmdef", "*.asmdef.meta" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Runtime/" }
 # Destination directory need to exist if we're copying a file instead of a directory
 New-Item -Type dir "package-release/Documentation~/" -Force
 Get-ChildItem "package/Documentation~/" -Include "*.md" -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination "package-release/Documentation~/" }


### PR DESCRIPTION
PR #316 broken packaging which tries to copy files that don't exist.

This PR fixes that (by removing the two copy commands) and also moves the script to a local file so we can test things locally more easily

#skip-changelog