### PR TITLE
feat: Android automated symbol upload

### DIFF
--- a/src/Sentry.Unity.Editor/Android/AndroidBuildPostProcessor.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidBuildPostProcessor.cs
@@ -18,14 +18,33 @@ namespace Sentry.Unity.Editor.Android
         [MenuItem("Tools/SentryUploadSymbols")]
         public static void PostProcess() => UploadSymbols(pathToBuiltProject);
 
+        [MenuItem("Tools/Test")]
+        public static void Test()
+        {
+            Debug.Log(EditorUserBuildSettings.development);
+        }
+
         public static void UploadSymbols(string pathToBuiltProject)
         {
+            if (!EditorUserBuildSettings.androidCreateSymbolsZip)
+            {
+                Debug.Log("no symbols.zip created. skipping upload");
+                return;
+            }
+
             var sentryCliOptions = AssetDatabase.LoadAssetAtPath("Assets/Plugins/Sentry/SentryCliOptions.asset",
                 typeof(SentryCliOptions)) as SentryCliOptions;
             var sentryCliPath = GetSentryCliPath();
 
             if (sentryCliOptions is null || !sentryCliOptions.UploadSymbols || sentryCliPath is null)
             {
+                Debug.Log("sentry-cli options said no");
+                return;
+            }
+
+            if (EditorUserBuildSettings.development && !sentryCliOptions.UploadDevelopmentSymbols)
+            {
+                Debug.Log("not uploading development symbols");
                 return;
             }
 

--- a/src/Sentry.Unity.Editor/Android/AndroidBuildPostProcessor.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidBuildPostProcessor.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace Sentry.Unity.Editor.Android
+{
+    public static class AndroidBuildPostProcessor
+    {
+        private const string pathToBuiltProject = @"/Users/bitfox/_Workspace/Unity/samples/Builds/test.apk";
+
+        [PostProcessBuild(1)]
+        public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject) => UploadSymbols(pathToBuiltProject);
+
+        [MenuItem("Tools/SentryUploadSymbols")]
+        public static void PostProcess() => UploadSymbols(pathToBuiltProject);
+
+        public static void UploadSymbols(string pathToBuiltProject)
+        {
+            var sentryCliOptions = AssetDatabase.LoadAssetAtPath("Assets/Plugins/Sentry/SentryCliOptions.asset",
+                typeof(SentryCliOptions)) as SentryCliOptions;
+            var sentryCliPath = GetSentryCliPath();
+
+            if (sentryCliOptions is null || !sentryCliOptions.UploadSymbols || sentryCliPath is null)
+            {
+                return;
+            }
+
+            var builtProjectName = Path.GetFileNameWithoutExtension(pathToBuiltProject);
+            var filesInDirectory = Directory.GetFiles(Path.GetDirectoryName(pathToBuiltProject)).ToList();
+
+            var symbolsFile = filesInDirectory.Find(f => f.EndsWith("symbols.zip") && f.Contains($"{builtProjectName}-{Application.version}"));
+            if (symbolsFile is null)
+            {
+                Debug.LogWarning("failed to locate symbols file");
+                return;
+            }
+
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = sentryCliPath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                Arguments = $"--auth-token {sentryCliOptions.Auth} upload-dif --org {sentryCliOptions.Organization} --project {sentryCliOptions.Project} {symbolsFile}"
+            };
+
+            var process = Process.Start(processInfo);
+            var output = process.StandardOutput.ReadToEnd();
+            Debug.Log(output);
+
+            process.WaitForExit();
+        }
+
+        public static string? GetSentryCliPath()
+        {
+            // Todo: return path depending on platform
+
+            var sentryCliPath = Path.GetFullPath("Packages/io.sentry.unity.dev/Editor/sentry-cli/sentry-cli-Darwin-x86_64");
+            if (!File.Exists(sentryCliPath))
+            {
+                Debug.LogWarning("failed to find sentry-cli");
+                return null;
+            }
+
+            return sentryCliPath;
+        }
+    }
+}

--- a/src/Sentry.Unity.Editor/BuildPostProcessor.cs
+++ b/src/Sentry.Unity.Editor/BuildPostProcessor.cs
@@ -91,7 +91,7 @@ namespace Sentry.Unity.Editor.Android
             var sentryCli = string.Empty;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                sentryCli = "sentry-cli-Darwin-x86_64";
+                sentryCli = "sentry-cli-Darwin-universal";
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/Sentry.Unity.Editor/SentryCliOptions.cs
+++ b/src/Sentry.Unity.Editor/SentryCliOptions.cs
@@ -7,6 +7,7 @@ namespace Sentry.Unity.Editor
     public sealed class SentryCliOptions : ScriptableObject
     {
         [field: SerializeField] public bool UploadSymbols { get; set; } = true;
+        [field: SerializeField] public bool UploadDevelopmentSymbols { get; set; } = false;
         [field: SerializeField] public string? Auth { get; set; }
         [field: SerializeField] public string? Organization { get; set; }
         [field: SerializeField] public string? Project { get; set; }

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -35,6 +35,15 @@ namespace Sentry.Unity.Editor
 
             CheckForAndConvertJsonConfig();
             Options = LoadOptions();
+
+            var sentryCliOptions = AssetDatabase.LoadAssetAtPath("Assets/Plugins/Sentry/SentryCliOptions.asset",
+                typeof(SentryCliOptions)) as SentryCliOptions;
+            if (sentryCliOptions is null)
+            {
+                var sentrySecrets = CreateInstance<SentryCliOptions>();
+                AssetDatabase.CreateAsset(sentrySecrets, "Assets/Plugins/Sentry/SentryCliOptions.asset");
+                AssetDatabase.SaveAssets();
+            }
         }
 
         private ScriptableSentryUnityOptions LoadOptions()


### PR DESCRIPTION
The idea is to upload symbols if the automated symbol-upload is enabled.

- [ ] Make sentry-cli work with the unity package
  - [ ] Add sentry-cli to package-dev
  - [ ] Add restoring/loading specified version via script to msbuild (i.e. https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/plugin-build/download-sentry-cli.sh)
  - [ ] Make sure properties are set (chmod +x)
- [ ] Store sentry-cli options somewhere 
  - [ ] Create on sentry window open with options & link XML?
  - [ ] Split Sentry Scriptable Options into SDK and Editor related options?
  - [x] Contain Auth Token, Org-Slug, Proj-Name, Upload toggle
- [x] Hook into the BuildPostProcessor
  - [x] Check if `Create symbols.zip` is enabled
  - [x] Check if `Development Build` is disabled
  - [x] Check for `BuiltName-ApplicationVersion-v1.symbols.zip`
  - [x] Use platform specific version of sentry-cli for uploading