### PR TITLE
fix: Reinitializing native backend for IL2CPP only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Android Native Support no longer crashes when built with Mono while trying to capture a crash ([#524](https://github.com/getsentry/sentry-unity/pull/524))
 - Bump Sentry .NET SDK 3.13.0 ([#503](https://github.com/getsentry/sentry-unity/pull/503))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.13.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.12.3...3.13.0)

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -31,7 +31,11 @@ namespace Sentry.Unity
 #if SENTRY_NATIVE_IOS
                 SentryNativeIos.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
+#if ENABLE_IL2CPP
+                SentryNativeAndroid.Configure(options, true);
+#else
                 SentryNativeAndroid.Configure(options);
+#endif
 #endif
 
                 SentryUnity.Init(options);

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -31,11 +31,11 @@ namespace Sentry.Unity
 #if SENTRY_NATIVE_IOS
                 SentryNativeIos.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
-var il2cpp =
+                var il2cpp =
 #if ENABLE_IL2CPP
-        true;
+                true;
 #else
-        false;
+                false;
 #endif
                 SentryNativeAndroid.Configure(options, il2cpp);
 #endif

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -31,11 +31,13 @@ namespace Sentry.Unity
 #if SENTRY_NATIVE_IOS
                 SentryNativeIos.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
+var il2cpp =
 #if ENABLE_IL2CPP
-                SentryNativeAndroid.Configure(options, true);
+        true;
 #else
-                SentryNativeAndroid.Configure(options);
+        false;
 #endif
+                SentryNativeAndroid.Configure(options, il2cpp);
 #endif
 
                 SentryUnity.Init(options);

--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -79,7 +79,13 @@ public class SmokeTester : MonoBehaviour
             SentryNativeIos.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
             Debug.Log("SMOKE TEST: Configure Native Android.");
-            SentryNativeAndroid.Configure(options);
+            var il2cpp =
+#if ENABLE_IL2CPP
+            true;
+#else
+            false;
+#endif
+            SentryNativeAndroid.Configure(options, il2cpp);
 #endif
 
             Debug.Log("SMOKE TEST: SentryUnity Init.");
@@ -108,13 +114,13 @@ public class SmokeTester : MonoBehaviour
 
             // Test passed: Exit Code 200 to avoid false positive from a graceful exit unrelated to this test run
             Application.Quit(200);
-            
+
         }
         catch (Exception ex)
         {
             Debug.Log("SMOKE TEST: FAILED");
             Debug.LogError(ex);
-            Application.Quit(-1);        
+            Application.Quit(-1);
         }
     }
 

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -12,7 +12,7 @@ namespace Sentry.Unity.Android
         /// Configures the native Android support.
         /// </summary>
         /// <param name="options">The Sentry Unity options to use.</param>
-        public static void Configure(SentryUnityOptions options, bool isIL2CPP = false)
+        public static void Configure(SentryUnityOptions options, bool il2cpp)
         {
             if (options.AndroidNativeSupportEnabled)
             {
@@ -37,7 +37,9 @@ namespace Sentry.Unity.Android
                     return crashedLastRun.Value;
                 };
 
-                if (isIL2CPP)
+                // When running on Mono, we shouldn't take over the signal handler because its used to propagate exceptions into the VM.
+                // If we take over, a C# null reference ends up crashing the app.
+                if (il2cpp)
                 {
                     // At this point Unity has taken the signal handler and will not invoke the original handler (Sentry)
                     // So we register our backend once more to make sure user-defined data is available in the crash report.

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using UnityEngine;
 
 namespace Sentry.Unity.Android
 {
@@ -11,7 +12,7 @@ namespace Sentry.Unity.Android
         /// Configures the native Android support.
         /// </summary>
         /// <param name="options">The Sentry Unity options to use.</param>
-        public static void Configure(SentryUnityOptions options)
+        public static void Configure(SentryUnityOptions options, bool isIL2CPP = false)
         {
             if (options.AndroidNativeSupportEnabled)
             {
@@ -35,9 +36,13 @@ namespace Sentry.Unity.Android
 
                     return crashedLastRun.Value;
                 };
-                // At this point Unity has taken the signal handler and will not invoke the original handler (Sentry)
-                // So we register our backend once more to make sure user-defined data is available in the crash report.
-                SentryNative.ReinstallBackend();
+
+                if (isIL2CPP)
+                {
+                    // At this point Unity has taken the signal handler and will not invoke the original handler (Sentry)
+                    // So we register our backend once more to make sure user-defined data is available in the crash report.
+                    SentryNative.ReinstallBackend();
+                }
             }
         }
     }

--- a/test/Sentry.Unity.Android.Tests/SentryNativeAndroidTests.cs
+++ b/test/Sentry.Unity.Android.Tests/SentryNativeAndroidTests.cs
@@ -69,10 +69,18 @@ namespace Sentry.Unity.Android.Tests
         }
 
         [Test]
-        public void Configure_DefaultConfiguration_ReInitializesNativeBackend()
+        public void Configure_DefaultConfiguration_DoesNotReInitializesNativeBackend()
         {
             Assert.False(_reinstallCalled); // Sanity check
             SentryNativeAndroid.Configure(new());
+            Assert.False(_reinstallCalled);
+        }
+
+        [Test]
+        public void Configure_IsBuiltWithIl2CPP_ReInitializesNativeBackend()
+        {
+            Assert.False(_reinstallCalled); // Sanity check
+            SentryNativeAndroid.Configure(new(), true);
             Assert.True(_reinstallCalled);
         }
 


### PR DESCRIPTION
Aims to fix: https://github.com/getsentry/sentry-unity/issues/499

On Mono, when an actual crash happens and we reinitialized the native backend the app does what it's supposed to do when it crashes. It crashes. To prevent this we only reinizialize when building with IL2CPP.
