### PR TITLE
chore: Bump CI and sample sample to 2019.4.33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             unity-path: Unity.app/Contents/MacOS
             unity-config-path: /Library/Application Support/Unity/config/
           - unity-version: 2019.4.33f1
-            unity-version-changeset: bd5abf232a62
+            unity-version-changeset: c9b2b02eeeef
           - unity-version: 2020.3.21f1
             unity-version-changeset: a38c86f6690f
           - unity-version: 2021.1.26f1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         # 2022.1.0a12 removed until S.T.J issues fixed
-        unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
+        unity-version: [2019.4.33f1, 2020.3.21f1, 2021.1.26f1]
         include:
           - os: windows-latest
             unity-installation-path: C:/Program Files/Unity/
@@ -36,7 +36,7 @@ jobs:
             unity-root: /Applications/Unity/Hub/Editor/
             unity-path: Unity.app/Contents/MacOS
             unity-config-path: /Library/Application Support/Unity/config/
-          - unity-version: 2019.4.31f1
+          - unity-version: 2019.4.33f1
             unity-version-changeset: bd5abf232a62
           - unity-version: 2020.3.21f1
             unity-version-changeset: a38c86f6690f
@@ -281,7 +281,7 @@ jobs:
       matrix:
          api-level: [21, 27, 29]
          avd-target: [default]
-         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
+         unity-version: [2019.4.33f1, 2020.3.21f1, 2021.1.26f1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
@@ -357,7 +357,7 @@ jobs:
          api-level: [30]
          avd-target: [google_apis]
          #api-level 30 image is only available with google services.
-         unity-version: [2019.4.31f1, 2020.3.21f1, 2021.1.26f1]
+         unity-version: [2019.4.33f1, 2020.3.21f1, 2021.1.26f1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3

--- a/samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt
+++ b/samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.31f1
-m_EditorVersionWithRevision: 2019.4.31f1 (bd5abf232a62)
+m_EditorVersion: 2019.4.33f1
+m_EditorVersionWithRevision: 2019.4.33f1 (c9b2b02eeeef)


### PR DESCRIPTION
#skip-changelog