### PR TITLE
feat: iOS scope sync - added 'crashed last run'

### DIFF
--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -2,6 +2,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+bool CrashedLastRun() {
+    return[SentrySDK crashedLastRun];
+}
+
 void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message, const char* type, const char* category, int level) {
     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
         return;

--- a/src/Sentry.Unity.iOS/IosNativeScopeObserver.cs
+++ b/src/Sentry.Unity.iOS/IosNativeScopeObserver.cs
@@ -7,6 +7,9 @@ namespace Sentry.Unity.iOS
     public class IosNativeScopeObserver : IScopeObserver
     {
         [DllImport("__Internal")]
+        private static extern bool CrashedLastRun();
+
+        [DllImport("__Internal")]
         private static extern void SentryNativeBridgeAddBreadcrumb(string timestamp, string? message, string? type, string? category, int level);
 
         [DllImport("__Internal")]
@@ -26,7 +29,11 @@ namespace Sentry.Unity.iOS
 
         private readonly SentryUnityOptions _options;
 
-        public IosNativeScopeObserver(SentryUnityOptions options) => _options = options;
+        public IosNativeScopeObserver(SentryUnityOptions options)
+        {
+            _options = options;
+            _options.CrashedLastRun = CrashedLastRun;
+        }
 
         public void AddBreadcrumb(Breadcrumb breadcrumb)
         {


### PR DESCRIPTION
Added `CrashedLastRun` to bridge so the .NET layer can properly deal with sessions that crashed on the native layer. 

#skip-changelog