### PR TITLE
fix: Craft - Exclude symbols for github target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,6 +9,7 @@ targets:
     releaseRepoOwner: getsentry
     releaseRepoName: unity
   - name: github
+    excludeNames: /^libsentry.*\.so$/
   - name: registry
     sdks:
       upm:sentry-unity:


### PR DESCRIPTION
#skip-changelog