### PR TITLE
feat: iOS symbol upload with bitcode enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Automated symbols upload for iOS builds when bitcode is enabled ([#444](https://github.com/getsentry/sentry-unity/pull/444))
 - Automated symbols upload for iOS builds when bitcode is disabled ([#443](https://github.com/getsentry/sentry-unity/pull/443))
 
 ### Fixes

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -92,15 +92,27 @@ namespace Sentry.Unity.Editor.iOS
             _project.AddShellScriptBuildPhase(mainTargetGuid,
                 SymbolUploadPhaseName,
                 "/bin/sh",
-                $@"export SENTRY_PROPERTIES=sentry.properties
-if [ ""$ENABLE_BITCODE"" = ""NO"" ] ; then
-    echo ""Bitcode is disabled - Uploading symbols""
+                $@"process_upload_symbols()
+{{
     ERROR=$(./{SentryCli.SentryCliMacOS} upload-dif $BUILT_PRODUCTS_DIR > ./sentry-symbols-upload.log 2>&1 &)
     if [ ! $? -eq 0 ] ; then
         echo ""warning: sentry-cli - $ERROR""
     fi
+}}
+
+export SENTRY_PROPERTIES=sentry.properties
+if [ ""$ENABLE_BITCODE"" = ""NO"" ] ; then
+    echo ""Bitcode is disabled""
+    echo ""Uploading symbols""
+    process_upload_symbols
 else
-    echo ""Bitcode is enabled - Skipping symbols upload""
+    echo ""Bitcode is enabled""
+    if [ ""$ACTION"" = ""install"" ] ; then
+        echo ""Uploading symbols and bcsymbolmaps""
+        process_upload_symbols
+    else
+        echo ""Skipping symbol upload on bitcode enabled and non-install builds""
+    fi
 fi"
             );
         }


### PR DESCRIPTION
With `bitcode` enabled and at the end of building for an archive, we upload all `symbols` and `bcsymbolmaps` we find in the output directory.

TODO: Needs documentation that the users either have to set up App Store Connect Integration or down- and upload the dSYMs themselves.