### PR TITLE
fix: Symbol upload requires IL2CPP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Android: Automated symbol upload no longer breaks non IL2CPP builds ([#450](https://github.com/getsentry/sentry-unity/pull/450))
 - Sentry no longer requires Xcode projects to be exported on macOS ([#442](https://github.com/getsentry/sentry-unity/pull/442))
 
 ## 0.7.0

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -49,7 +49,10 @@ namespace Sentry.Unity.Editor.Android
         public void OnPostGenerateGradleAndroidProject(string basePath)
         {
             ModifyManifest(basePath);
-            SetupSymbolsUpload(basePath);
+
+            var unityProjectPath = Directory.GetParent(Application.dataPath).FullName;
+            var gradleProjectPath = Directory.GetParent(basePath).FullName;
+            SetupSymbolsUpload(unityProjectPath, gradleProjectPath);
         }
 
         internal void ModifyManifest(string basePath)
@@ -142,7 +145,7 @@ namespace Sentry.Unity.Editor.Android
             _ = androidManifest.Save();
         }
 
-        internal void SetupSymbolsUpload(string basePath)
+        internal void SetupSymbolsUpload(string unityProjectPath, string gradleProjectPath)
         {
             var options = _getOptions();
             var logger = options?.DiagnosticLogger ?? new UnityLogger(new SentryUnityOptions());
@@ -176,9 +179,6 @@ namespace Sentry.Unity.Editor.Android
 
             try
             {
-                var unityProjectPath = Directory.GetParent(Application.dataPath).FullName;
-                var gradleProjectPath = Directory.GetParent(basePath).FullName;
-
                 var symbolsPath = DebugSymbolUpload.GetSymbolsPath(
                     unityProjectPath,
                     gradleProjectPath,

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -157,7 +157,13 @@ namespace Sentry.Unity.Editor.Android
             }
 
             var sentryCliOptions = _getSentryCliOptions();
-            if (sentryCliOptions is null || !sentryCliOptions.UploadSymbols)
+            if (sentryCliOptions is null)
+            {
+                logger.LogWarning("Failed to load sentry-cli options - Skipping symbols upload.");
+                return;
+            }
+
+            if (!sentryCliOptions.UploadSymbols)
             {
                 logger.LogDebug("Automated symbols upload has been disabled.");
                 return;

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -272,6 +272,17 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
+        public void SetupSymbolsUpload_SentryCliOptionsNull_LogsWarningAndReturns()
+        {
+            _fixture.SentryCliOptions = null;
+            var sut = _fixture.GetSut();
+
+            sut.SetupSymbolsUpload("unity_project_path", "gradle_project_path");
+
+            AssertLogContains(SentryLevel.Warning, "Failed to load sentry-cli options - Skipping symbols upload.");
+        }
+
+        [Test]
         public void SetupSymbolsUpload_SymbolsUploadDisabled_LogsAndReturns()
         {
             _fixture.SentryCliOptions!.UploadSymbols = false;


### PR DESCRIPTION
With automatic symbols upload enabled and scripting backend not IL2CPP we currently break builds because we're looking for symbol files that don't exist.
That and we were missing a bunch of upload feature related tests.