### PR TITLE
feat: Added flag to toggle log debouncing 

### DIFF
--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   <Enabled>k__BackingField: 1
   <Dsn>k__BackingField: https://94677106febe46b88b9b9ae5efd18a00@o447951.ingest.sentry.io/5439417
   <CaptureInEditor>k__BackingField: 1
+  <EnableLogDebouncing>k__BackingField: 0
   <TracesSampleRate>k__BackingField: 0
   <AutoSessionTracking>k__BackingField: 1
   <AutoSessionTrackingInterval>k__BackingField: 30000

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -151,6 +151,11 @@ namespace Sentry.Unity.Editor
                 new GUIContent("Capture In Editor", "Capture errors while running in the Editor."),
                 Options.CaptureInEditor);
 
+            Options.EnableLogDebouncing = EditorGUILayout.Toggle(
+                new GUIContent("Enable Log Debouncing", "The SDK debounces log messages of the same type if " +
+                                                    "they are more frequent than once per second."),
+                Options.EnableLogDebouncing);
+
             EditorGUILayout.Space();
             EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
             EditorGUILayout.Space();

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -26,6 +26,7 @@ namespace Sentry.Unity
 
         [field: SerializeField] internal string? Dsn { get; set; }
         [field: SerializeField] internal bool CaptureInEditor { get; set; }
+        [field: SerializeField] internal bool EnableLogDebouncing { get; set; }
         [field: SerializeField] internal double TracesSampleRate { get; set; }
         [field: SerializeField] internal bool AutoSessionTracking { get; set; }
         [field: SerializeField] internal int AutoSessionTrackingInterval { get; set; }
@@ -79,6 +80,7 @@ namespace Sentry.Unity
 
             options.Dsn = scriptableOptions.Dsn;
             options.CaptureInEditor = scriptableOptions.CaptureInEditor;
+            options.EnableLogDebouncing = scriptableOptions.EnableLogDebouncing;
             options.TracesSampleRate = scriptableOptions.TracesSampleRate;
             options.AutoSessionTracking = scriptableOptions.AutoSessionTracking;
             options.AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(scriptableOptions.AutoSessionTrackingInterval);

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -33,6 +33,11 @@ namespace Sentry.Unity
         public bool CaptureInEditor { get; set; } = true;
 
         /// <summary>
+        /// Whether Sentry events should be debounced it too frequent.
+        /// </summary>
+        public bool EnableLogDebouncing { get; set; } = false;
+
+        /// <summary>
         /// Whether the SDK should be in <see cref="Debug"/> mode only while in the Unity Editor.
         /// </summary>
         public bool DebugOnlyInEditor { get; set; }

--- a/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -21,6 +21,7 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains("Enabled", optionsAsString);
             StringAssert.Contains("Dsn", optionsAsString);
             StringAssert.Contains("CaptureInEditor", optionsAsString);
+            StringAssert.Contains("EnableLogDebouncing", optionsAsString);
             StringAssert.Contains("TracesSampleRate", optionsAsString);
             StringAssert.Contains("AutoSessionTracking", optionsAsString);
             StringAssert.Contains("AutoSessionTrackingInterval", optionsAsString);

--- a/test/Sentry.Unity.Tests/SentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityOptionsTests.cs
@@ -32,6 +32,7 @@ namespace Sentry.Unity.Tests
                 Enabled = false,
                 Dsn = "test",
                 CaptureInEditor = false,
+                EnableLogDebouncing = true,
                 TracesSampleRate = 1.0f,
                 AutoSessionTracking = false,
                 AutoSessionTrackingInterval = TimeSpan.FromSeconds(1),
@@ -56,6 +57,7 @@ namespace Sentry.Unity.Tests
             scriptableOptions.Enabled = expectedOptions.Enabled;
             scriptableOptions.Dsn = expectedOptions.Dsn;
             scriptableOptions.CaptureInEditor = expectedOptions.CaptureInEditor;
+            scriptableOptions.EnableLogDebouncing = expectedOptions.EnableLogDebouncing;
             scriptableOptions.TracesSampleRate = expectedOptions.TracesSampleRate;
             scriptableOptions.AutoSessionTracking = expectedOptions.AutoSessionTracking;
             scriptableOptions.AutoSessionTrackingInterval = (int)expectedOptions.AutoSessionTrackingInterval.TotalMilliseconds;
@@ -111,6 +113,7 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(expected.Enabled, actual.Enabled);
             Assert.AreEqual(expected.Dsn, actual.Dsn);
             Assert.AreEqual(expected.CaptureInEditor, actual.CaptureInEditor);
+            Assert.AreEqual(expected.EnableLogDebouncing, actual.EnableLogDebouncing);
             Assert.AreEqual(expected.TracesSampleRate, actual.TracesSampleRate);
             Assert.AreEqual(expected.AutoSessionTracking, actual.AutoSessionTracking);
             Assert.AreEqual(expected.AutoSessionTrackingInterval, actual.AutoSessionTrackingInterval);

--- a/test/Sentry.Unity.Tests/UnityApplicationLoggingIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/UnityApplicationLoggingIntegrationTests.cs
@@ -21,14 +21,14 @@ namespace Sentry.Unity.Tests
 
         private Fixture _fixture = null!;
         private TestHub _hub = null!;
-        private SentryOptions _sentryOptions = null!;
+        private SentryUnityOptions _sentryOptions = null!;
 
         [SetUp]
         public void SetUp()
         {
             _fixture = new Fixture();
             _hub = new TestHub();
-            _sentryOptions = new SentryOptions();
+            _sentryOptions = new SentryUnityOptions();
         }
 
         [Test]
@@ -36,17 +36,6 @@ namespace Sentry.Unity.Tests
         {
             var sut = _fixture.GetSut(_hub, _sentryOptions);
 
-            sut.OnLogMessageReceived("condition", "stacktrace", LogType.Error);
-
-            Assert.AreEqual(1, _hub.CapturedEvents.Count);
-        }
-
-        [Test]
-        public void OnLogMessageReceived_WithSeveralErrorsDebounced_CaptureEvent()
-        {
-            var sut = _fixture.GetSut(_hub, _sentryOptions);
-
-            sut.OnLogMessageReceived("condition", "stacktrace", LogType.Error);
             sut.OnLogMessageReceived("condition", "stacktrace", LogType.Error);
 
             Assert.AreEqual(1, _hub.CapturedEvents.Count);
@@ -61,6 +50,21 @@ namespace Sentry.Unity.Tests
             sut.OnLogMessageReceived("condition", "stacktrace", LogType.Error);
 
             Assert.AreEqual(2, _hub.ConfigureScopeCalls.Count);
+        }
+
+        [Test]
+        [TestCase(LogType.Log)]
+        [TestCase(LogType.Warning)]
+        [TestCase(LogType.Error)]
+        public void OnLogMessageReceived_LogDebounceEnabled_DebouncesMessage(LogType unityLogType)
+        {
+            _sentryOptions.EnableLogDebouncing = true;
+            var sut = _fixture.GetSut(_hub, _sentryOptions);
+
+            sut.OnLogMessageReceived("condition", "stacktrace", unityLogType);
+            sut.OnLogMessageReceived("condition", "stacktrace", unityLogType);
+
+            Assert.AreEqual(1, _hub.ConfigureScopeCalls.Count);
         }
 
         [TestCaseSource(nameof(LogTypesAndSentryLevels))]


### PR DESCRIPTION
Motivation:
The debounce purely by `logType` is not granular enough to be truly useful. So until we've got a better solution for debouncing in place we at least give the option to turn in on and off.
Does not really close but should help: https://github.com/getsentry/sentry-unity/issues/294