### PR TITLE
fix: Xcode Sentry.framework import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Sentry no longer requires Xcode projects to be exported on macOS ([#442](https://github.com/getsentry/sentry-unity/pull/442))
+
 ## 0.7.0
 
 ### Features

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -60,7 +60,7 @@ namespace Sentry.Unity.Editor.iOS
             var packageName = SentryPackageInfo.GetName();
             var frameworkDirectory = PlayerSettings.iOS.sdkVersion == iOSSdkVersion.DeviceSDK ? "Device" : "Simulator";
 
-            var frameworkPath = Path.Combine("Packages", packageName, "Plugins", "iOS", frameworkDirectory, "Sentry.framework");
+            var frameworkPath = Path.GetFullPath(Path.Combine("Packages", packageName, "Plugins", "iOS", frameworkDirectory, "Sentry.framework"));
             if (Directory.Exists(frameworkPath))
             {
                 logger?.LogDebug("Copying Sentry.framework from '{0}' to '{1}'", frameworkPath, targetPath);

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -55,8 +55,8 @@ namespace Sentry.Unity.Editor.iOS
 
         public void AddSentryFramework()
         {
-            var frameworkPath = Path.Combine(_projectRoot, "Frameworks", FrameworkName);
-            var frameworkGuid = _project.AddFile(frameworkPath, frameworkPath);
+            var relativeFrameworkPath = Path.Combine("Frameworks", FrameworkName);
+            var frameworkGuid = _project.AddFile(Path.Combine(_projectRoot, relativeFrameworkPath), relativeFrameworkPath, PBXSourceTree.Sdk);
 
             var mainTargetGuid = _project.GetUnityMainTargetGuid();
             var unityFrameworkTargetGuid = _project.GetUnityFrameworkTargetGuid();

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -56,7 +56,7 @@ namespace Sentry.Unity.Editor.iOS
         public void AddSentryFramework()
         {
             var relativeFrameworkPath = Path.Combine("Frameworks", FrameworkName);
-            var frameworkGuid = _project.AddFile(Path.Combine(_projectRoot, relativeFrameworkPath), relativeFrameworkPath, PBXSourceTree.Sdk);
+            var frameworkGuid = _project.AddFile(relativeFrameworkPath, relativeFrameworkPath);
 
             var mainTargetGuid = _project.GetUnityMainTargetGuid();
             var unityFrameworkTargetGuid = _project.GetUnityFrameworkTargetGuid();


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-unity/issues/400 and can also be seen here: https://github.com/getsentry/sentry-unity/issues/432#issuecomment-982952428 by creating an additional import with `User/.../Unity/Builds/...`

- Copying files from the package under Windows requires the full path.
- The framework now gets added properly to the Xcode project. It relies on relative paths to work platform independently.