### PR TITLE
fix: android crumb level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Import link.xml caused an infinite loop ([#315](https://github.com/getsentry/sentry-unity/pull/315))
 - Removed unused .asmdefs which clears a warning from console ([#316](https://github.com/getsentry/sentry-unity/pull/316))
 - Don't send negative line number ([#317](https://github.com/getsentry/sentry-unity/pull/317))
+- Android breadcrumbs have correct level ([#338](https://github.com/getsentry/sentry-unity/pull/338))
 - Bump Sentry .NET SDK 3.9.3 ([#328](https://github.com/getsentry/sentry-unity/pull/328))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.9.3/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.9.0...3.9.3)

--- a/src/Sentry.Unity/Android/BreadcrumbExtensions.cs
+++ b/src/Sentry.Unity/Android/BreadcrumbExtensions.cs
@@ -21,13 +21,13 @@ namespace Sentry.Unity
         /// <returns>An Android Java object representing the SentryLevel.</returns>
         public static AndroidJavaObject ToJavaSentryLevel(this BreadcrumbLevel level)
             => level switch
-                {
-                    BreadcrumbLevel.Critical => JavaSentryLevelFatal,
-                    BreadcrumbLevel.Debug => JavaSentryLevelDebug,
-                    BreadcrumbLevel.Info => JavaSentryLevelInfo,
-                    BreadcrumbLevel.Warning => JavaSentryLevelWarning,
-                    BreadcrumbLevel.Error => JavaSentryLevelError,
-                    _ => JavaSentryLevelInfo
-                };
+            {
+                BreadcrumbLevel.Critical => JavaSentryLevelFatal,
+                BreadcrumbLevel.Debug => JavaSentryLevelDebug,
+                BreadcrumbLevel.Info => JavaSentryLevelInfo,
+                BreadcrumbLevel.Warning => JavaSentryLevelWarning,
+                BreadcrumbLevel.Error => JavaSentryLevelError,
+                _ => JavaSentryLevelInfo
+            };
     }
 }

--- a/src/Sentry.Unity/Android/BreadcrumbExtensions.cs
+++ b/src/Sentry.Unity/Android/BreadcrumbExtensions.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace Sentry.Unity
+{
+    /// <summary>
+    /// Extension methods to Breadcrumb.
+    /// </summary>
+    public static class BreadcrumbExtensions
+    {
+        private static readonly AndroidJavaObject JavaSentryLevel = new AndroidJavaClass("io.sentry.SentryLevel");
+        private static AndroidJavaObject JavaSentryLevelFatal = JavaSentryLevel.GetStatic<AndroidJavaObject>("FATAL");
+        private static AndroidJavaObject JavaSentryLevelDebug = JavaSentryLevel.GetStatic<AndroidJavaObject>("DEBUG");
+        private static AndroidJavaObject JavaSentryLevelInfo = JavaSentryLevel.GetStatic<AndroidJavaObject>("INFO");
+        private static AndroidJavaObject JavaSentryLevelWarning = JavaSentryLevel.GetStatic<AndroidJavaObject>("WARNING");
+        private static AndroidJavaObject JavaSentryLevelError = JavaSentryLevel.GetStatic<AndroidJavaObject>("ERROR");
+
+        /// <summary>
+        /// To Java SentryLevel.
+        /// </summary>
+        /// <param name="level">The Breadcrumb level to convert to Java level.</param>
+        /// <returns>An Android Java object representing the SentryLevel.</returns>
+        public static AndroidJavaObject ToJavaSentryLevel(this BreadcrumbLevel level)
+            => level switch
+                {
+                    BreadcrumbLevel.Critical => JavaSentryLevelFatal,
+                    BreadcrumbLevel.Debug => JavaSentryLevelDebug,
+                    BreadcrumbLevel.Info => JavaSentryLevelInfo,
+                    BreadcrumbLevel.Warning => JavaSentryLevelWarning,
+                    BreadcrumbLevel.Error => JavaSentryLevelError,
+                    _ => JavaSentryLevelInfo
+                };
+    }
+}

--- a/src/Sentry.Unity/Android/BreadcrumbExtensions.cs
+++ b/src/Sentry.Unity/Android/BreadcrumbExtensions.cs
@@ -8,11 +8,11 @@ namespace Sentry.Unity
     public static class BreadcrumbExtensions
     {
         private static readonly AndroidJavaObject JavaSentryLevel = new AndroidJavaClass("io.sentry.SentryLevel");
-        private static AndroidJavaObject JavaSentryLevelFatal = JavaSentryLevel.GetStatic<AndroidJavaObject>("FATAL");
-        private static AndroidJavaObject JavaSentryLevelDebug = JavaSentryLevel.GetStatic<AndroidJavaObject>("DEBUG");
-        private static AndroidJavaObject JavaSentryLevelInfo = JavaSentryLevel.GetStatic<AndroidJavaObject>("INFO");
-        private static AndroidJavaObject JavaSentryLevelWarning = JavaSentryLevel.GetStatic<AndroidJavaObject>("WARNING");
-        private static AndroidJavaObject JavaSentryLevelError = JavaSentryLevel.GetStatic<AndroidJavaObject>("ERROR");
+        private static readonly AndroidJavaObject JavaSentryLevelFatal = JavaSentryLevel.GetStatic<AndroidJavaObject>("FATAL");
+        private static readonly AndroidJavaObject JavaSentryLevelDebug = JavaSentryLevel.GetStatic<AndroidJavaObject>("DEBUG");
+        private static readonly AndroidJavaObject JavaSentryLevelInfo = JavaSentryLevel.GetStatic<AndroidJavaObject>("INFO");
+        private static readonly AndroidJavaObject JavaSentryLevelWarning = JavaSentryLevel.GetStatic<AndroidJavaObject>("WARNING");
+        private static readonly AndroidJavaObject JavaSentryLevelError = JavaSentryLevel.GetStatic<AndroidJavaObject>("ERROR");
 
         /// <summary>
         /// To Java SentryLevel.

--- a/src/Sentry.Unity/Android/UnityJavaScopeObserver.cs
+++ b/src/Sentry.Unity/Android/UnityJavaScopeObserver.cs
@@ -22,6 +22,7 @@ namespace Sentry.Unity
             using var javaBreadcrumb = new AndroidJavaObject("io.sentry.Breadcrumb");
             javaBreadcrumb.Set("message", breadcrumb.Message);
             javaBreadcrumb.Set("type", breadcrumb.Type);
+            javaBreadcrumb.Set("level", breadcrumb.Level.ToJavaSentryLevel());
             javaBreadcrumb.Set("category", breadcrumb.Category);
             _sentry.CallStatic("addBreadcrumb", javaBreadcrumb, null);
         }


### PR DESCRIPTION
Technically these JNI classes should be disposed on each use. Docs says subsequent calls to the same method are faster, but doesn't specify if that's on the same instance.

Since these would be used for the lifetime of the app, I believe we can allocate them statically (perhaps Lazily instead, on the first use) and go without disposing them altogether. Would be nice to get some validation of these thoughts before we merge this

![image](https://user-images.githubusercontent.com/1633368/134600139-b92d5b78-f646-49be-bc02-819debfa1a28.png)

![image](https://user-images.githubusercontent.com/1633368/134600146-ec021e2a-240f-426e-9e0d-64752ff55a58.png)
