### PR TITLE
Add Android Devices Test on mac-latest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }} - Android ${{  matrix.api-level }}
+    name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -73,15 +73,6 @@ jobs:
           path: samples/artifacts/builds
           # using hash of package.json to bust cache on release builds which modify it
           key: ${{ matrix.os }}-${{ matrix.unity-version }}-${{ matrix.unity-version-changeset }}-${{ hashFiles('package/package.json') }}
-
-      - name: AVD cache
-        uses: actions/cache@v2
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
 
       - name: Restore Unity Packages
         uses: actions/cache@v2
@@ -196,66 +187,12 @@ jobs:
         env:
           UNITY_VERSION: ${{ matrix.unity-version }}
         run: dotnet msbuild /t:UnitySmokeTestStandalonePlayerIL2CPP
-
-      - name: Smoke Test Android - 21
-        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          UNITY_VERSION: ${{ matrix.unity-version }}
+      
+      - name: Preparing test app for smoke test.
+      - uses: actions/upload-artifact@v2
         with:
-          api-level: 21
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: pwsh ./scripts/smoke-test-droid.ps1
-
-      - name: Smoke Test Android - 23
-        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          UNITY_VERSION: ${{ matrix.unity-version }}
-        with:
-          api-level: 23
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: pwsh ./scripts/smoke-test-droid.ps1
-
-      - name: Smoke Test Android - 25
-        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          UNITY_VERSION: ${{ matrix.unity-version }}
-        with:
-          api-level: 25
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: pwsh ./scripts/smoke-test-droid.ps1
-
-      - name: Smoke Test Android - 29
-        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          UNITY_VERSION: ${{ matrix.unity-version }}
-        with:
-          api-level: 29
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: pwsh ./scripts/smoke-test-droid.ps1
-
-      - name: Smoke Test Android - 30
-        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          UNITY_VERSION: ${{ matrix.unity-version }}
-        with:
-          api-level: 30
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: pwsh ./scripts/smoke-test-droid.ps1
+          name: droid-testapp-${{ matrix.unity-version }}
+          path: samples/artifacts/builds/Android/IL2CPP_Player.apk
 
       - name: Prepare Sentry package for release
         shell: pwsh
@@ -294,3 +231,38 @@ jobs:
         with:
           name: Test results (editmode)
           path: artifacts/test/editmode
