### PR TITLE
Gradle: Replacing backslashes with slashes on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,17 +110,11 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('submodules-status') }}-${{ matrix.unity-version }}-${{ matrix.unity-version-changeset }}-${{ hashFiles('package/package.json') }}
 
       - name: Setup Unity
-        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
+        uses: bitsandfoxes/setup-unity
         id: setup-unity
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-version-changeset:  ${{ matrix.unity-version-changeset }}
-
-      - name: Print setup output
-        run: |
-          echo unity-version: ${{ steps.setup-unity.outputs.unity-version }}
-          echo unity-path: ${{ steps.setup-unity.outputs.unity-path }}
-          echo env UNITY_PATH: ${{ env.UNITY_PATH }}
 
       - name: Setup Unity Modules - Windows IL2CPP
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,26 +118,26 @@ jobs:
 
       - name: Setup Unity Modules - Windows IL2CPP
         if: matrix.os == 'windows-latest'
-        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
+        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: windows-il2cpp
 
       - name: Setup Unity Modules - macOS IL2CPP
         if: matrix.os == 'macos-latest'
-        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
+        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: mac-il2cpp
 
       - name: Setup Unity Modules - Android
-        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
+        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: android
 
       - name: Setup Unity Modules - iOS
-        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
+        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('submodules-status') }}-${{ matrix.unity-version }}-${{ matrix.unity-version-changeset }}-${{ hashFiles('package/package.json') }}
 
       - name: Setup Unity
-        uses: bitsandfoxes/setup-unity
+        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
         id: setup-unity
         with:
           unity-version: ${{ matrix.unity-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('submodules-status') }}-${{ matrix.unity-version }}-${{ matrix.unity-version-changeset }}-${{ hashFiles('package/package.json') }}
 
       - name: Setup Unity
-        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
+        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
         id: setup-unity
         with:
           unity-version: ${{ matrix.unity-version }}
@@ -118,26 +118,26 @@ jobs:
 
       - name: Setup Unity Modules - Windows IL2CPP
         if: matrix.os == 'windows-latest'
-        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
+        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: windows-il2cpp
 
       - name: Setup Unity Modules - macOS IL2CPP
         if: matrix.os == 'macos-latest'
-        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
+        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: mac-il2cpp
 
       - name: Setup Unity Modules - Android
-        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
+        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: android
 
       - name: Setup Unity Modules - iOS
-        uses: bitsandfoxes/setup-unity@465111b8a4184a1ee4549e26cae0638b0df34f48
+        uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8
         with:
           unity-version: ${{ matrix.unity-version }}
           unity-modules: ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
           unity-version: ${{ matrix.unity-version }}
           unity-version-changeset:  ${{ matrix.unity-version-changeset }}
 
