### PR TITLE
Fix SentrySdkCaptureEvent_OnNotUIThread_Succeeds and improve log for failed tests.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -419,36 +419,27 @@ void PrintFailedTests(XElement element)
         }
         else
         {
-            var sb = new StringBuilder();
+            var sb = new StringBuilder()
+              .Append("Test ")
+              .Append(descendant.Attribute("id")?.Value)
+              .Append(": ")
+              .AppendLine(descendant.Attribute("name")?.Value);
+
             var failure = descendant.Descendants("failure")
                 .Descendants("message")
                 .FirstOrDefault()
                 ?.Value;
 
-            sb.AppendLine(failure);
+            var stack = descendant.Descendants("failure")
+                .Descendants("stack-trace")
+                .FirstOrDefault()
+                ?.Value;
 
-            var lines = descendant.Attribute("name")?.Value.Split(new[] { "\\n" }, StringSplitOptions.None);
-            if (lines is null)
-            {
-                Log.LogError(sb.ToString());
-                continue;
-            }
+            sb.AppendLine(failure)
+              .Append("StackTrace: ")
+              .AppendLine(stack);
 
-            for (int i = 0; i < lines.Length; i++)
-            {
-                if (i == 0)
-                {
-                    sb.AppendLine();
-                    Console.WriteLine();
-                }
-                else
-                {
-                    sb.Append('\t');
-                }
-
-                sb.AppendLine(lines[i].Replace("\\r", ""));
-            }
-            Log.LogError(sb.ToString());
+            Console.Error.WriteLine(sb.ToString());
         }
     }
 }

--- a/test/Sentry.Unity.Tests/UnityEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventProcessorTests.cs
@@ -64,7 +64,11 @@ namespace Sentry.Unity.Tests
             SentrySdk.FlushAsync(TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
 
             // assert
-            Assert.Zero(_testLogger.Logs.Count(log => log.logLevel >= SentryLevel.Warning));
+            var logsFound = _testLogger.Logs.Where(log => log.logLevel >= SentryLevel.Warning);
+            Assert.Zero(
+                logsFound.Count(),
+                "Error messages captured:\n{0}\n == END ==",
+                string.Join("\n", logsFound.Select(p => p.message)));
             // Sanity check: At least some logs must have been printed
             Assert.NotZero(_testLogger.Logs.Count(log => log.logLevel <= SentryLevel.Info));
         }


### PR DESCRIPTION
- [ ] Fi SentrySdkCaptureEvent_OnNotUIThread_Succeeds

- [ ] Improve readability of errored test.

#skip-changelog.