### PR TITLE
disable gradle daemon

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -130,7 +130,7 @@ or
     <Error Condition="!Exists('$(SentryAndroidRoot)')" Text="Couldn't find the Android root at $(SentryAndroidRoot)."></Error>
     <Message Importance="High" Text="Building Sentry Android SDK."></Message>
 
-    <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="./gradlew :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --stacktrace --warning-mode all"></Exec>
+    <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="./gradlew :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode all"></Exec>
 
     <ItemGroup>
       <!-- building snapshot based on version, i.e: sentry-5.0.0-beta.3-SNAPSHOT.jar -->


### PR DESCRIPTION
The Gradle daemon is designed to speed up subsequent builds. But on GitHub action it runs only once and the daemon is killed (all processes spawned during the build are killed). 

Trying to hunt down the reason why the builds are hanging even after all steps completed. Including the final:

![image](https://user-images.githubusercontent.com/1633368/139558614-512230c1-c705-479e-8ce6-68ff91ed23ca.png)


#skip-changelog