### PR TITLE
enable  --warning-mode all in gradle

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -120,7 +120,7 @@ or
     <Error Condition="!Exists('$(SentryAndroidRoot)')" Text="Couldn't find the Android root at $(SentryAndroidRoot)."></Error>
     <Message Importance="High" Text="Building Sentry Android SDK."></Message>
 
-    <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="./gradlew :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --warning-mode all"></Exec>
+    <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="./gradlew :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --stacktrace --warning-mode all"></Exec>
 
     <ItemGroup>
       <!-- building snapshot based on version, i.e: sentry-5.0.0-beta.3-SNAPSHOT.jar -->


### PR DESCRIPTION
i think it make sense to enable gradle warning in the build

#skip-changelog