### PR TITLE
Add Android screenshot if failed and test refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,17 @@ jobs:
         with:
          api-level: ${{ matrix.api-level }}
          force-avd-creation: false
+         ram-size: 2048M
          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
          disable-animations: false
          script: pwsh ./scripts/smoke-test-droid.ps1
+
+      - name: Upload screenshot if smoke test failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: droid-${{ matrix.api-level }}-testapp${{ matrix.unity-version }}-screenshot
+          path: samples/artifacts/builds/Android/screen.png
 
   android-smoke-test-with-gservices:
     needs: [build]
@@ -312,7 +320,15 @@ jobs:
         with:
          api-level: ${{ matrix.api-level }}
          target: google_apis
+         ram-size: 2048M
          force-avd-creation: false
          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
          disable-animations: false
          script: pwsh ./scripts/smoke-test-droid.ps1
+
+      - name: Upload screenshot if smoke test failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: droid-${{ matrix.api-level }}-testapp${{ matrix.unity-version }}-screenshot
+          path: samples/artifacts/builds/Android/screen.png

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -10,6 +10,24 @@ Set-Variable -Name "ApkFileName" -Value "IL2CPP_Player.apk"
 Set-Variable -Name "ProcessName" -Value "io.sentry.samples.unityofbugs"
 Set-Variable -Name "TestActivityName" -Value "io.sentry.samples.unityofbugs/com.unity3d.player.UnityPlayerActivity"
 
+function TakeScreenshot {
+    param ( $deviceId )
+    adb -s $deviceId shell "screencap -p /storage/emulated/0/screen.png"
+    adb pull "/storage/emulated/0/screen.png" "$ApkPath"
+    adb shell "rm /storage/emulated/0/screen.png" 
+
+}
+
+function WriteDeviceLog {
+    param ( $deviceId ) 
+    adb -s $device logcat -d 
+    # | select-string "Unity|unity|sentry|Sentry|SMOKE"
+}
+
+function DateTimeNow {
+    return Get-Date -UFormat "%T %Z"
+}
+
 # Filter device List
 $RawAdbDeviceList = adb devices
 $DeviceList = @()
@@ -72,7 +90,8 @@ foreach ($device in $DeviceList)
         adb -s $device shell am start -n $TestActivityName -e test smoke
         #despite calling start, the app might not be started yet.
 
-        $Timeout = 30
+        Write-Output (DateTimeNow)
+        $Timeout = 35
         While ($Timeout -gt 0) 
         {
             #Get a list of active processes
@@ -89,11 +108,14 @@ foreach ($device in $DeviceList)
             {
                 # Some devices might take a while to start the test, so we wait for the activity to start before checking if it was closed.
                 $AppStarted = 'True'
+
+                adb -s $device -s $device shell screencap -p /sdcard/screen.png
             }
             Write-Output "Waiting Process on $device to complete, waiting $Timeout seconds"
             Start-Sleep -Seconds 1
             $Timeout--
         }
+        Write-Output (DateTimeNow)
 
         $stdout = adb -s $device logcat -d  | select-string 'Unity   : Timeout while trying detaching'
         If ($stdout -eq $null)
@@ -111,9 +133,11 @@ foreach ($device in $DeviceList)
     If ($Timeout -eq 0)
     {
         Write-Warning "Test Timeout, see Logcat info for more information below."
-        adb -s $device logcat -d  | select-string "Unity|unity|sentry|Sentry|SMOKE"
+        WriteDeviceLog($device)
         Write-Output "PS info."
-        adb -s $device ps
+        adb -s $device shell ps
+
+        TakeScreenshot($device)
         Throw "Test Timeout"
     }
 
@@ -125,7 +149,8 @@ foreach ($device in $DeviceList)
     Else
     {
         Write-Warning "Process completed but Smoke test was not signaled."
-        adb -s $device logcat -d  | select-string "Unity|unity|sentry|Sentry|SMOKE"
+        WriteDeviceLog($device)
+        TakeScreenshot($device)
         Throw "Smoke Test Failed."
     }
 }

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -91,7 +91,7 @@ foreach ($device in $DeviceList)
         #despite calling start, the app might not be started yet.
 
         Write-Output (DateTimeNow)
-        $Timeout = 1
+        $Timeout = 45
         While ($Timeout -gt 0) 
         {
             #Get a list of active processes

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -91,7 +91,7 @@ foreach ($device in $DeviceList)
         #despite calling start, the app might not be started yet.
 
         Write-Output (DateTimeNow)
-        $Timeout = 35
+        $Timeout = 45
         While ($Timeout -gt 0) 
         {
             #Get a list of active processes
@@ -108,8 +108,6 @@ foreach ($device in $DeviceList)
             {
                 # Some devices might take a while to start the test, so we wait for the activity to start before checking if it was closed.
                 $AppStarted = 'True'
-
-                adb -s $device -s $device shell screencap -p /sdcard/screen.png
             }
             Write-Output "Waiting Process on $device to complete, waiting $Timeout seconds"
             Start-Sleep -Seconds 1

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -91,7 +91,7 @@ foreach ($device in $DeviceList)
         #despite calling start, the app might not be started yet.
 
         Write-Output (DateTimeNow)
-        $Timeout = 45
+        $Timeout = 1
         While ($Timeout -gt 0) 
         {
             #Get a list of active processes


### PR DESCRIPTION
* Upload screenshots if test failed.
* Increased timeout by 15 seconds.
* Fix PS log if test timed out
* Removed Sentry/Unity filter from logcat.
* Increased Android ram to 2GB
#skip-changelog.