### PR TITLE
fix: Properly embedded iOS native support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fixed Xcode generation with invalid or disabled SentryOptions ([#330](https://github.com/getsentry/sentry-unity/pull/330))
 - Fixed iOS support related reference resolution issue for Windows ([#325](https://github.com/getsentry/sentry-unity/pull/325))
 - Import link.xml caused an infinite loop ([#315](https://github.com/getsentry/sentry-unity/pull/315))
 - Removed unused .asmdefs which clears a warning from console ([#316](https://github.com/getsentry/sentry-unity/pull/316))

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -27,11 +27,17 @@ namespace Sentry.Unity
             {
 
 #if SENTRY_NATIVE_IOS
-                options.ScopeObserver = new IosNativeScopeObserver(options);
-                options.EnableScopeSync = true;
+                if (options.IosNativeSupportEnabled)
+                {
+                    options.ScopeObserver = new IosNativeScopeObserver(options);
+                    options.EnableScopeSync = true;
+                }
 #elif SENTRY_NATIVE_ANDROID
-                options.ScopeObserver = new UnityJavaScopeObserver(options);
-                options.EnableScopeSync = true;
+                if (options.AndroidNativeSupportEnabled)
+                {
+                    options.ScopeObserver = new UnityJavaScopeObserver(options);
+                    options.EnableScopeSync = true;
+                }
 #endif
 
                 SentryUnity.Init(options);

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -30,7 +30,7 @@ namespace Sentry.Unity.Editor.iOS
 
                 if (!options.IosNativeSupportEnabled)
                 {
-                    options.DiagnosticLogger?.LogDebug("iOS Native support disabled. Native support disabled.");
+                    options.DiagnosticLogger?.LogDebug("iOS Native support disabled through the options.");
                     return;
                 }
 

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -16,29 +16,30 @@ namespace Sentry.Unity.Editor.iOS
             }
 
             var options = ScriptableSentryUnityOptions.LoadSentryUnityOptions(BuildPipeline.isBuildingPlayer);
-            if (options?.Validate() != true)
-            {
-                new UnityLogger(new SentryOptions()).LogWarning(
-                    "Failed to validate Sentry Options. Xcode project will not be modified.");
-                return;
-            }
-
-            if (!options.IosNativeSupportEnabled)
-            {
-                options.DiagnosticLogger?.LogDebug("iOS Native support disabled. Won't modify the xcode project");
-                return;
-            }
 
             try
             {
-                using var sentryXcodeProject = SentryXcodeProject.Open(pathToProject, options);
+                using var sentryXcodeProject = SentryXcodeProject.Open(pathToProject);
                 sentryXcodeProject.AddSentryFramework();
-                sentryXcodeProject.AddNativeOptions();
-                sentryXcodeProject.AddSentryToMain();
+
+                if (options?.Validate() != true)
+                {
+                    new UnityLogger(new SentryOptions()).LogWarning("Failed to validate Sentry Options. Native support disabled.");
+                    return;
+                }
+
+                if (!options.IosNativeSupportEnabled)
+                {
+                    options.DiagnosticLogger?.LogDebug("iOS Native support disabled. Native support disabled.");
+                    return;
+                }
+
+                sentryXcodeProject.AddNativeOptions(options);
+                sentryXcodeProject.AddSentryToMain(options);
             }
             catch (Exception e)
             {
-                options.DiagnosticLogger?.LogError("Failed to add Sentry to the xcode project", e);
+                options?.DiagnosticLogger?.LogError("Failed to add the Sentry framework to the generated Xcode project", e);
             }
         }
     }

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -14,8 +14,6 @@ namespace Sentry.Unity.Editor.iOS
         private readonly string _unityPackageFrameworkRoot = Path.Combine("Frameworks", "io.sentry.unity");
 
         private readonly string _projectRoot;
-        private readonly SentryUnityOptions _options;
-
         private readonly PBXProject _project;
         private readonly string _projectPath;
 
@@ -24,22 +22,15 @@ namespace Sentry.Unity.Editor.iOS
         private readonly INativeMain _nativeMain;
         private readonly INativeOptions _nativeOptions;
 
-        public SentryXcodeProject(
-            string projectRoot,
-            SentryUnityOptions options)
-            : this(projectRoot, options, new NativeMain(), new NativeOptions())
-        {
-        }
+        public SentryXcodeProject(string projectRoot) : this(projectRoot, new NativeMain(), new NativeOptions())
+        { }
 
         internal SentryXcodeProject(
             string projectRoot,
-            SentryUnityOptions options,
             INativeMain mainModifier,
             INativeOptions sentryNativeOptions)
         {
             _projectRoot = projectRoot;
-            _options = options;
-
             _projectPath = PBXProject.GetPBXProjectPath(projectRoot);
             _project = new PBXProject();
 
@@ -47,9 +38,9 @@ namespace Sentry.Unity.Editor.iOS
             _nativeOptions = sentryNativeOptions;
         }
 
-        public static SentryXcodeProject Open(string path, SentryUnityOptions options)
+        public static SentryXcodeProject Open(string path)
         {
-            var xcodeProject = new SentryXcodeProject(path, options);
+            var xcodeProject = new SentryXcodeProject(path);
             xcodeProject.ReadFromProjectFile();
             xcodeProject.SetRelativeFrameworkPath();
 
@@ -104,14 +95,14 @@ namespace Sentry.Unity.Editor.iOS
             _project.AddBuildProperty(targetGuid, "OTHER_LDFLAGS", "-ObjC");
         }
 
-        public void AddNativeOptions()
+        public void AddNativeOptions(SentryUnityOptions options)
         {
-            _nativeOptions.CreateFile(Path.Combine(_projectRoot, _optionsPath), _options);
+            _nativeOptions.CreateFile(Path.Combine(_projectRoot, _optionsPath), options);
             _project.AddFile(_optionsPath, _optionsPath);
         }
 
-        public void AddSentryToMain() =>
-            _nativeMain.AddSentry(Path.Combine(_projectRoot, _mainPath), _options.DiagnosticLogger);
+        public void AddSentryToMain(SentryUnityOptions options) =>
+            _nativeMain.AddSentry(Path.Combine(_projectRoot, _mainPath), options.DiagnosticLogger);
 
         internal string ProjectToString() => _project.WriteToString();
 

--- a/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
@@ -26,7 +26,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
             public INativeMain NativeMain { get; set; } = new NativeMainTest();
             public INativeOptions NativeOptions { get; set; } = new NativeOptionsTest();
 
-            public SentryXcodeProject GetSut() => new(ProjectRoot, Options, NativeMain, NativeOptions);
+            public SentryXcodeProject GetSut() => new(ProjectRoot, NativeMain, NativeOptions);
         }
 
         private Fixture _fixture = new();
@@ -117,7 +117,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
             xcodeProject.ReadFromProjectFile();
             xcodeProject.RelativeFrameworkPath = "Frameworks/io.sentry.unity/Plugins/iOS/";
 
-            xcodeProject.AddNativeOptions();
+            xcodeProject.AddNativeOptions(_fixture.Options);
 
             StringAssert.Contains("SentryOptions.m", xcodeProject.ProjectToString());
         }


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-unity/issues/304

Unity copies the `.framework` and our `bridge.m` in any case. But with invalid options, we bail too soon and the Xcode project gets left in a broken state.
