### PR TITLE
fix: Smoke test include native SDK init

### DIFF
--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -63,21 +63,21 @@ public class SmokeTester : MonoBehaviour
             evt.Set();
         }
         
+        var options = new SentryUnityOptions();
+        options.Dsn = "https://key@sentry/project";
+        options.Debug = true;
+        // TODO: Must be set explicitly for the time being.
+        options.RequestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
+        options.DiagnosticLogger = new ConsoleDiagnosticLogger(SentryLevel.Debug);
+        options.CreateHttpClientHandler = () => new TestHandler(Verify);
+
 #if SENTRY_NATIVE_IOS
         SentryNativeIos.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
         SentryNativeAndroid.Configure(options);
 #endif
 
-        SentryUnity.Init(o =>
-        {
-            o.Dsn = "https://key@sentry/project";
-            o.Debug = true;
-            // TODO: Must be set explicitly for the time being.
-            o.RequestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
-            o.DiagnosticLogger = new ConsoleDiagnosticLogger(SentryLevel.Debug);
-            o.CreateHttpClientHandler = () => new TestHandler(Verify);
-        });
+        SentryUnity.Init(options);
 
         var guid = Guid.NewGuid().ToString();
         Debug.LogError(guid);

--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -11,6 +11,19 @@ using Sentry.Unity;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static System.Environment;
+#if !UNITY_EDITOR
+#if UNITY_IOS
+#define SENTRY_NATIVE_IOS
+#elif UNITY_ANDROID
+#define SENTRY_NATIVE_ANDROID
+#endif
+#endif
+
+#if SENTRY_NATIVE_IOS
+using Sentry.Unity.iOS;
+#elif UNITY_ANDROID
+using Sentry.Unity.Android;
+#endif
 
 public class SmokeTester : MonoBehaviour
 {
@@ -49,6 +62,12 @@ public class SmokeTester : MonoBehaviour
             requests.Add(message.Content.ReadAsStringAsync().Result);
             evt.Set();
         }
+        
+#if SENTRY_NATIVE_IOS
+        SentryNativeIos.Configure(options);
+#elif SENTRY_NATIVE_ANDROID
+        SentryNativeAndroid.Configure(options);
+#endif
 
         SentryUnity.Init(o =>
         {

--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Sentry;
-using Sentry.Infrastructure;
-using Sentry.Unity;
-using UnityEngine;
-using UnityEngine.SceneManagement;
-using static System.Environment;
-#if !UNITY_EDITOR
+﻿#if !UNITY_EDITOR
 #if UNITY_IOS
 #define SENTRY_NATIVE_IOS
 #elif UNITY_ANDROID
@@ -25,11 +12,23 @@ using Sentry.Unity.iOS;
 using Sentry.Unity.Android;
 #endif
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Sentry;
+using Sentry.Infrastructure;
+using Sentry.Unity;
+using UnityEngine;
+
 public class SmokeTester : MonoBehaviour
 {
     public void Start()
     {
-#if UNITY_ANDROID
+#if SENTRY_NATIVE_ANDROID
         using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
         using (var currentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
         using (var intent = currentActivity.Call<AndroidJavaObject>("getIntent"))
@@ -62,7 +61,7 @@ public class SmokeTester : MonoBehaviour
             requests.Add(message.Content.ReadAsStringAsync().Result);
             evt.Set();
         }
-        
+
         var options = new SentryUnityOptions();
         options.Dsn = "https://key@sentry/project";
         options.Debug = true;


### PR DESCRIPTION
We need to refactor things so that we can resume the init bits from smoke-test and SentryInitialization

@lucas-zimerman 

#skip-changelog