### PR TITLE
chore: Removed audio listener after package cleanup

### DIFF
--- a/samples/unity-of-bugs/Assets/Scenes/1_BugfarmScene.unity
+++ b/samples/unity-of-bugs/Assets/Scenes/1_BugfarmScene.unity
@@ -1275,7 +1275,6 @@ GameObject:
   m_Component:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
-  - component: {fileID: 519420029}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1283,14 +1282,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &519420029
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The component "AudioListener" does no longer exist because we removed the audio package in our sample project.

#skip-changelog