+
+  android-smoke-test:
+      needs: [build]
+      name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }} - Android ${{ matrix.api-level }} smoke tests 
+      runs-on: macos-latest
+      strategy:
+        matrix:
+           api-level: [15, 18, 21, 26, 29]
+           # 2021.1.26f1 is not being generated.
+           unity-version: [2019.4.31f1, 2020.3.21f1]
+      steps:
+         - uses: actions/checkout@v2
+         
+         - uses: actions/download-artifact@v2
+           with:
+              name: droid-testapp-${{ matrix.unity-version }}
+              path: samples/artifacts/builds/Android
+              
+         - name: AVD cache
+           uses: actions/cache@v2
+           id: avd-cache
+           with:
+             path: |
+               ~/.android/avd/*
+               ~/.android/adb*
+             key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
+                           
+         - uses: reactivecircus/android-emulator-runner@v2
+           with:
+             api-level: ${{ matrix.api-level }}
+             force-avd-creation: false
+             emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+             disable-animations: false
+             script: pwsh ./scripts/smoke-test-droid.ps1
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,6 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedCheck
           shell: pwsh
           run: ./scripts/smoke-test-droid.ps1      
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-         api-level: [15, 18, 21, 26, 29]
+         api-level: [21, 26, 29]
          # 2021.1.26f1 is not being generated.
          unity-version: [2019.4.31f1, 2020.3.21f1]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,14 +251,14 @@ jobs:
             name: droid-testapp-${{ matrix.unity-version }}
             path: samples/artifacts/builds/Android
 
-        - name: AVD cache
-          uses: actions/cache@v2
-          id: avd-cache
-          with:
-           path: |
-             ~/.android/avd/*
-             ~/.android/adb*
-           key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
+#        - name: AVD cache
+#          uses: actions/cache@v2
+#          id: avd-cache
+#          with:
+#           path: |
+#             ~/.android/avd/*
+#             ~/.android/adb*
+#           key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
 
         - name: Smoke test
           uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,30 +242,30 @@ jobs:
            # 2021.1.26f1 is not being generated.
            unity-version: [2019.4.31f1, 2020.3.21f1]
       steps:
-         - name: Checkout
-           uses: actions/checkout@v2
-         
-         - name: Download test app artifact
-           uses: actions/download-artifact@v2
-           with:
-              name: droid-testapp-${{ matrix.unity-version }}
-              path: samples/artifacts/builds/Android
-              
-         - name: AVD cache
-           uses: actions/cache@v2
-           id: avd-cache
-           with:
-             path: |
-               ~/.android/avd/*
-               ~/.android/adb*
-             key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
-                           
-         - name: Smoke test
-           uses: reactivecircus/android-emulator-runner@v2
-           with:
-             api-level: ${{ matrix.api-level }}
-             force-avd-creation: false
-             emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-             disable-animations: false
-             script: pwsh ./scripts/smoke-test-droid.ps1
-  
+        - name: Checkout
+          uses: actions/checkout@v2.3.3
+
+        - name: Download test app artifact
+          uses: actions/download-artifact@v2
+          with:
+            name: droid-testapp-${{ matrix.unity-version }}
+            path: samples/artifacts/builds/Android
+
+        - name: AVD cache
+          uses: actions/cache@v2
+          id: avd-cache
+          with:
+           path: |
+             ~/.android/avd/*
+             ~/.android/adb*
+           key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
+
+        - name: Smoke test
+          uses: reactivecircus/android-emulator-runner@v2
+          with:
+           api-level: ${{ matrix.api-level }}
+           force-avd-creation: false
+           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+           disable-animations: false
+           script: pwsh ./scripts/smoke-test-droid.ps1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,9 @@ jobs:
           Write-Output "${{ matrix.unity-root }}${{ matrix.unity-version }}/${{ matrix.unity-path }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           
       - name: Make symbolic link for Unity (Windows)
-         if: matrix.os == 'windows-latest'
-         shell: pwsh
-         run: New-Item -ItemType SymbolicLink -Path "C:\${{ matrix.unity-version }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity-version }}"
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: New-Item -ItemType SymbolicLink -Path "C:\${{ matrix.unity-version }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity-version }}"
 
 
       - name: Build Sentry.Unity Solution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
 
   android-smoke-test:
     needs: [build]
-    name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }} - Android ${{ matrix.api-level }} smoke tests 
+    name: Unity ${{ matrix.unity-version }} - macos-latest - Android ${{ matrix.api-level }} smoke tests 
     runs-on: macos-latest
     strategy:
       matrix:
@@ -261,7 +261,7 @@ jobs:
           key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
 
       - name: Smoke test
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
         with:
          api-level: ${{ matrix.api-level }}
          force-avd-creation: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,12 @@ jobs:
         shell: pwsh
         run: |
           Write-Output "${{ matrix.unity-root }}${{ matrix.unity-version }}/${{ matrix.unity-path }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          
+      - name: Make symbolic link for Unity (Windows)
+         if: ${{ matrix.os != 'windows-latest' }}
+         shell: pwsh
+         run: New-Item -ItemType SymbolicLink -Path "C:\${{ matrix.unity-version }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity-version }}"
+
 
       - name: Build Sentry.Unity Solution
         env:
@@ -167,7 +173,7 @@ jobs:
       - name: Build Android Player with IL2CPP
         # TODO: Remove condition once path too long issue resolved:
         # PathTooLongException: Path is too long. Path: C:\Program Files\Unity\Hub\Editor\2021.1.26f1\Editor\Data\PlaybackEngines\AndroidPlayer\SDK\tempToolsDir\lib\monitor-x86\p2\org.eclipse.equinox.p2.engine\profileRegistry\DefaultProfile.profile\.data\org.eclipse.equinox.internal.p2.touchpoint.eclipse.actions
-        if: ${{ matrix.os != 'windows-latest' || matrix.unity-version != '2021.1.26f1' }}
+#        if: ${{ matrix.os != 'windows-latest' || matrix.unity-version != '2021.1.26f1' }}
         env:
           UNITY_VERSION: ${{ matrix.unity-version }}
         run: dotnet msbuild /t:UnityBuildPlayerAndroidIL2CPP /p:Configuration=Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,9 +242,11 @@ jobs:
            # 2021.1.26f1 is not being generated.
            unity-version: [2019.4.31f1, 2020.3.21f1]
       steps:
-         - uses: actions/checkout@v2
+         - name: Checkout
+           uses: actions/checkout@v2
          
-         - uses: actions/download-artifact@v2
+         - name: Download test app artifact
+           uses: actions/download-artifact@v2
            with:
               name: droid-testapp-${{ matrix.unity-version }}
               path: samples/artifacts/builds/Android
@@ -258,7 +260,8 @@ jobs:
                ~/.android/adb*
              key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
                            
-         - uses: reactivecircus/android-emulator-runner@v2
+         - name: Smoke test
+           uses: reactivecircus/android-emulator-runner@v2
            with:
              api-level: ${{ matrix.api-level }}
              force-avd-creation: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,9 +234,10 @@ jobs:
 
   android-smoke-test:
     needs: [build]
-    name: Smoke Test -Android ${{ matrix.api-level }} Unity ${{ matrix.unity-version }} 
+    name: Smoke Test - Android ${{ matrix.api-level }} Unity ${{ matrix.unity-version }} 
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
          api-level: [21, 22, 23, 24, 25, 26, 27, 28, 29]
          #api-level 30 image is only available with google services.
@@ -274,6 +275,7 @@ jobs:
     name: Smoke Test - Android ${{ matrix.api-level }} Unity ${{ matrix.unity-version }} 
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
          api-level: [30]
          #api-level 30 image is only available with google services.
@@ -301,6 +303,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
         with:
          api-level: ${{ matrix.api-level }}
+         target: google_apis
          force-avd-creation: false
          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
          disable-animations: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         run: dotnet msbuild /t:UnitySmokeTestStandalonePlayerIL2CPP
       
       - name: Preparing test app for smoke test.
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: droid-testapp-${{ matrix.unity-version }}
           path: samples/artifacts/builds/Android/IL2CPP_Player.apk
@@ -255,10 +255,10 @@ jobs:
         uses: actions/cache@v2
         id: avd-cache
         with:
-            path: |
-         	 ~/.android/avd/*
-         	 ~/.android/adb*
-            key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
 
       - name: Smoke test
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,9 @@ jobs:
           UNITY_VERSION: ${{ matrix.unity-version }}
         with:
           name: Run Smoke Tests (Android)
-          api-level: 29
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          api-level: ${{ matrix.api-level }}
           disable-animations: true
+          script: ./gradlew connectedCheck --stacktrace
           shell: pwsh
           run: ./scripts/smoke-test-droid.ps1      
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,14 +233,14 @@ jobs:
           path: artifacts/test/editmode
 
   android-smoke-test:
-      needs: [build]
-      name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }} - Android ${{ matrix.api-level }} smoke tests 
-      runs-on: macos-latest
-      strategy:
-        matrix:
-           api-level: [15, 18, 21, 26, 29]
-           # 2021.1.26f1 is not being generated.
-           unity-version: [2019.4.31f1, 2020.3.21f1]
+    needs: [build]
+    name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }} - Android ${{ matrix.api-level }} smoke tests 
+    runs-on: macos-latest
+    strategy:
+      matrix:
+         api-level: [15, 18, 21, 26, 29]
+         # 2021.1.26f1 is not being generated.
+         unity-version: [2019.4.31f1, 2020.3.21f1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,31 +241,30 @@ jobs:
            api-level: [15, 18, 21, 26, 29]
            # 2021.1.26f1 is not being generated.
            unity-version: [2019.4.31f1, 2020.3.21f1]
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2.3.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+    
+      - name: Download test app artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: droid-testapp-${{ matrix.unity-version }}
+          path: samples/artifacts/builds/Android
 
-        - name: Download test app artifact
-          uses: actions/download-artifact@v2
-          with:
-            name: droid-testapp-${{ matrix.unity-version }}
-            path: samples/artifacts/builds/Android
+      - name: AVD cache
+        uses: actions/cache@v2
+        id: avd-cache
+           with:
+            path: |
+         	 ~/.android/avd/*
+         	 ~/.android/adb*
+            key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
 
-#        - name: AVD cache
-#          uses: actions/cache@v2
-#          id: avd-cache
-#          with:
-#           path: |
-#             ~/.android/avd/*
-#             ~/.android/adb*
-#           key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
-
-        - name: Smoke test
-          uses: reactivecircus/android-emulator-runner@v2
-          with:
-           api-level: ${{ matrix.api-level }}
-           force-avd-creation: false
-           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-           disable-animations: false
-           script: pwsh ./scripts/smoke-test-droid.ps1
-
+      - name: Smoke test
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+         api-level: ${{ matrix.api-level }}
+         force-avd-creation: false
+         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+         disable-animations: false
+         script: pwsh ./scripts/smoke-test-droid.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Build Android Player with IL2CPP
         # TODO: Remove condition once path too long issue resolved:
         # PathTooLongException: Path is too long. Path: C:\Program Files\Unity\Hub\Editor\2021.1.26f1\Editor\Data\PlaybackEngines\AndroidPlayer\SDK\tempToolsDir\lib\monitor-x86\p2\org.eclipse.equinox.p2.engine\profileRegistry\DefaultProfile.profile\.data\org.eclipse.equinox.internal.p2.touchpoint.eclipse.actions
-        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
+        if: ${{ matrix.os != 'windows-latest' || matrix.unity-version != '2021.1.26f1' }}
         env:
           UNITY_VERSION: ${{ matrix.unity-version }}
         run: dotnet msbuild /t:UnityBuildPlayerAndroidIL2CPP /p:Configuration=Release
@@ -234,13 +234,13 @@ jobs:
 
   android-smoke-test:
     needs: [build]
-    name: Unity ${{ matrix.unity-version }} - macos-latest - Android ${{ matrix.api-level }} smoke tests 
+    name: Smoke Test -Android ${{ matrix.api-level }} Unity ${{ matrix.unity-version }} 
     runs-on: macos-latest
     strategy:
       matrix:
-         api-level: [21, 26, 29]
-         # 2021.1.26f1 is not being generated.
-         unity-version: [2019.4.31f1, 2020.3.21f1]
+         api-level: [21, 22, 23, 24, 25, 26, 27, 28, 29]
+         #api-level 30 image is only available with google services.
+         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
@@ -259,6 +259,43 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}
+
+      - name: Smoke test
+        uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
+        with:
+         api-level: ${{ matrix.api-level }}
+         force-avd-creation: false
+         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+         disable-animations: false
+         script: pwsh ./scripts/smoke-test-droid.ps1
+
+  android-smoke-test-with-gservices:
+    needs: [build]
+    name: Smoke Test - Android ${{ matrix.api-level }} Unity ${{ matrix.unity-version }} 
+    runs-on: macos-latest
+    strategy:
+      matrix:
+         api-level: [30]
+         #api-level 30 image is only available with google services.
+         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+    
+      - name: Download test app artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: droid-testapp-${{ matrix.unity-version }}
+          path: samples/artifacts/builds/Android
+
+      - name: AVD cache
+        uses: actions/cache@v2
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}-${{ matrix.unity-version }}-gservices
 
       - name: Smoke test
         uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           Write-Output "${{ matrix.unity-root }}${{ matrix.unity-version }}/${{ matrix.unity-path }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           
       - name: Make symbolic link for Unity (Windows)
-         if: ${{ matrix.os != 'windows-latest' }}
+         if: matrix.os == 'windows-latest'
          shell: pwsh
          run: New-Item -ItemType SymbolicLink -Path "C:\${{ matrix.unity-version }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity-version }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        api-level: [21, 23, 29]
         # 2022.1.0a12 removed until S.T.J issues fixed
         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
         include:
@@ -198,13 +197,61 @@ jobs:
           UNITY_VERSION: ${{ matrix.unity-version }}
         run: dotnet msbuild /t:UnitySmokeTestStandalonePlayerIL2CPP
 
-      - name: Setup Android Emulators and Smoke test for Android
-        if: matrix.os == 'macos-latest'
+      - name: Smoke Test Android - 21
+        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
         uses: reactivecircus/android-emulator-runner@v2
         env:
           UNITY_VERSION: ${{ matrix.unity-version }}
         with:
-          api-level: ${{ matrix.api-level }}
+          api-level: 21
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: pwsh ./scripts/smoke-test-droid.ps1
+
+      - name: Smoke Test Android - 23
+        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          UNITY_VERSION: ${{ matrix.unity-version }}
+        with:
+          api-level: 23
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: pwsh ./scripts/smoke-test-droid.ps1
+
+      - name: Smoke Test Android - 25
+        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          UNITY_VERSION: ${{ matrix.unity-version }}
+        with:
+          api-level: 25
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: pwsh ./scripts/smoke-test-droid.ps1
+
+      - name: Smoke Test Android - 29
+        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          UNITY_VERSION: ${{ matrix.unity-version }}
+        with:
+          api-level: 29
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: pwsh ./scripts/smoke-test-droid.ps1
+
+      - name: Smoke Test Android - 30
+        if: ${{ matrix.os != 'windows-latest' && matrix.unity-version != '2021.1.26f1' }}
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          UNITY_VERSION: ${{ matrix.unity-version }}
+        with:
+          api-level: 30
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
+        api-level: [21]
         # 2022.1.0a12 removed until S.T.J issues fixed
         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
         include:
@@ -73,6 +74,15 @@ jobs:
           path: samples/artifacts/builds
           # using hash of package.json to bust cache on release builds which modify it
           key: ${{ matrix.os }}-${{ matrix.unity-version }}-${{ matrix.unity-version-changeset }}-${{ hashFiles('package/package.json') }}
+
+      - name: AVD cache
+        uses: actions/cache@v2
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
 
       - name: Restore Unity Packages
         uses: actions/cache@v2
@@ -187,6 +197,21 @@ jobs:
         env:
           UNITY_VERSION: ${{ matrix.unity-version }}
         run: dotnet msbuild /t:UnitySmokeTestStandalonePlayerIL2CPP
+
+      - name: Setup Android Emulators
+        if: matrix.os == 'macos-latest'
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          UNITY_VERSION: ${{ matrix.unity-version }}
+        with:
+          name: Run Smoke Tests (Android)
+          api-level: 29
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew connectedCheck
+          shell: pwsh
+          run: ./scripts/smoke-test-droid.ps1      
 
       - name: Prepare Sentry package for release
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }}
+    name: Unity ${{ matrix.unity-version }} - ${{ matrix.os }} - Android ${{  matrix.api-level }}
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        api-level: [21]
+        api-level: [21, 23, 29]
         # 2022.1.0a12 removed until S.T.J issues fixed
         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
         include:
@@ -198,18 +198,17 @@ jobs:
           UNITY_VERSION: ${{ matrix.unity-version }}
         run: dotnet msbuild /t:UnitySmokeTestStandalonePlayerIL2CPP
 
-      - name: Setup Android Emulators
+      - name: Setup Android Emulators and Smoke test for Android
         if: matrix.os == 'macos-latest'
         uses: reactivecircus/android-emulator-runner@v2
         env:
           UNITY_VERSION: ${{ matrix.unity-version }}
         with:
-          name: Run Smoke Tests (Android)
           api-level: ${{ matrix.api-level }}
-          disable-animations: true
-          script: ./gradlew connectedCheck --stacktrace
-          shell: pwsh
-          run: ./scripts/smoke-test-droid.ps1      
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: pwsh ./scripts/smoke-test-droid.ps1
 
       - name: Prepare Sentry package for release
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache
-           with:
+        with:
             path: |
          	 ~/.android/avd/*
          	 ~/.android/adb*

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,9 +27,11 @@
 
     <!-- Unity paths on Windows -->
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-      <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">\\?\C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
+      <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
-      <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">\\?\C:\Program Files\Unity\Editor</UnityRoot>
+      <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
+      <!--Short version for Github Actions to avoid long path names errors.-->
+      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,8 +31,7 @@
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
       <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">
-      C:\$(UnityVersion)\Editor
-      </UnityRoot>
+      C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,9 +27,9 @@
 
     <!-- Unity paths on Windows -->
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-      <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
+      <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">\\?\C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
-      <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
+      <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">\\?\C:\Program Files\Unity\Editor</UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,6 +27,7 @@
 
     <!-- Unity paths on Windows -->
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,10 +27,12 @@
 
     <!-- Unity paths on Windows -->
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
+      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">
+      C:\$(UnityVersion)\Editor
+      </UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,8 +30,6 @@
       <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
-      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">
-      C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>

--- a/samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset
+++ b/samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset
@@ -66,6 +66,12 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 0
   androidBlitType: 0
+  androidResizableWindow: 0
+  androidDefaultWindowWidth: 1920
+  androidDefaultWindowHeight: 1080
+  androidMinimumWindowWidth: 400
+  androidMinimumWindowHeight: 300
+  androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -249,7 +255,8 @@ PlayerSettings:
   clonedFromGUID: 5f34be1353de5cf4398729fda238591b
   templatePackageId: com.unity.template.2d@3.3.2
   templateDefaultScene: Assets/Scenes/SampleScene.unity
-  AndroidTargetArchitectures: 1
+  AndroidTargetArchitectures: 5
+  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
@@ -266,6 +273,7 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  chromeosInputEmulation: 1
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
@@ -539,6 +547,7 @@ PlayerSettings:
   switchTitleNames_12: 
   switchTitleNames_13: 
   switchTitleNames_14: 
+  switchTitleNames_15: 
   switchPublisherNames_0: 
   switchPublisherNames_1: 
   switchPublisherNames_2: 
@@ -554,6 +563,7 @@ PlayerSettings:
   switchPublisherNames_12: 
   switchPublisherNames_13: 
   switchPublisherNames_14: 
+  switchPublisherNames_15: 
   switchIcons_0: {fileID: 0}
   switchIcons_1: {fileID: 0}
   switchIcons_2: {fileID: 0}
@@ -569,6 +579,7 @@ PlayerSettings:
   switchIcons_12: {fileID: 0}
   switchIcons_13: {fileID: 0}
   switchIcons_14: {fileID: 0}
+  switchIcons_15: {fileID: 0}
   switchSmallIcons_0: {fileID: 0}
   switchSmallIcons_1: {fileID: 0}
   switchSmallIcons_2: {fileID: 0}
@@ -584,6 +595,7 @@ PlayerSettings:
   switchSmallIcons_12: {fileID: 0}
   switchSmallIcons_13: {fileID: 0}
   switchSmallIcons_14: {fileID: 0}
+  switchSmallIcons_15: {fileID: 0}
   switchManualHTML: 
   switchAccessibleURLs: 
   switchLegalInformation: 
@@ -646,6 +658,8 @@ PlayerSettings:
   switchSocketInitializeEnabled: 1
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
+  switchUseMicroSleepForYield: 1
+  switchMicroSleepForYieldTime: 25
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -716,10 +730,36 @@ PlayerSettings:
   ps4videoRecordingFeaturesUsed: 0
   ps4contentSearchFeaturesUsed: 0
   ps4CompatibilityPS5: 0
+  ps4AllowPS5Detection: 0
   ps4GPU800MHz: 1
   ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
   ps4attribVROutputEnabled: 0
+  ps5ParamFilePath: 
+  ps5VideoOutPixelFormat: 0
+  ps5VideoOutInitialWidth: 1920
+  ps5VideoOutOutputMode: 1
+  ps5BackgroundImagePath: 
+  ps5StartupImagePath: 
+  ps5Pic2Path: 
+  ps5StartupImagesFolder: 
+  ps5IconImagesFolder: 
+  ps5SaveDataImagePath: 
+  ps5SdkOverride: 
+  ps5BGMPath: 
+  ps5ShareOverlayImagePath: 
+  ps5NPConfigZipPath: 
+  ps5Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
+  ps5UseResolutionFallback: 0
+  ps5UseAudio3dBackend: 0
+  ps5ScriptOptimizationLevel: 2
+  ps5Audio3dVirtualSpeakerCount: 14
+  ps5UpdateReferencePackage: 
+  ps5disableAutoHideSplash: 0
+  ps5OperatingSystemCanDisableSplashScreen: 0
+  ps5IncludedModules: []
+  ps5SharedBinaryContentLabels: []
+  ps5SharedBinarySystemFolders: []
   monoEnv: 
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
@@ -748,6 +788,7 @@ PlayerSettings:
     Android: 1
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
+  suppressCommonWarnings: 1
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -1,0 +1,96 @@
+# GITHUB_WORKSPACE is the root folder where the project is stored.
+Set-Variable -Name "ApkPath" -Value ($Env:GITHUB_WORKSPACE + "/samples/artifacts/builds/Android")
+Set-Variable -Name "ApkFileName" -Value "IL2CPP_Player.apk"
+
+Set-Variable -Name "AdbPath" -Value ($Env:ANDROID_HOME + "/platform-tools")
+
+# Check if APK was built.
+if (Test-Path -Path "$ApkPath/$ApkFileName" ) 
+{
+    Write-Output "Found $ApkPath/$ApkFileName"
+}
+else
+{
+    Write-Error "Expected APK on $ApkPath/$ApkFileName but it was not found."
+    exit(-1);
+}
+
+
+# Filter device List
+$RawAdbDeviceList = ."$AdbPath/adb.exe" devices
+$deviceList = @()
+foreach ($device in $RawAdbDeviceList)
+{
+    if ($device.EndsWith("device"))
+    {
+        $deviceList += $device.Replace("device", '').Trim()
+    }
+}
+$deviceCount = $deviceList.Count
+
+if ($deviceCount -eq 0)
+{
+    Write-Error "It seems like no devices were found $RawAdbDeviceList"
+    exit(-1)
+}
+else
+{
+    Write-Output "Found $deviceCount devices, they are $deviceList"
+}
+
+# Test
+foreach ($device in $deviceList)
+{
+    Write-Output "Installing Apk on $device."
+
+    $stdout = ."$AdbPath/adb.exe" -s $device install -r $ApkPath/$ApkFileName
+    if($stdout -notcontains "Success")
+    {
+        Write-Error "Failed to Install APK: $stdout."
+        exit(-1)
+    }
+
+    Write-Output "Clearing logcat from $device."
+
+    ."$AdbPath/adb.exe" -s $device logcat -c
+
+    Write-Output "Starting Test..."
+
+    ."$AdbPath/adb.exe" -s $device shell am start -n io.sentry.samples.unityofbugs/com.unity3d.player.UnityPlayerActivity -e test smoke
+
+    Start-Sleep -Seconds 2
+
+    for ($i = 30; $i -gt 0; $i--) {
+        $smokeTestId = (& "$AdbPath/adb.exe" '-s', $device, 'shell', 'pidof', 'io.sentry.samples.unityofbugs'  2>&1)
+        if ( $smokeTestId -eq $null)
+        {
+            $i = -2;
+        }
+        else
+        {
+            Write-Output "Proccess $smokeTestId still running on $device, waiting $i seconds"
+            Start-Sleep -Seconds 1
+        }
+    }
+
+    if ( $i -eq -2)
+    {
+        Write-Error "Test Timeout"
+        exit(-1)
+    }
+
+    $stdout = ."$AdbPath/adb.exe"  -s $device logcat -d  | findstr SMOKE
+    if ( $stdout -ne $null)
+    {
+        Write-Output "$stdout"
+    }
+    else
+    {
+        Write-Error "Smoke Test Failed, printing logcat..."
+        ."$AdbPath/adb.exe" -s $device logcat -d  | findstr "Unity unity sentry Sentry SMOKE"
+        exit(-1)
+    }
+}
+
+Write-Output "Test completed."
+exit(0)

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -50,7 +50,9 @@ foreach ($device in $DeviceList)
     Write-Output "Checking device $device with SDK $deviceSdk and API $deviceApi"
     Write-Output ""
 
-    adb -s $device uninstall $ProcessName
+    Write-Output "Removing previous APP if found."
+    $stdout = adb -s $device uninstall $ProcessName
+    Write-Output "Installing test app..."
     $stdout = (adb -s $device install -r $ApkPath/$ApkFileName)
     If($stdout -notcontains "Success")
     {

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -5,7 +5,7 @@ Write-Output "#            VALIDATOR                          #"
 Write-Output "#                       SCRIPT                  #"
 Write-Output "#################################################"
 
-Set-Variable -Name "ApkPath" -Value "/samples/artifacts/builds/Android"
+Set-Variable -Name "ApkPath" -Value "samples/artifacts/builds/Android"
 Set-Variable -Name "ApkFileName" -Value "IL2CPP_Player.apk"
 Set-Variable -Name "ActivityName" -Value "io.sentry.samples.unityofbugs"
 Set-Variable -Name "TestActivityName" -Value "io.sentry.samples.unityofbugs/com.unity3d.player.UnityPlayerActivity"

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -2,8 +2,6 @@
 Set-Variable -Name "ApkPath" -Value ($Env:GITHUB_WORKSPACE + "/samples/artifacts/builds/Android")
 Set-Variable -Name "ApkFileName" -Value "IL2CPP_Player.apk"
 
-Set-Variable -Name "AdbPath" -Value ($Env:ANDROID_HOME + "/platform-tools")
-
 # Check if APK was built.
 if (Test-Path -Path "$ApkPath/$ApkFileName" ) 
 {
@@ -17,7 +15,7 @@ else
 
 
 # Filter device List
-$RawAdbDeviceList = ."$AdbPath/adb.exe" devices
+$RawAdbDeviceList = ".adb" devices
 $deviceList = @()
 foreach ($device in $RawAdbDeviceList)
 {
@@ -43,7 +41,7 @@ foreach ($device in $deviceList)
 {
     Write-Output "Installing Apk on $device."
 
-    $stdout = ."$AdbPath/adb.exe" -s $device install -r $ApkPath/$ApkFileName
+    $stdout = ".adb" -s $device install -r $ApkPath/$ApkFileName
     if($stdout -notcontains "Success")
     {
         Write-Error "Failed to Install APK: $stdout."
@@ -52,16 +50,16 @@ foreach ($device in $deviceList)
 
     Write-Output "Clearing logcat from $device."
 
-    ."$AdbPath/adb.exe" -s $device logcat -c
+    ".adb" -s $device logcat -c
 
     Write-Output "Starting Test..."
 
-    ."$AdbPath/adb.exe" -s $device shell am start -n io.sentry.samples.unityofbugs/com.unity3d.player.UnityPlayerActivity -e test smoke
+    ".adb" -s $device shell am start -n io.sentry.samples.unityofbugs/com.unity3d.player.UnityPlayerActivity -e test smoke
 
     Start-Sleep -Seconds 2
 
     for ($i = 30; $i -gt 0; $i--) {
-        $smokeTestId = (& "$AdbPath/adb.exe" '-s', $device, 'shell', 'pidof', 'io.sentry.samples.unityofbugs'  2>&1)
+        $smokeTestId = (& ".adb" '-s', $device, 'shell', 'pidof', 'io.sentry.samples.unityofbugs'  2>&1)
         if ( $smokeTestId -eq $null)
         {
             $i = -2;
@@ -79,7 +77,7 @@ foreach ($device in $deviceList)
         exit(-1)
     }
 
-    $stdout = ."$AdbPath/adb.exe"  -s $device logcat -d  | findstr SMOKE
+    $stdout = ".adb"  -s $device logcat -d  | findstr SMOKE
     if ( $stdout -ne $null)
     {
         Write-Output "$stdout"
@@ -87,7 +85,7 @@ foreach ($device in $deviceList)
     else
     {
         Write-Error "Smoke Test Failed, printing logcat..."
-        ."$AdbPath/adb.exe" -s $device logcat -d  | findstr "Unity unity sentry Sentry SMOKE"
+        ".adb" -s $device logcat -d  | findstr "Unity unity sentry Sentry SMOKE"
         exit(-1)
     }
 }

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -50,6 +50,7 @@ foreach ($device in $deviceList)
     Write-Output "Checking device $device with SDK $deviceSdk and API $deviceApi"
     Write-Output ""
 
+    adb -s $device uninstall $ActivityName
     $stdout = (adb -s $device install -r $ApkPath/$ApkFileName)
     if($stdout -notcontains "Success")
     {


### PR DESCRIPTION
Add smoke tests with Android emulators.
Tests will run only if the main tests are completed on all devices to allow better usage of job parallelism.

NOTE: In addition to the test, the IL2CPP apk required to support the X86 ABI in order to run the tests.
Additionally, the tests only ran on macOS due to Virtualization limitations on Github being exclusively supported on the macOS host.

#skip-changelog.