### PR TITLE
fix: Editor.Tests.dll failed to resolve Sentry

### DIFF
--- a/test/Sentry.Unity.Editor.Tests/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/AndroidManifestConfigurationTests.cs
@@ -64,7 +64,7 @@ namespace Sentry.Unity.Editor.Tests
 
             Assert.True(manifest.Contains(
                     "<meta-data android:name=\"io.sentry.auto-init\" android:value=\"false\" />"),
-                    "Expected 'auto-init' to be disabled");
+                "Expected 'auto-init' to be disabled");
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace Sentry.Unity.Editor.Tests
 
             Assert.True(manifest.Contains(
                     "<meta-data android:name=\"io.sentry.auto-init\" android:value=\"false\" />"),
-                    "Expected 'auto-init' to be disabled");
+                "Expected 'auto-init' to be disabled");
         }
 
         [Test]
@@ -209,12 +209,6 @@ namespace Sentry.Unity.Editor.Tests
             new () { SentryLevel = SentryLevel.Warning, JavaLevel = "warning" }
         };
 
-        public struct SentryJavaLevel
-        {
-            public SentryLevel SentryLevel;
-            public string JavaLevel;
-        }
-
         [Test]
         public void OnPostGenerateGradleAndroidProject_DiagnosticLevel_TestCases(
             [ValueSource(nameof(SentryJavaLevels))] SentryJavaLevel levels)
@@ -278,6 +272,12 @@ namespace Sentry.Unity.Editor.Tests
             Directory.CreateDirectory(destination);
             File.Copy(newAndroidManifest, Path.Combine(destination, "AndroidManifest.xml"), false);
             return basePath;
+        }
+
+        public struct SentryJavaLevel
+        {
+            public SentryLevel SentryLevel;
+            public string JavaLevel;
         }
     }
 }

--- a/test/Sentry.Unity.Editor.Tests/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/AndroidManifestConfigurationTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
-using Sentry;
 using Sentry.Unity.Editor.Android;
 
 namespace Sentry.Unity.Editor.Tests
@@ -33,7 +32,6 @@ namespace Sentry.Unity.Editor.Tests
 
         [SetUp]
         public void SetUp() => _fixture = new Fixture();
-
         private Fixture _fixture = null!;
 
         [Test]
@@ -63,7 +61,7 @@ namespace Sentry.Unity.Editor.Tests
 
             Assert.True(manifest.Contains(
                     "<meta-data android:name=\"io.sentry.auto-init\" android:value=\"false\" />"),
-                "Expected 'auto-init' to be disabled");
+                    "Expected 'auto-init' to be disabled");
         }
 
         [Test]
@@ -73,20 +71,18 @@ namespace Sentry.Unity.Editor.Tests
             var sut = _fixture.GetSut();
             var manifest = WithAndroidManifest(basePath => sut.OnPostGenerateGradleAndroidProject(basePath));
 
-            AssertLogContains(SentryLevel.Debug,
-                "Sentry SDK has been disabled.\nYou can disable this log by raising the debug verbosity level above 'Debug'.");
+            AssertLogContains(SentryLevel.Debug, "Sentry SDK has been disabled.\nYou can disable this log by raising the debug verbosity level above 'Debug'.");
 
             Assert.True(manifest.Contains(
                     "<meta-data android:name=\"io.sentry.auto-init\" android:value=\"false\" />"),
-                "Expected 'auto-init' to be disabled");
+                    "Expected 'auto-init' to be disabled");
         }
 
         [Test]
         [TestCase(null)]
         [TestCase("")]
         [TestCase("  ")]
-        public void OnPostGenerateGradleAndroidProject_UnityOptions_EnabledWithoutDsn_LogWarningAndDisableInit(
-            string? dsn)
+        public void OnPostGenerateGradleAndroidProject_UnityOptions_EnabledWithoutDsn_LogWarningAndDisableInit(string? dsn)
         {
             _fixture.SentryUnityOptions!.Dsn = dsn;
             var sut = _fixture.GetSut();
@@ -100,8 +96,7 @@ namespace Sentry.Unity.Editor.Tests
         }
 
         [Test]
