### PR TITLE
fix: Sentry.Unity.Editor.iOS is 'OSX only' by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Sentry.Unity.Editor.iOS.dll no longer breaks builds on Windows when the iOS module has not been installed  ([#559](https://github.com/getsentry/sentry-unity/pull/559))
 - Importing the link.xml when opening the config window no longer causes an infinite loop ([#539](https://github.com/getsentry/sentry-unity/pull/539))
 
 ## 0.9.4

--- a/package/Editor/iOS/Sentry.Unity.Editor.iOS.dll.meta
+++ b/package/Editor/iOS/Sentry.Unity.Editor.iOS.dll.meta
@@ -1,0 +1,86 @@
+fileFormatVersion: 2
+guid: ab77fe3d77aab47838f950495e9f5869
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Sentry.Unity.Editor/SentryPreprocessBuild.cs
+++ b/src/Sentry.Unity.Editor/SentryPreprocessBuild.cs
@@ -17,7 +17,7 @@ namespace Sentry.Unity.Editor
             switch (report.summary.platform)
             {
                 case BuildTarget.iOS:
-                    CheckIOSEditorImportSettingsOnWindows(Path.Combine("Packages", SentryPackageInfo.GetName(), "Editor", "iOS",
+                    CheckIOSEditorImportSettings(Path.Combine("Packages", SentryPackageInfo.GetName(), "Editor", "iOS",
                         "Sentry.Unity.Editor.iOS", ".meta"));
                     break;
                 default:
@@ -26,10 +26,10 @@ namespace Sentry.Unity.Editor
             }
         }
 
-        internal void CheckIOSEditorImportSettingsOnWindows(string metaFilePath, IApplication? application = null)
+        internal void CheckIOSEditorImportSettings(string metaFilePath, IApplication? application = null)
         {
             application ??= ApplicationAdapter.Instance;
-            if (application.Platform != RuntimePlatform.WindowsEditor)
+            if (application.Platform == RuntimePlatform.OSXEditor)
             {
                 return;
             }


### PR DESCRIPTION
Closes: https://github.com/getsentry/sentry-unity/issues/525
Instead of requiring users to have the iOS module installed or embed the package and delete the `Sentry.Unity.Editor.iOS.dll` to get rid of the error, we set the default import settings to `OSX only`. 
If a user targets iOS on Windows we log the problem with a solution.