### PR TITLE
fix android jni threading

### DIFF
--- a/src/Sentry.Unity.Android/BreadcrumbExtensions.cs
+++ b/src/Sentry.Unity.Android/BreadcrumbExtensions.cs
@@ -7,27 +7,23 @@ namespace Sentry.Unity.Android
     /// </summary>
     public static class BreadcrumbExtensions
     {
-        private static readonly AndroidJavaObject JavaSentryLevel = new AndroidJavaClass("io.sentry.SentryLevel");
-        private static readonly AndroidJavaObject JavaSentryLevelFatal = JavaSentryLevel.GetStatic<AndroidJavaObject>("FATAL");
-        private static readonly AndroidJavaObject JavaSentryLevelDebug = JavaSentryLevel.GetStatic<AndroidJavaObject>("DEBUG");
-        private static readonly AndroidJavaObject JavaSentryLevelInfo = JavaSentryLevel.GetStatic<AndroidJavaObject>("INFO");
-        private static readonly AndroidJavaObject JavaSentryLevelWarning = JavaSentryLevel.GetStatic<AndroidJavaObject>("WARNING");
-        private static readonly AndroidJavaObject JavaSentryLevelError = JavaSentryLevel.GetStatic<AndroidJavaObject>("ERROR");
-
         /// <summary>
         /// To Java SentryLevel.
         /// </summary>
         /// <param name="level">The Breadcrumb level to convert to Java level.</param>
         /// <returns>An Android Java object representing the SentryLevel.</returns>
         public static AndroidJavaObject ToJavaSentryLevel(this BreadcrumbLevel level)
-            => level switch
+        {
+            using var javaSentryLevel = new AndroidJavaClass("io.sentry.SentryLevel");
+            return level switch
             {
-                BreadcrumbLevel.Critical => JavaSentryLevelFatal,
-                BreadcrumbLevel.Debug => JavaSentryLevelDebug,
-                BreadcrumbLevel.Info => JavaSentryLevelInfo,
-                BreadcrumbLevel.Warning => JavaSentryLevelWarning,
-                BreadcrumbLevel.Error => JavaSentryLevelError,
-                _ => JavaSentryLevelInfo
+                BreadcrumbLevel.Critical => javaSentryLevel.GetStatic<AndroidJavaObject>("FATAL"),
+                BreadcrumbLevel.Error => javaSentryLevel.GetStatic<AndroidJavaObject>("ERROR"),
+                BreadcrumbLevel.Warning => javaSentryLevel.GetStatic<AndroidJavaObject>("WARNING"),
+                BreadcrumbLevel.Debug => javaSentryLevel.GetStatic<AndroidJavaObject>("DEBUG"),
+                // BreadcrumbLevel.Info or unknown:
+                _ => javaSentryLevel.GetStatic<AndroidJavaObject>("INFO")
             };
+        }
     }
 }


### PR DESCRIPTION
Resolves #345

* Not storing the reference of any JNI object
* Calling `AndroidJNI.AttachCurrentThread();` before any call to Java layer

#skip-changelog

Not adding to the changelog since this feature wasn't released yet.