### PR TITLE
Fix long path error on Windows build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,11 @@ jobs:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: ios
 
-      - name: Create Unity license config
-        shell: pwsh
-        run: |
-          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
-          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+      - name: Create Unity license config 
+        shell: pwsh 
+        run: | 
+          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory 
+          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}' 
 
       # Need to write to $GITHUB_PATH to make the environment variable available to other steps.
       - name: Add Unity on PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,11 @@ jobs:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: ios
 
-      - name: Create Unity license config 
-        shell: pwsh 
-        run: | 
-          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory 
-          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}' 
+      - name: Create Unity license config
+        shell: pwsh
+        run: |
+          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
+          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
 
       # Need to write to $GITHUB_PATH to make the environment variable available to other steps.
       - name: Add Unity on PATH
@@ -143,10 +143,10 @@ jobs:
         run: |
           Write-Output "${{ matrix.unity-root }}${{ matrix.unity-version }}/${{ matrix.unity-path }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Make symbolic link for Unity (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: New-Item -ItemType SymbolicLink -Path "C:\${{ matrix.unity-version }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity-version }}"
+      - name: Make symbolic link for Unity (Windows) 
+        if: matrix.os == 'windows-latest' 
+        shell: pwsh 
+        run: New-Item -ItemType SymbolicLink -Path "C:\${{ matrix.unity-version }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity-version }}" 
 
       - name: Build Sentry.Unity Solution
         env:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,7 +30,7 @@
       <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
-      <!--Short version for Github Actions to avoid long path names errors-->
+      <!--Short version for GitHub Actions to avoid long path names errors on Windows-->
       <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,8 +30,8 @@
       <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
-      <!--Short version for Github Actions to avoid long path names errors-->
-      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot>
+      <!--Short version for Github Actions to avoid long path names errors--> 
+      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot> 
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>$(UnityRoot)\Unity.exe</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>


### PR DESCRIPTION
Fix reduces the path on windows so long path errors will no longer happen during Github Actions tests for now.

#skip-changelog

