### PR TITLE
Remove jcenter repository

### DIFF
--- a/samples/unity-of-bugs/Assets/Plugins/Android.meta
+++ b/samples/unity-of-bugs/Assets/Plugins/Android.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3d8e902de94b1a4ea0d1cfb75989c3c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/samples/unity-of-bugs/Assets/Plugins/Android/baseProjectTemplate.gradle
+++ b/samples/unity-of-bugs/Assets/Plugins/Android/baseProjectTemplate.gradle
@@ -1,0 +1,29 @@
+allprojects {
+    buildscript {
+        repositories {**ARTIFACTORYREPOSITORY**
+            google()
+            mavenCentral()
+        }
+
+        dependencies {
+            // If you are changing the Android Gradle Plugin version, make sure it is compatible with the Gradle version preinstalled with Unity
+            // See which Gradle version is preinstalled with Unity here https://docs.unity3d.com/Manual/android-gradle-overview.html
+            // See official Gradle and Android Gradle Plugin compatibility table here https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+            // To specify a custom Gradle version in Unity, go do "Preferences > External Tools", uncheck "Gradle Installed with Unity (recommended)" and specify a path to a custom Gradle version
+            classpath 'com.android.tools.build:gradle:3.4.0'
+            **BUILD_SCRIPT_DEPS**
+        }
+    }
+
+    repositories {**ARTIFACTORYREPOSITORY**
+        google()
+        mavenCentral()
+        flatDir {
+            dirs "${project(':unityLibrary').projectDir}/libs"
+        }
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/samples/unity-of-bugs/Assets/Plugins/Android/baseProjectTemplate.gradle.meta
+++ b/samples/unity-of-bugs/Assets/Plugins/Android/baseProjectTemplate.gradle.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 42ce04af93192e44d9fb0c8444f52acf
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Unity is failing by having Jcenter repository by default.

This PR uses the default baseProjectTemplate.gradle and replaces JCenter by mavenCentral.

#skip-changelog.