### PR TITLE
Regression: collect android native libraries as an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
+          name: Android-libraries
+          path: modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
+
+      - uses: actions/download-artifact@v2
+        with:
           name: iOS-sdk
           path: package-dev/Plugins/iOS
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -53,9 +53,15 @@ jobs:
       - name: Build
         run: dotnet msbuild /t:Build${{ inputs.target }}SDK /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
 
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.target }}-sdk
           path: package-dev/Plugins/${{ inputs.target }}
+          retention-days: 1
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ inputs.target == 'Android' }}
+        with:
+          name: ${{ inputs.target }}-libraries
+          path: modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib/*
           retention-days: 1

--- a/test/Scripts.Tests/android-libs.snapshot
+++ b/test/Scripts.Tests/android-libs.snapshot
@@ -1,0 +1,12 @@
+/arm64-v8a
+/armeabi-v7a
+/x86
+/x86_64
+arm64-v8a/libsentry-android.so
+arm64-v8a/libsentry.so
+armeabi-v7a/libsentry-android.so
+armeabi-v7a/libsentry.so
+x86/libsentry-android.so
+x86/libsentry.so
+x86_64/libsentry-android.so
+x86_64/libsentry.so

--- a/test/Scripts.Tests/test-pack-contents.ps1
+++ b/test/Scripts.Tests/test-pack-contents.ps1
@@ -42,6 +42,23 @@ try {
         $result | Format-Table -AutoSize
         exit 3
     }
-} finally{
+} finally {
     $zip.Dispose()
+}
+
+$androidLibsDir = "$projectRoot/modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib/"
+if (-not(Test-Path -Path $androidLibsDir)) {
+    Write-Host  "Android native libs not found in: '$androidLibsDir'"
+    exit 1
+}
+
+$androidLibs = Get-ChildItem -Recurse $androidLibsDir | ForEach-Object {$_.Directory.Name + "/" + $_.Name}
+$result = Compare-Object $androidLibs (Get-Content "$PSScriptRoot/android-libs.snapshot")
+if ($result.count -eq 0) {
+    Write-Host  "Android native libs match snapshot."
+}
+else {
+    Write-Host  "Android native libs do not match snapshot."
+    $result | Format-Table -AutoSize
+    exit 3
 }


### PR DESCRIPTION
Fixes a regression introduced by #547 - native libs were not collected anymore

TODO: where are these libs used? Do we need them in the final artifact [as they were before](https://github.com/getsentry/sentry-unity/blob/e1ddb54972935499fbca95c1558916b941d7e0c2/.github/workflows/ci.yml#L286) or can we just have a separate artifact "Android-libraries" (or a similar name)

#skip-changelog