-        public void
-            OnPostGenerateGradleAndroidProject_UnityOptions_AndroidNativeSupportEnabledFalse_LogDebugAndDisableInit()
+        public void OnPostGenerateGradleAndroidProject_UnityOptions_AndroidNativeSupportEnabledFalse_LogDebugAndDisableInit()
         {
             _fixture.SentryUnityOptions!.AndroidNativeSupportEnabled = false;
             var sut = _fixture.GetSut();

--- a/test/Sentry.Unity.Editor.Tests/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/AndroidManifestConfigurationTests.cs
@@ -20,7 +20,10 @@ namespace Sentry.Unity.Editor.Tests
                 // Options configured to initialize the Android SDK, tests will change from there:
                 SentryUnityOptions = new()
                 {
-                    Enabled = true, Dsn = "https://k@h/p", AndroidNativeSupportEnabled = true, Debug = true
+                    Enabled = true,
+                    Dsn = "https://k@h/p",
+                    AndroidNativeSupportEnabled = true,
+                    Debug = true
                 };
                 SentryUnityOptions.DiagnosticLogger = new UnityLogger(SentryUnityOptions, LoggerInterceptor);
 


### PR DESCRIPTION
Upon package import users get hit with an API update prompt followed by an error in the console: 
`Failed to resolve assembly: 'Sentry'`.
Apparently, editor tests can't deal with test cases containing types from different assemblies?

![Screenshot 2021-09-20 at 16 15 43](https://user-images.githubusercontent.com/25725783/134170028-18c4d26f-32a7-46e9-a90f-40163e50df3a.png)

<details><summary>Errorlog</summary>
```
Unable to update following assemblies:Packages/io.sentry.unity.dev/Tests/Editor/Sentry.Unity.Editor.Tests.dll (Name = Sentry.Unity.Editor.Tests, Error = 131) (Output: /var/folders/49/tcrc4c010s5dzxspqp6f8nbm0000gn/T/tmp17cd92f3.tmp)

System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'Sentry, Version=3.9.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0'
  at Mono.Cecil.BaseAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name, Mono.Cecil.ReaderParameters parameters) [0x00105] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.BaseAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name) [0x00007] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.DefaultAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name) [0x0001d] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.MetadataResolver.Resolve (Mono.Cecil.TypeReference type) [0x00038] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.ModuleDefinition.Resolve (Mono.Cecil.TypeReference type) [0x00006] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.TypeReference.Resolve () [0x00006] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.Mixin.CheckedResolve (Mono.Cecil.TypeReference self) [0x00000] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.SignatureReader.ReadCustomAttributeEnum (Mono.Cecil.TypeReference enum_type) [0x00000] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.SignatureReader.ReadCustomAttributeElementValue (Mono.Cecil.TypeReference type) [0x0002f] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.SignatureReader.ReadCustomAttributeElement (Mono.Cecil.TypeReference type) [0x00015] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.SignatureReader.ReadCustomAttributeElement (Mono.Cecil.TypeReference type) [0x00030] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.SignatureReader.ReadCustomAttributeFixedArgument (Mono.Cecil.TypeReference type) [0x00015] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.SignatureReader.ReadCustomAttributeConstructorArguments (Mono.Cecil.CustomAttribute attribute, Mono.Collections.Generic.Collection`1[T] parameters) [0x0002e] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.MetadataReader.ReadCustomAttributeSignature (Mono.Cecil.CustomAttribute attribute) [0x0003c] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.CustomAttribute.<Resolve>b__35_0 (Mono.Cecil.CustomAttribute attribute, Mono.Cecil.MetadataReader reader) [0x00000] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.ModuleDefinition.Read[TItem,TRet] (TItem item, System.Func`3[T1,T2,TResult] read) [0x00029] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.CustomAttribute.Resolve () [0x00017] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at Mono.Cecil.CustomAttribute.get_ConstructorArguments () [0x00000] in <a3989f8c34e6476eaca56644d5639ee8>:0 
  at AssemblyUpdater.Steps.MoveToNamespace.Visit (Mono.Cecil.CustomAttribute customAttribute, Unity.Cecil.Visitor.Context context) [0x000d3] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at Unity.Cecil.Visitor.Visitor.Visit (Mono.Cecil.MethodDefinition methodDefinition, Unity.Cecil.Visitor.Context context) [0x00035] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at Unity.Cecil.Visitor.Visitor.Visit (Mono.Cecil.TypeDefinition typeDefinition, Unity.Cecil.Visitor.Context context) [0x00190] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at Unity.Cecil.Visitor.Visitor.Visit (Mono.Cecil.ModuleDefinition moduleDefinition, Unity.Cecil.Visitor.Context context) [0x00021] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at Unity.Cecil.Visitor.Visitor.Visit (Mono.Cecil.AssemblyDefinition assemblyDefinition, Unity.Cecil.Visitor.Context context) [0x00021] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at AssemblyUpdater.Steps.AssemblyUpdaterStepBase.Visit (Mono.Cecil.AssemblyDefinition assemblyDefinition, Unity.Cecil.Visitor.Context context) [0x00001] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in <eae584ce26bc40229c1b1aa476bfa589>:0 
   --- End of inner exception stack trace ---
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00048] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at Unity.Cecil.Visitor.Visitor.Visit[T] (T node, Unity.Cecil.Visitor.Context context) [0x00037] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at Unity.Cecil.Visitor.Extensions.DoAccept[T] (T definition, Unity.Cecil.Visitor.Visitor visitor) [0x0001d] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at Unity.Cecil.Visitor.Extensions.Accept (Mono.Cecil.AssemblyDefinition assemblyDefinition, Unity.Cecil.Visitor.Visitor visitor) [0x00001] in <05fd34f074244315b2adf4027eb2c66a>:0 
  at AssemblyUpdater.Steps.AssemblyUpdaterStepBase.Apply (AssemblyUpdater.Core.AssemblyUpdaterContext context) [0x00013] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at AssemblyUpdater.Core.AssemblyUpdaterPipeline.RunUpdateRound (AssemblyUpdater.Core.AssemblyUpdaterContext context) [0x00034] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at AssemblyUpdater.Core.AssemblyUpdaterPipeline.Run (AssemblyUpdater.Core.AssemblyUpdaterContext context) [0x0000a] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at AssemblyUpdater.Application.Program.UpdateAssembly (AssemblyUpdater.Application.AssemblyOptions config, AssemblyUpdater.Core.AssemblyUpdaterContext context) [0x00026] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at AssemblyUpdater.Application.Program+<>c__DisplayClass0_0.<Main>b__1 (AssemblyUpdater.Application.UpdateOptions o) [0x0004d] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
  at CommandLine.ParserResultExtensions.WithParsed[T] (CommandLine.ParserResult`1[T] result, System.Action`1[T] action) [0x0001e] in <5f6458f0234f43a48c09047109c24684>:0 
  at AssemblyUpdater.Application.Program.Main (System.String[] args) [0x0004c] in <d3fa45b9e08f449c9741ef7c6ca84121>:0 
Following assemblies were successfully updated but due to the failed ones above they were ignored (not copied to the destination folder).Packages/io.sentry.unity.dev/Runtime/Sentry.Unity.dll (Result = 0) (Output: /var/folders/49/tcrc4c010s5dzxspqp6f8nbm0000gn/T/tmp383a6a14.tmp)

Packages/io.sentry.unity.dev/Editor/Sentry.Unity.Editor.dll (Result = 0) (Output: /var/folders/49/tcrc4c010s5dzxspqp6f8nbm0000gn/T/tmpd6e997.tmp)

Packages/io.sentry.unity.dev/Editor/iOS/Sentry.Unity.Editor.iOS.dll (Result = 0) (Output: /var/folders/49/tcrc4c010s5dzxspqp6f8nbm0000gn/T/tmp43b5bec2.tmp)

Packages/io.sentry.unity.dev/Tests/Editor/Sentry.Unity.Editor.iOS.Tests.dll (Result = 0) (Output: /var/folders/49/tcrc4c010s5dzxspqp6f8nbm0000gn/T/tmp6be56723.tmp)

Packages/io.sentry.unity.dev/Tests/Runtime/Sentry.Unity.Tests.dll (Result = 0) (Output: /var/folders/49/tcrc4c010s5dzxspqp6f8nbm0000gn/T/tmp3602963.tmp)


UnityEditor.Scripting.APIUpdaterLogger:WriteErrorToConsole (string,object[])
UnityEditorInternal.APIUpdating.APIUpdaterManager:HandleAssemblyUpdaterErrors (System.Collections.Generic.IEnumerable`1<UnityEditorInternal.APIUpdating.AssemblyUpdaterUpdateTask>) (at /Users/bokken/buildslave/unity/build/Editor/Mono/Scripting/APIUpdater/APIUpdaterManager.bindings.cs:230)
UnityEditorInternal.APIUpdating.APIUpdaterManager:UpdateAssemblies () (at /Users/bokken/buildslave/unity/build/Editor/Mono/Scripting/APIUpdater/APIUpdaterManager.bindings.cs:117)
UnityEditorInternal.APIUpdating.APIUpdaterManager:ProcessImportedAssemblies (string[]) (at /Users/bokken/buildslave/unity/build/Editor/Mono/Scripting/APIUpdater/APIUpdaterManager.bindings.cs:375)
```
</details>

#skip-changelog