### PR TITLE
fix: Resolving iOS reference on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,19 +26,14 @@ package-dev/**/*.xml
 package-dev/**/TestSentryOptions.json
 package-dev/Tests/Editor/TestFiles/
 
-!package-dev/Runtime/Sentry.Unity.dll.meta
-!package-dev/Runtime/Sentry.Unity.iOS.dll.meta
-!package-dev/Tests/*.meta
+# Adding .meta to control target platforms for all of our DLLs
+!package-dev/**/Sentry*.dll.meta
 
 # required to be marked as iOS only
 !package-dev/**/*.framework.meta
 
 # Android SDK files
 package-dev/Plugins/Android/Sentry/*
-
-# required to be marked as Editor only
-!package-dev/Tests/Runtime/Sentry.Unity.Tests.dll.meta
-!package-dev/Tests/Runtime/Sentry.Unity.iOS.Tests.dll.meta
 
 # Build output of Sentry.Unity
 sentry-unity/Assets/Plugins/Sentry/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Fixed iOS support related reference resolution issue for Windows ([#324](https://github.com/getsentry/sentry-unity/pull/324))
+- Fixed iOS support related reference resolution issue for Windows ([#325](https://github.com/getsentry/sentry-unity/pull/325))
 - Import link.xml caused an infinite loop ([#315](https://github.com/getsentry/sentry-unity/pull/315))
 - Removed unused .asmdefs which clears a warning from console ([#316](https://github.com/getsentry/sentry-unity/pull/316))
 - Don't send negative line number ([#317](https://github.com/getsentry/sentry-unity/pull/317))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fixed iOS support related reference resolution issue for Windows ([#324](https://github.com/getsentry/sentry-unity/pull/324))
 - Import link.xml caused an infinite loop ([#315](https://github.com/getsentry/sentry-unity/pull/315))
 - Removed unused .asmdefs which clears a warning from console ([#316](https://github.com/getsentry/sentry-unity/pull/316))
 - Don't send negative line number ([#317](https://github.com/getsentry/sentry-unity/pull/317))

--- a/package-dev/Editor/Sentry.Unity.Editor.dll.meta
+++ b/package-dev/Editor/Sentry.Unity.Editor.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 7f7ea26e3243148e5ab9a7c58391af93
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Editor/iOS/Sentry.Unity.Editor.iOS.dll.meta
+++ b/package-dev/Editor/iOS/Sentry.Unity.Editor.iOS.dll.meta
@@ -1,0 +1,86 @@
+fileFormatVersion: 2
+guid: ab77fe3d77aab47838f950495e9f5869
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Runtime/Sentry.dll.meta
+++ b/package-dev/Runtime/Sentry.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 00c1d3d6cffc74e1a8e149a922b7f53a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Tests/Editor/Sentry.Unity.Editor.Tests.dll.meta
+++ b/package-dev/Tests/Editor/Sentry.Unity.Editor.Tests.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 5b830fbb140384bdd91f42f3e292d79c
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Tests/Editor/Sentry.Unity.Editor.iOS.Tests.dll.meta
+++ b/package-dev/Tests/Editor/Sentry.Unity.Editor.iOS.Tests.dll.meta
@@ -1,0 +1,86 @@
+fileFormatVersion: 2
+guid: 229856c93cfc8485681cefb43652fccd
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-unity/issues/309
The *dll.meta files allow us fine-grained control of which DLLs do what on which platform.

![Screenshot 2021-09-20 at 18 42 13](https://user-images.githubusercontent.com/25725783/134040854-87fc6aeb-ebb2-41b5-a410-58dcd7827ad4.png)

So all of our iOS related DLL are exclusive to OSX.
I added all of our dll metas in this PR because this issue keeps coming up and I don't want to manually exclude each and every file.