### PR TITLE
fix: Added a file exists check for sentry-cli exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Xcode exports no longer break with sentry-cli already added ([#457](https://github.com/getsentry/sentry-unity/pull/457))
+
 ## 0.8.0
 
 ### Features

--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   <AndroidNativeSupportEnabled>k__BackingField: 1
   <Debug>k__BackingField: 1
   <DebugOnlyInEditor>k__BackingField: 0
-  <DiagnosticLevel>k__BackingField: 0
+  <DiagnosticLevel>k__BackingField: 2

--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -35,4 +35,4 @@ MonoBehaviour:
   <AndroidNativeSupportEnabled>k__BackingField: 1
   <Debug>k__BackingField: 1
   <DebugOnlyInEditor>k__BackingField: 0
-  <DiagnosticLevel>k__BackingField: 2
+  <DiagnosticLevel>k__BackingField: 0

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -63,7 +63,7 @@ namespace Sentry.Unity.Editor.iOS
                 }
 
                 SentryCli.CreateSentryProperties(pathToProject, sentryCliOptions);
-                SentryCli.AddExecutableToXcodeProject(pathToProject);
+                SentryCli.AddExecutableToXcodeProject(pathToProject, logger);
 
                 sentryXcodeProject.AddBuildPhaseSymbolUpload(logger);
             }

--- a/src/Sentry.Unity.Editor/SentryCli.cs
+++ b/src/Sentry.Unity.Editor/SentryCli.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using UnityEngine;
 
@@ -74,7 +75,7 @@ namespace Sentry.Unity.Editor
             }
         }
 
-        internal static void AddExecutableToXcodeProject(string projectPath)
+        internal static void AddExecutableToXcodeProject(string projectPath, IDiagnosticLogger? logger)
         {
             var executableSource = GetSentryCliPath(SentryCliMacOS);
             var executableDestination = Path.Combine(projectPath, SentryCliMacOS);
@@ -82,6 +83,12 @@ namespace Sentry.Unity.Editor
             if (!Directory.Exists(projectPath))
             {
                 throw new DirectoryNotFoundException($"Xcode project directory not found at {executableDestination}");
+            }
+
+            if (File.Exists(executableDestination))
+            {
+                logger?.LogDebug("sentry-cli executable already found at {0}", executableDestination);
+                return;
             }
 
             File.Copy(executableSource, executableDestination);

--- a/test/Sentry.Unity.Editor.Tests/Sentry.Unity.Editor.Tests.csproj
+++ b/test/Sentry.Unity.Editor.Tests/Sentry.Unity.Editor.Tests.csproj
@@ -20,4 +20,11 @@
     <Folder Include="TestFiles\SymbolsUploadProject\GradleProject\unityLibrary\src\main" />
     <Folder Include="TestFiles\SymbolsUploadProject\UnityProject\Temp\StagingArea\symbols" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../SharedClasses/*.cs">
+      <Link>%(RecursiveDir)/%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+  
 </Project>

--- a/test/Sentry.Unity.Editor.Tests/SentryCliTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/SentryCliTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using NUnit.Framework;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
+using Sentry.Unity.Tests.SharedClasses;
 
 namespace Sentry.Unity.Editor.Tests
 {
@@ -84,7 +85,7 @@ namespace Sentry.Unity.Editor.Tests
         [Test]
         public void AddExecutableToXcodeProject_ProjectPathDoesNotExist_ThrowsDirectoryNotFoundException()
         {
-            Assert.Throws<DirectoryNotFoundException>(() => SentryCli.AddExecutableToXcodeProject("non-existent-path"));
+            Assert.Throws<DirectoryNotFoundException>(() => SentryCli.AddExecutableToXcodeProject("non-existent-path", new UnityLogger(new SentryUnityOptions())));
         }
 
         [Test]
@@ -93,9 +94,25 @@ namespace Sentry.Unity.Editor.Tests
             var fakeXcodeProjectDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(fakeXcodeProjectDirectory);
 
-            SentryCli.AddExecutableToXcodeProject(fakeXcodeProjectDirectory);
+            SentryCli.AddExecutableToXcodeProject(fakeXcodeProjectDirectory, new UnityLogger(new SentryUnityOptions()));
 
             Assert.IsTrue(File.Exists(Path.Combine(fakeXcodeProjectDirectory, SentryCli.SentryCliMacOS)));
+
+            Directory.Delete(fakeXcodeProjectDirectory, true);
+        }
+
+        [Test]
+        public void AddExecutableToXcodeProject_ExecutableAlreadyExists_LogsAndReturns()
+        {
+            var logger = new TestLogger();
+            var fakeXcodeProjectDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(fakeXcodeProjectDirectory);
+
+            SentryCli.AddExecutableToXcodeProject(fakeXcodeProjectDirectory, logger);
+            SentryCli.AddExecutableToXcodeProject(fakeXcodeProjectDirectory, logger);
+
+            Assert.IsTrue(File.Exists(Path.Combine(fakeXcodeProjectDirectory, SentryCli.SentryCliMacOS)));
+            Assert.AreEqual(1, logger.Logs.Count);
 
             Directory.Delete(fakeXcodeProjectDirectory, true);
         }


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-unity/issues/456

Now there is a check in place to prevent us from trying to override an already existing sentry-cli executable.