### PR TITLE
feat: Added a repackage script

### DIFF
--- a/scripts/repack.ps1
+++ b/scripts/repack.ps1
@@ -1,0 +1,16 @@
+assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
+
+$unity_version = Get-Content ./samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt | grep m_EditorVersion -m 1 | cut -d ' ' -f 2
+
+if ($IsWindows){
+    $unity_path = "C:\Program Files\Unity\Hub\Editor\${unity_version}\Editor\Unity.exe"
+}
+else {
+    $unity_path = "/Applications/Unity/Hub/Editor/$unity_version/Unity.app/Contents/MacOS/Unity"
+}
+
+# Start up Unity to create the appropriate .meta files
+Start-Process -FilePath $unity_path -ArgumentList "-quit -batchmode -nographics -logFile - -projectPath `"samples/unity-of-bugs/`"" -Wait
+
+& "./scripts/pack.ps1"
+& "./test/Scripts.Tests/test-pack-contents.ps1" "accept"


### PR DESCRIPTION
When modifying the package contents there are quite a few manual steps required.
The result of running `./scripts/repack.ps1` is a new snapshot of the package to contain the added/removed files.

#skip-changelog