### PR TITLE
fix: Disabling flaky debounce tests

### DIFF
--- a/test/Sentry.Unity.Tests/DebouncerTests.cs
+++ b/test/Sentry.Unity.Tests/DebouncerTests.cs
@@ -11,45 +11,48 @@ namespace Sentry.Unity.Tests
     /// </summary>
     public sealed class DebouncerTests
     {
-        private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
+        // Disabling because of flakiness
+        // https://github.com/getsentry/sentry-unity/issues/335
 
-        [UnityTest]
-        public IEnumerator LogTimeDebounce()
-        {
-            yield return AssertDefaultDebounce(new LogTimeDebounce(DefaultOffset));
-        }
-
-        [UnityTest]
-        public IEnumerator ErrorTimeDebounce()
-        {
-            yield return AssertDefaultDebounce(new ErrorTimeDebounce(DefaultOffset));
-        }
-
-        [UnityTest]
-        public IEnumerator WarningTimeDebounce()
-        {
-            yield return AssertDefaultDebounce(new WarningTimeDebounce(DefaultOffset));
-        }
-
-        private IEnumerator AssertDefaultDebounce(TimeDebounceBase debouncer)
-        {
-            // pass
-            Assert.IsTrue(debouncer.Debounced());
-
-            yield return new WaitForSeconds(0.050f);
-
-            // skip
-            Assert.IsFalse(debouncer.Debounced());
-
-            yield return new WaitForSeconds(0.02f);
-
-            // skip
-            Assert.IsFalse(debouncer.Debounced());
-
-            yield return new WaitForSeconds(0.04f);
-
-            // pass
-            Assert.IsTrue(debouncer.Debounced());
-        }
+        // private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
+        //
+        // [UnityTest]
+        // public IEnumerator LogTimeDebounce()
+        // {
+        //     yield return AssertDefaultDebounce(new LogTimeDebounce(DefaultOffset));
+        // }
+        //
+        // [UnityTest]
+        // public IEnumerator ErrorTimeDebounce()
+        // {
+        //     yield return AssertDefaultDebounce(new ErrorTimeDebounce(DefaultOffset));
+        // }
+        //
+        // [UnityTest]
+        // public IEnumerator WarningTimeDebounce()
+        // {
+        //     yield return AssertDefaultDebounce(new WarningTimeDebounce(DefaultOffset));
+        // }
+        //
+        // private IEnumerator AssertDefaultDebounce(TimeDebounceBase debouncer)
+        // {
+        //     // pass
+        //     Assert.IsTrue(debouncer.Debounced());
+        //
+        //     yield return new WaitForSeconds(0.050f);
+        //
+        //     // skip
+        //     Assert.IsFalse(debouncer.Debounced());
+        //
+        //     yield return new WaitForSeconds(0.02f);
+        //
+        //     // skip
+        //     Assert.IsFalse(debouncer.Debounced());
+        //
+        //     yield return new WaitForSeconds(0.04f);
+        //
+        //     // pass
+        //     Assert.IsTrue(debouncer.Debounced());
+        // }
     }
 }

--- a/test/Sentry.Unity.Tests/DebouncerTests.cs
+++ b/test/Sentry.Unity.Tests/DebouncerTests.cs
@@ -14,23 +14,24 @@ namespace Sentry.Unity.Tests
         private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
 
         [UnityTest]
