### PR TITLE
fix: Config windows saves changes to sentry-cli options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Config window now saves changes to sentry-cli options ([#454](https://github.com/getsentry/sentry-unity/pull/454))
 - Sentry no longer requires Xcode projects to be exported on macOS ([#442](https://github.com/getsentry/sentry-unity/pull/442))
 
 ## 0.7.0

--- a/src/Sentry.Unity.Editor/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/SentryWindow.cs
@@ -393,6 +393,7 @@ namespace Sentry.Unity.Editor
             Validate();
 
             EditorUtility.SetDirty(Options);
+            EditorUtility.SetDirty(CliOptions);
             AssetDatabase.SaveAssets();
         }
 


### PR DESCRIPTION
Missed a dirty flag so changes to the sentry-cli options end up getting lost.