### PR TITLE
fix: Editor.iOS uses PackageInfo for package name

### DIFF
--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -8,9 +8,6 @@ namespace Sentry.Unity.Editor.iOS
 {
     public static class BuildPostProcess
     {
-        private static string PackageName = "io.sentry.unity";
-        private static string PackageNameDev = "io.sentry.unity.dev";
-
         [PostProcessBuild(1)]
         public static void OnPostProcessBuild(BuildTarget target, string pathToProject)
         {
@@ -60,7 +57,7 @@ namespace Sentry.Unity.Editor.iOS
                 return;
             }
 
-            var packageName = GetPackageName();
+            var packageName = SentryPackageInfo.GetName();
             var frameworkDirectory = PlayerSettings.iOS.sdkVersion == iOSSdkVersion.DeviceSDK ? "Device" : "Simulator";
 
             var frameworkPath = Path.Combine("Packages", packageName, "Plugins", "iOS", frameworkDirectory, "Sentry.framework");
@@ -75,23 +72,6 @@ namespace Sentry.Unity.Editor.iOS
             {
                 throw new FileNotFoundException($"Failed to copy 'Sentry.framework' from '{frameworkPath}' to Xcode project");
             }
-        }
-
-        private static string GetPackageName()
-        {
-            var packagePath = Path.Combine("Packages", PackageName);
-            if (Directory.Exists(Path.Combine(packagePath)))
-            {
-                return PackageName;
-            }
-
-            packagePath = Path.Combine("Packages", PackageNameDev);
-            if (Directory.Exists(Path.Combine(packagePath)))
-            {
-                return PackageNameDev;
-            }
-
-            throw new FileNotFoundException("Failed to locate the Sentry package");
         }
     }
 }

--- a/src/Sentry.Unity.Editor.iOS/Sentry.Unity.Editor.iOS.csproj
+++ b/src/Sentry.Unity.Editor.iOS/Sentry.Unity.Editor.iOS.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="../sentry-dotnet/src/Sentry/Sentry.csproj" Private="false" />
     <ProjectReference Include="../Sentry.Unity/Sentry.Unity.csproj" Private="false" />
-    <ProjectReference Include="..\Sentry.Unity.Editor\Sentry.Unity.Editor.csproj" />
+    <ProjectReference Include="../Sentry.Unity.Editor/Sentry.Unity.Editor.csproj" Private="false"/>
   </ItemGroup>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->

--- a/src/Sentry.Unity.Editor.iOS/Sentry.Unity.Editor.iOS.csproj
+++ b/src/Sentry.Unity.Editor.iOS/Sentry.Unity.Editor.iOS.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="../sentry-dotnet/src/Sentry/Sentry.csproj" Private="false" />
     <ProjectReference Include="../Sentry.Unity/Sentry.Unity.csproj" Private="false" />
+    <ProjectReference Include="..\Sentry.Unity.Editor\Sentry.Unity.Editor.csproj" />
   </ItemGroup>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->

--- a/src/Sentry.Unity.Editor/Properties/AssemblyInfo.cs
+++ b/src/Sentry.Unity.Editor/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Sentry.Unity.Editor.iOS")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Editor.Tests")]


### PR DESCRIPTION
During development, we append `.dev` to the package name. That has to be taken into account e.g. we copy Sentry.framework to the generated Xcode project and the package name is part of the path.

The Android symbols upload introduced a static PackageInfo so there is no need to keep this inside the Editor.iOS project.

#skip-changelog