### PR TITLE
fix: Added check for Sentry.framework copy success

### DIFF
--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -21,7 +21,10 @@ namespace Sentry.Unity.Editor.iOS
 
             try
             {
-                CopyFrameworkToBuildDirectory(pathToProject, options?.DiagnosticLogger);
+                var frameworkDirectory = PlayerSettings.iOS.sdkVersion == iOSSdkVersion.DeviceSDK ? "Device" : "Simulator";
+                var pathToFramework = Path.GetFullPath(Path.Combine("Packages", SentryPackageInfo.GetName(), "Plugins", "iOS", frameworkDirectory, "Sentry.framework"));
+
+                CopyFrameworkToBuildDirectory(pathToProject, pathToFramework, options?.DiagnosticLogger);
 
                 using var sentryXcodeProject = SentryXcodeProject.Open(pathToProject);
                 sentryXcodeProject.AddSentryFramework();
@@ -73,9 +76,9 @@ namespace Sentry.Unity.Editor.iOS
             }
         }
 
-        private static void CopyFrameworkToBuildDirectory(string pathToProject, IDiagnosticLogger? logger)
+        internal static void CopyFrameworkToBuildDirectory(string pathToXcodeProject, string pathToSentryFramework, IDiagnosticLogger? logger)
         {
-            var targetPath = Path.Combine(pathToProject, "Frameworks", "Sentry.framework");
+            var targetPath = Path.Combine(pathToXcodeProject, "Frameworks", "Sentry.framework");
             if (Directory.Exists(targetPath))
             {
                 // If the target path already exists we can bail. Unity doesn't allow an appending builds when switching
@@ -84,21 +87,17 @@ namespace Sentry.Unity.Editor.iOS
                 return;
             }
 
-            var packageName = SentryPackageInfo.GetName();
-            var frameworkDirectory = PlayerSettings.iOS.sdkVersion == iOSSdkVersion.DeviceSDK ? "Device" : "Simulator";
-
-            var frameworkPath = Path.GetFullPath(Path.Combine("Packages", packageName, "Plugins", "iOS", frameworkDirectory, "Sentry.framework"));
-            if (Directory.Exists(frameworkPath))
+            if (Directory.Exists(pathToSentryFramework))
             {
-                logger?.LogDebug("Copying Sentry.framework from '{0}' to '{1}'", frameworkPath, targetPath);
+                logger?.LogDebug("Copying 'Sentry.framework' from '{0}' to '{1}'", pathToSentryFramework, targetPath);
 
-                Directory.CreateDirectory(Path.Combine(pathToProject, "Frameworks"));
-                FileUtil.CopyFileOrDirectoryFollowSymlinks(frameworkPath, targetPath);
+                Directory.CreateDirectory(Path.Combine(pathToXcodeProject, "Frameworks"));
+                FileUtil.CopyFileOrDirectory(pathToSentryFramework, targetPath);
             }
 
             if (!Directory.Exists(targetPath))
             {
-                throw new FileNotFoundException($"Failed to copy 'Sentry.framework' from '{frameworkPath}' to Xcode project {targetPath}");
+                throw new FileNotFoundException($"Failed to copy 'Sentry.framework' from '{pathToSentryFramework}' to Xcode project {targetPath}");
             }
         }
     }

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -95,9 +95,10 @@ namespace Sentry.Unity.Editor.iOS
                 Directory.CreateDirectory(Path.Combine(pathToProject, "Frameworks"));
                 FileUtil.CopyFileOrDirectoryFollowSymlinks(frameworkPath, targetPath);
             }
-            else
+
+            if (!Directory.Exists(targetPath))
             {
-                throw new FileNotFoundException($"Failed to copy 'Sentry.framework' from '{frameworkPath}' to Xcode project");
+                throw new FileNotFoundException($"Failed to copy 'Sentry.framework' from '{frameworkPath}' to Xcode project {targetPath}");
             }
         }
     }

--- a/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Sentry.Unity.Tests.SharedClasses;
+
+namespace Sentry.Unity.Editor.iOS.Tests
+{
+    public class BuildPostProcessorTests
+    {
+        public class Fixture
+        {
+            public string TestDirectoryPath { get; set;}
+            public string SentryFrameworkPath { get; set; }
+            public string XcodeProjectPath { get; set; }
+
+            public Fixture()
+            {
+                TestDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 4));
+                SentryFrameworkPath = Path.Combine(TestDirectoryPath, "Sentry.framework");
+                XcodeProjectPath = Path.Combine(TestDirectoryPath, "XcodeProject");
+            }
+        }
+
+        private Fixture _fixture = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = new Fixture();
+
+            Directory.CreateDirectory(_fixture.TestDirectoryPath);
+            Directory.CreateDirectory(_fixture.SentryFrameworkPath);
+            Directory.CreateDirectory(_fixture.XcodeProjectPath);
+        }
+
+        [TearDown]
+        public void TearDown() => Directory.Delete(_fixture.TestDirectoryPath, true);
+
+        [Test]
+        public void CopyFrameworkToBuildDirectory_CopiesFramework()
+        {
+            BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, new TestLogger());
+
+            Assert.IsTrue(Directory.Exists(Path.Combine(_fixture.XcodeProjectPath, "Frameworks", "Sentry.framework")));
+        }
+
+        [Test]
+        public void CopyFrameworkToBuildDirectory_FrameworkAlreadyCopied_LogsSkipMessage()
+        {
+            var testLogger = new TestLogger();
+
+            BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, testLogger);
+            BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, testLogger);
+
+            Assert.IsTrue(testLogger.Logs.Any(log =>
+                log.logLevel == SentryLevel.Debug &&
+                log.message.Contains("'Sentry.framework' has already copied")));
+        }
+
+        [Test]
+        public void CopyFrameworkToBuildDirectory_FailedToCopyFramework_ThrowsFileNotFoundException()
+        {
+            _fixture.SentryFrameworkPath = "non-existent-path";
+
+            Assert.Throws<IOException>(() =>
+                BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, new TestLogger()));
+        }
+    }
+}