+      - name: Print setup output
+        run: |
+          echo unity-version: ${{ steps.setup-unity.outputs.unity-version }}
+          echo unity-path: ${{ steps.setup-unity.outputs.unity-path }}
+          echo env UNITY_PATH: ${{ env.UNITY_PATH }}
+
       - name: Setup Unity Modules - Windows IL2CPP
         if: matrix.os == 'windows-latest'
         uses: kuler90/setup-unity@f44e3f35ce3737316a15321ec3468161940e23e8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix missing Sentry/Sentry.h ([#504](https://github.com/getsentry/sentry-unity/pull/504))
+- Automated Android symbols upload now correctly escapes sentry-cli executable path ([#507](https://github.com/getsentry/sentry-unity/pull/507))
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Automated Android symbols upload now uses valid paths on Windows ([#509](https://github.com/getsentry/sentry-unity/pull/509))
+
 ## 0.9.2
 
 ### Features

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -26,9 +26,12 @@ namespace Sentry.Unity.Editor.Android
         public static void AppendUploadToGradleFile(string sentryCliPath, string gradleProjectPath, string symbolsDirectoryPath, IApplication? application = null)
         {
             application ??= ApplicationAdapter.Instance;
+
+            // On Windows the paths contains backslashes that need to be either escaped or replaced with slashes (opting for slash for consistency)
             if (application.Platform == RuntimePlatform.WindowsEditor)
             {
-                sentryCliPath = sentryCliPath.Replace(@"\", @"\\"); // On Windows the path contains backslashes that need to be escaped
+                sentryCliPath = sentryCliPath.Replace(@"\", "/");
+                symbolsDirectoryPath = symbolsDirectoryPath.Replace(@"\", "/");
             }
 
             if (!File.Exists(sentryCliPath))

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using Sentry.Unity.Integrations;
+using UnityEngine;
 
 namespace Sentry.Unity.Editor.Android
 {
@@ -21,8 +23,14 @@ namespace Sentry.Unity.Editor.Android
             return symbolsPath;
         }
 
-        public static void AppendUploadToGradleFile(string sentryCliPath, string gradleProjectPath, string symbolsDirectoryPath)
+        public static void AppendUploadToGradleFile(string sentryCliPath, string gradleProjectPath, string symbolsDirectoryPath, IApplication? application = null)
         {
+            application ??= ApplicationAdapter.Instance;
+            if (application.Platform == RuntimePlatform.WindowsEditor)
+            {
+                sentryCliPath = sentryCliPath.Replace(@"\", @"\\"); // On Windows the path contains backslashes that need to be escaped
+            }
+
             if (!File.Exists(sentryCliPath))
             {
                 throw new FileNotFoundException("Failed to find sentry-cli", sentryCliPath);

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using Sentry.Unity.Editor.Android;
+using UnityEngine;
 
 namespace Sentry.Unity.Editor.Tests.Android
 {
@@ -91,6 +92,23 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
+        public void AppendUploadToGradleFile_SentryCliExecutableExists_AddsPathToGradleFile()
+        {
+            var expectedSentryCliPath = _fixture.SentryCliPath;
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                expectedSentryCliPath = expectedSentryCliPath.Replace(@"\", @"\\");
+            }
+
+            var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, false);
+
+            DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
+            var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
+
+            StringAssert.Contains(expectedSentryCliPath, actualFileContent);
+        }
+
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public void AppendUploadToGradleFile_AllRequirementsMet_AppendsSentryCliToFile(bool export)
@@ -100,7 +118,6 @@ namespace Sentry.Unity.Editor.Tests.Android
             DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
             var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
 
-            StringAssert.Contains(_fixture.SentryCliPath, actualFileContent);
             StringAssert.Contains(symbolsDirectoryPath, actualFileContent);
         }
 

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -92,33 +92,25 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
-        public void AppendUploadToGradleFile_SentryCliExecutableExists_AddsPathToGradleFile()
-        {
-            var expectedSentryCliPath = _fixture.SentryCliPath;
-            if (Application.platform == RuntimePlatform.WindowsEditor)
-            {
-                expectedSentryCliPath = expectedSentryCliPath.Replace(@"\", @"\\");
-            }
-
-            var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, false);
-
-            DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
-            var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
-
-            StringAssert.Contains(expectedSentryCliPath, actualFileContent);
-        }
-
-        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public void AppendUploadToGradleFile_AllRequirementsMet_AppendsSentryCliToFile(bool export)
         {
             var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, export);
+            var expectedSentryCliPath = _fixture.SentryCliPath;
+            var expectedSymbolsDirectoryPath = symbolsDirectoryPath;
+
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                expectedSentryCliPath = expectedSentryCliPath.Replace(@"\", "/");
+                expectedSymbolsDirectoryPath = symbolsDirectoryPath.Replace(@"\", "/");
+            }
 
             DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
             var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
 
-            StringAssert.Contains(symbolsDirectoryPath, actualFileContent);
+            StringAssert.Contains(expectedSentryCliPath, actualFileContent);
+            StringAssert.Contains(expectedSymbolsDirectoryPath, actualFileContent);
         }
 
         public static void SetupFakeProject(string fakeProjectPath)


### PR DESCRIPTION
The previous PR #507 missed the symbols path. Also, for consistency in the `gradle.build`file I opted to replace Windows path backslashes with slashes (the hardcoded paths already use slashes)