### PR TITLE
draft: Hook for package installation trigger

### DIFF
--- a/src/Sentry.Unity.Editor/SentryAssetPostProcessor.cs
+++ b/src/Sentry.Unity.Editor/SentryAssetPostProcessor.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor
+{
+    public class SentryAssetPostProcessor : AssetPostprocessor
+    {
+        private static ListRequest? _listRequest;
+
+        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets,
+            string[] movedAssets, string[] movedFromAssetPaths)
+        {
+            // TODO: maybe filter for Packages/io.sentry?
+            var isPackageImport = importedAssets.Any(path => path.StartsWith("Packages/"));
+
+            if (isPackageImport)
+            {
+                _listRequest = Client.List(true);
+                EditorApplication.update += UpdateListRequest;
+            }
+        }
+
+        [MenuItem("Tools/TempPackageImport")]
+        static void TempPackageImport()
+        {
+            _listRequest = Client.List(true);
+            EditorApplication.update += UpdateListRequest;
+        }
+
+        private static void UpdateListRequest()
+        {
+            if (_listRequest is null)
+            {
+                EditorApplication.update -= UpdateListRequest;
+                return;
+            }
+
+            if (!_listRequest.IsCompleted)
+            {
+                return;
+            }
+
+            if (_listRequest.Status == StatusCode.Success)
+            {
+                foreach (var package in _listRequest.Result)
+                {
+                    if (package.name == SentryPackageInfo.GetName())
+                    {
+                        Debug.Log("Found the Sentry package!");
+                        // TODO: here we create the link.xml and the options and whatever else
+                    }
+                }
+            }
+            else
+            {
+            }
+
+            EditorApplication.update -= UpdateListRequest;
+        }
+    }
+}

--- a/src/Sentry.Unity.Editor/SentryPackageInfo.cs
+++ b/src/Sentry.Unity.Editor/SentryPackageInfo.cs
@@ -2,12 +2,12 @@ using System.IO;
 
 namespace Sentry.Unity.Editor
 {
-    public static class SentryPackageInfo
+    internal static class SentryPackageInfo
     {
         internal static string PackageName = "io.sentry.unity";
         internal static string PackageNameDev = "io.sentry.unity.dev";
 
-        internal static string GetName()
+        public static string GetName()
         {
             var packagePath = Path.Combine("Packages", PackageName);
             if (Directory.Exists(Path.Combine(packagePath)))


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-unity/pull/213

Goal: Having a package installation trigger for creating link.xml or prompting an installation window. 

https://docs.unity3d.com/Manual/upm-api.html won't work for now because the events are not available in Unity 2019.4

#skip-changelog