### PR TITLE
fail ci if artifact is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         with:
           name: ${{ github.sha }}
+          if-no-files-found: error
           # Adding the native libraries so the symbol collector craft target can find/upload them
           path: |
             package-release.zip


### PR DESCRIPTION
By default it only warns

Example: A build that was successful, now fails with:

![image](https://user-images.githubusercontent.com/1633368/145738880-022b1d2a-34be-4772-adef-a68d17e32679.png)

#skip-changelog