### PR TITLE
explicitly set <SignAssembly>false</SignAssembly>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fixed overwriting Xcode build properties ([#466](https://github.com/getsentry/sentry-unity/pull/466))
 - Xcode exports no longer break with sentry-cli already added ([#457](https://github.com/getsentry/sentry-unity/pull/457))
-- Explicitly set <SignAssembly>false</SignAssembly> ([#470](https://github.com/getsentry/sentry-unity/pull/470)). So that Sentry.dll is not string named when consumed inside Unity.
+- Explicitly set <SignAssembly>false</SignAssembly> ([#470](https://github.com/getsentry/sentry-unity/pull/470)). So that Sentry.dll is not strong named when consumed inside Unity.
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed overwriting Xcode build properties ([#466](https://github.com/getsentry/sentry-unity/pull/466))
 - Xcode exports no longer break with sentry-cli already added ([#457](https://github.com/getsentry/sentry-unity/pull/457))
+- Explicitly set <SignAssembly>false</SignAssembly> ([#470](https://github.com/getsentry/sentry-unity/pull/470)). So that Sentry.dll is not string named when consumed inside Unity.
 
 ## 0.8.0
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <!-- Must be set here but will be overwritten below once the UnityVersion is ±resolved -->
     <!-- When using Unity 2022 the default will change to netstandard2.1 -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <Target Name="ResetTargetFrameworks" AfterTargets="FindUnity" BeforeTargets="BeforeResolveReferences">


### PR DESCRIPTION
to override sn on sentry.dll