### PR TITLE
Remove OSX limitation

### DIFF
--- a/package-dev/Editor/iOS/Sentry.Unity.Editor.iOS.dll.meta
+++ b/package-dev/Editor/iOS/Sentry.Unity.Editor.iOS.dll.meta
@@ -41,7 +41,6 @@ PluginImporter:
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
-        OS: OSX
   - first:
       Standalone: Linux64
     second:


### PR DESCRIPTION
The fix allows other Operational Systems than OSX to execute the actions from Sentry.Unity.Editor.iOS

![image](https://user-images.githubusercontent.com/8229322/148446269-97f4c306-84c7-4ccd-b3bf-5ebbf1da1d0c.png)

Before that, only on OSX the header files would be properly set on Xcode.