--- a/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
@@ -63,7 +63,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
         {
             _fixture.SentryFrameworkPath = "non-existent-path";
 
-            Assert.Throws<IOException>(() =>
+            Assert.Throws<FileNotFoundException>(() =>
                 BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, new TestLogger()));
         }
     }

--- a/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
@@ -8,41 +8,31 @@ namespace Sentry.Unity.Editor.iOS.Tests
 {
     public class BuildPostProcessorTests
     {
-        public class Fixture
-        {
-            public string TestDirectoryPath { get; set;}
-            public string SentryFrameworkPath { get; set; }
-            public string XcodeProjectPath { get; set; }
-
-            public Fixture()
-            {
-                TestDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 4));
-                SentryFrameworkPath = Path.Combine(TestDirectoryPath, "Sentry.framework");
-                XcodeProjectPath = Path.Combine(TestDirectoryPath, "XcodeProject");
-            }
-        }
-
-        private Fixture _fixture = null!;
+        private string _testDirectoryPath = null!;
+        private string _sentryFrameworkPath = null!;
+        private string _xcodeProjectPath = null!;
 
         [SetUp]
         public void Setup()
         {
-            _fixture = new Fixture();
+            _testDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 4));
+            _sentryFrameworkPath = Path.Combine(_testDirectoryPath, "Sentry.framework");
+            _xcodeProjectPath = Path.Combine(_testDirectoryPath, "XcodeProject");
 
-            Directory.CreateDirectory(_fixture.TestDirectoryPath);
-            Directory.CreateDirectory(_fixture.SentryFrameworkPath);
-            Directory.CreateDirectory(_fixture.XcodeProjectPath);
+            Directory.CreateDirectory(_testDirectoryPath);
+            Directory.CreateDirectory(_sentryFrameworkPath);
+            Directory.CreateDirectory(_xcodeProjectPath);
         }
 
         [TearDown]
-        public void TearDown() => Directory.Delete(_fixture.TestDirectoryPath, true);
+        public void TearDown() => Directory.Delete(_testDirectoryPath, true);
 
         [Test]
         public void CopyFrameworkToBuildDirectory_CopiesFramework()
         {
-            BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, new TestLogger());
+            BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, _sentryFrameworkPath, new TestLogger());
 
-            Assert.IsTrue(Directory.Exists(Path.Combine(_fixture.XcodeProjectPath, "Frameworks", "Sentry.framework")));
+            Assert.IsTrue(Directory.Exists(Path.Combine(_xcodeProjectPath, "Frameworks", "Sentry.framework")));
         }
 
         [Test]
@@ -50,8 +40,8 @@ namespace Sentry.Unity.Editor.iOS.Tests
         {
             var testLogger = new TestLogger();
 
-            BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, testLogger);
-            BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, testLogger);
+            BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, _sentryFrameworkPath, testLogger);
+            BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, _sentryFrameworkPath, testLogger);
 
             Assert.IsTrue(testLogger.Logs.Any(log =>
                 log.logLevel == SentryLevel.Debug &&
@@ -59,12 +49,8 @@ namespace Sentry.Unity.Editor.iOS.Tests
         }
 
         [Test]
-        public void CopyFrameworkToBuildDirectory_FailedToCopyFramework_ThrowsFileNotFoundException()
-        {
-            _fixture.SentryFrameworkPath = "non-existent-path";
-
+        public void CopyFrameworkToBuildDirectory_FailedToCopyFramework_ThrowsFileNotFoundException() =>
             Assert.Throws<FileNotFoundException>(() =>
-                BuildPostProcess.CopyFrameworkToBuildDirectory(_fixture.XcodeProjectPath, _fixture.SentryFrameworkPath, new TestLogger()));
-        }
+                BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, "non-existent-path", new TestLogger()));
     }
 }


### PR DESCRIPTION
Issues (e.g. https://github.com/getsentry/sentry-unity/issues/465) about successful Unity builds but missing Sentry.framework keep coming up.
If we failed to copy the framework to the target we throw and log the paths so at least we know what's going on.

#skip-changelog