### PR TITLE
fix: added DSN nullcheck in editor window

### DIFF
--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -146,7 +146,7 @@ namespace Sentry.Unity.Editor
             Options.Dsn = EditorGUILayout.TextField(
                 new GUIContent("DSN", "The URL to your Sentry project. " +
                                       "Get yours on sentry.io -> Project Settings."),
-                Options.Dsn).Trim();
+                Options.Dsn)?.Trim();
 
             Options.CaptureInEditor = EditorGUILayout.Toggle(
                 new GUIContent("Capture In Editor", "Capture errors while running in the Editor."),


### PR DESCRIPTION
`string?` should be checked with `?` before `.Trim()` otherwise there'll be a `NullReferenceException: Object reference not set to an instance of an object`

#skip-changelog