### PR TITLE
fix: Escaping sentry-cli path on Windows for gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix missing Sentry/Sentry.h ([#504](https://github.com/getsentry/sentry-unity/pull/504))
+- Automated Android symbols upload now correctly escapes sentry-cli executable path ([#507](https://github.com/getsentry/sentry-unity/pull/507))
 
 ## 0.9.1
 

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using Sentry.Unity.Integrations;
+using UnityEngine;
 
 namespace Sentry.Unity.Editor.Android
 {
@@ -21,8 +23,14 @@ namespace Sentry.Unity.Editor.Android
             return symbolsPath;
         }
 
-        public static void AppendUploadToGradleFile(string sentryCliPath, string gradleProjectPath, string symbolsDirectoryPath)
+        public static void AppendUploadToGradleFile(string sentryCliPath, string gradleProjectPath, string symbolsDirectoryPath, IApplication? application = null)
         {
+            application ??= ApplicationAdapter.Instance;
+            if (application.Platform == RuntimePlatform.WindowsEditor)
+            {
+                sentryCliPath = sentryCliPath.Replace(@"\", @"\\"); // On Windows the path contains backslashes that need to be escaped
+            }
+
             if (!File.Exists(sentryCliPath))
             {
                 throw new FileNotFoundException("Failed to find sentry-cli", sentryCliPath);

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using Sentry.Unity.Editor.Android;
+using UnityEngine;
 
 namespace Sentry.Unity.Editor.Tests.Android
 {
@@ -102,6 +103,24 @@ namespace Sentry.Unity.Editor.Tests.Android
 
             StringAssert.Contains(_fixture.SentryCliPath, actualFileContent);
             StringAssert.Contains(symbolsDirectoryPath, actualFileContent);
+        }
+
+        [Test]
+        public void AppendUploadToGradleFile_SentryCliPathContainsBackslashes_AddsToGradleFileWithEscapedBackslashes()
+        {
+            if (Application.platform != RuntimePlatform.WindowsEditor)
+            {
+                Assert.Inconclusive("Skipping: Not on Windows Editor");
+            }
+
+            var pathWithBackslashes = _fixture.SentryCliPath.Replace("/", @"\");
+            _fixture.SentryCliPath = pathWithBackslashes;
+            var expectedEscapedPath = pathWithBackslashes.Replace(@"\", @"\\");
+
+            DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, "symbols/path");
+            var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
+
+            StringAssert.Contains(expectedEscapedPath, actualFileContent);
         }
 
         public static void SetupFakeProject(string fakeProjectPath)

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -92,6 +92,23 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
+        public void AppendUploadToGradleFile_SentryCliExecutableExists_AddsPathToGradleFile()
+        {
+            var expectedSentryCliPath = _fixture.SentryCliPath;
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                expectedSentryCliPath = expectedSentryCliPath.Replace(@"\", @"\\");
+            }
+
+            var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, false);
+
+            DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
+            var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
+
+            StringAssert.Contains(expectedSentryCliPath, actualFileContent);
+        }
+
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public void AppendUploadToGradleFile_AllRequirementsMet_AppendsSentryCliToFile(bool export)
@@ -101,26 +118,7 @@ namespace Sentry.Unity.Editor.Tests.Android
             DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
             var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
 
-            StringAssert.Contains(_fixture.SentryCliPath, actualFileContent);
             StringAssert.Contains(symbolsDirectoryPath, actualFileContent);
-        }
-
-        [Test]
-        public void AppendUploadToGradleFile_SentryCliPathContainsBackslashes_AddsToGradleFileWithEscapedBackslashes()
-        {
-            if (Application.platform != RuntimePlatform.WindowsEditor)
-            {
-                Assert.Inconclusive("Skipping: Not on Windows Editor");
-            }
-
-            var pathWithBackslashes = _fixture.SentryCliPath.Replace("/", @"\");
-            _fixture.SentryCliPath = pathWithBackslashes;
-            var expectedEscapedPath = pathWithBackslashes.Replace(@"\", @"\\");
-
-            DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, "symbols/path");
-            var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
-
-            StringAssert.Contains(expectedEscapedPath, actualFileContent);
         }
 
         public static void SetupFakeProject(string fakeProjectPath)


### PR DESCRIPTION
Gradle requires paths containing backslashes to be escaped.