-        [Ignore("Ignored due to flakiness")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
+
         public IEnumerator LogTimeDebounce()
         {
+            Assert.Inconclusive("Flaky"); // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
             yield return AssertDefaultDebounce(new LogTimeDebounce(DefaultOffset));
         }
 
         [UnityTest]
-        [Ignore("Ignored due to flakiness")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
         public IEnumerator ErrorTimeDebounce()
         {
+            Assert.Inconclusive("Flaky"); // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
             yield return AssertDefaultDebounce(new ErrorTimeDebounce(DefaultOffset));
         }
 
         [UnityTest]
-        [Ignore("Ignored due to flakiness")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
         public IEnumerator WarningTimeDebounce()
         {
+            Assert.Inconclusive("Flaky"); // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
             yield return AssertDefaultDebounce(new WarningTimeDebounce(DefaultOffset));
         }
 

--- a/test/Sentry.Unity.Tests/DebouncerTests.cs
+++ b/test/Sentry.Unity.Tests/DebouncerTests.cs
@@ -14,7 +14,6 @@ namespace Sentry.Unity.Tests
         private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
 
         [UnityTest]
-
         public IEnumerator LogTimeDebounce()
         {
             Assert.Inconclusive("Flaky"); // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335

--- a/test/Sentry.Unity.Tests/DebouncerTests.cs
+++ b/test/Sentry.Unity.Tests/DebouncerTests.cs
@@ -9,24 +9,26 @@ namespace Sentry.Unity.Tests
     /// <summary>
     /// Testing debouncer in realtime.
     /// </summary>
-    [Ignore("Flakey")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
     public sealed class DebouncerTests
     {
         private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
 
         [UnityTest]
+        [Ignore("Ignored due to flakiness")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
         public IEnumerator LogTimeDebounce()
         {
             yield return AssertDefaultDebounce(new LogTimeDebounce(DefaultOffset));
         }
 
         [UnityTest]
+        [Ignore("Ignored due to flakiness")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
         public IEnumerator ErrorTimeDebounce()
         {
             yield return AssertDefaultDebounce(new ErrorTimeDebounce(DefaultOffset));
         }
 
         [UnityTest]
+        [Ignore("Ignored due to flakiness")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
         public IEnumerator WarningTimeDebounce()
         {
             yield return AssertDefaultDebounce(new WarningTimeDebounce(DefaultOffset));

--- a/test/Sentry.Unity.Tests/DebouncerTests.cs
+++ b/test/Sentry.Unity.Tests/DebouncerTests.cs
@@ -9,50 +9,48 @@ namespace Sentry.Unity.Tests
     /// <summary>
     /// Testing debouncer in realtime.
     /// </summary>
+    [Ignore("Flakey")] // Ignoring because of flakiness: https://github.com/getsentry/sentry-unity/issues/335
     public sealed class DebouncerTests
     {
-        // Disabling because of flakiness
-        // https://github.com/getsentry/sentry-unity/issues/335
+        private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
 
-        // private readonly TimeSpan DefaultOffset = TimeSpan.FromMilliseconds(100);
-        //
-        // [UnityTest]
-        // public IEnumerator LogTimeDebounce()
-        // {
-        //     yield return AssertDefaultDebounce(new LogTimeDebounce(DefaultOffset));
-        // }
-        //
-        // [UnityTest]
-        // public IEnumerator ErrorTimeDebounce()
-        // {
-        //     yield return AssertDefaultDebounce(new ErrorTimeDebounce(DefaultOffset));
-        // }
-        //
-        // [UnityTest]
-        // public IEnumerator WarningTimeDebounce()
-        // {
-        //     yield return AssertDefaultDebounce(new WarningTimeDebounce(DefaultOffset));
-        // }
-        //
-        // private IEnumerator AssertDefaultDebounce(TimeDebounceBase debouncer)
-        // {
-        //     // pass
-        //     Assert.IsTrue(debouncer.Debounced());
-        //
-        //     yield return new WaitForSeconds(0.050f);
-        //
-        //     // skip
-        //     Assert.IsFalse(debouncer.Debounced());
-        //
-        //     yield return new WaitForSeconds(0.02f);
-        //
-        //     // skip
-        //     Assert.IsFalse(debouncer.Debounced());
-        //
-        //     yield return new WaitForSeconds(0.04f);
-        //
-        //     // pass
-        //     Assert.IsTrue(debouncer.Debounced());
-        // }
+        [UnityTest]
+        public IEnumerator LogTimeDebounce()
+        {
+            yield return AssertDefaultDebounce(new LogTimeDebounce(DefaultOffset));
+        }
+
+        [UnityTest]
+        public IEnumerator ErrorTimeDebounce()
+        {
+            yield return AssertDefaultDebounce(new ErrorTimeDebounce(DefaultOffset));
+        }
+
+        [UnityTest]
+        public IEnumerator WarningTimeDebounce()
+        {
+            yield return AssertDefaultDebounce(new WarningTimeDebounce(DefaultOffset));
+        }
+
+        private IEnumerator AssertDefaultDebounce(TimeDebounceBase debouncer)
+        {
+            // pass
+            Assert.IsTrue(debouncer.Debounced());
+
+            yield return new WaitForSeconds(0.050f);
+
+            // skip
+            Assert.IsFalse(debouncer.Debounced());
+
+            yield return new WaitForSeconds(0.02f);
+
+            // skip
+            Assert.IsFalse(debouncer.Debounced());
+
+            yield return new WaitForSeconds(0.04f);
+
+            // pass
+            Assert.IsTrue(debouncer.Debounced());
+        }
     }
 }


### PR DESCRIPTION
Tracked by: https://github.com/getsentry/sentry-unity/issues/335
They are just too unreliable. 
And debouncing is disabled by default.

#skip-changelog