### PR TITLE
feat: Support for programmatic option configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Support for programmatic options configuration ([#564](https://github.com/getsentry/sentry-unity/pull/564))
+
 ## 0.10.0
 
 ### Features

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -64,6 +64,19 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                 new GUIContent("Windows Native Support", "Whether to enable Native Windows support to " +
                                                          "capture errors written in languages such as C and C++."),
                 options.WindowsNativeSupportEnabled);
+
+            EditorGUILayout.Space();
+            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
+            EditorGUILayout.Space();
+
+            GUILayout.Label("Programmatic Options Configuration", EditorStyles.boldLabel);
+
+            options.OptionsConfiguration = EditorGUILayout.ObjectField(
+                new GUIContent("Options Configuration", "A scriptable object that inherits from " +
+                                                        "'ScriptableOptionsConfiguration' that allows you to " +
+                                                        "programmatically modify Sentry options i.e. implement the " +
+                                                        "'BeforeSend' callback."),
+                    options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false) as ScriptableOptionsConfiguration;
         }
     }
 }

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -73,10 +73,6 @@ namespace Sentry.Unity.Editor
             EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
             EditorGUILayout.Space();
 
-            EditorGUILayout.Space();
-            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
-            EditorGUILayout.Space();
-
             EditorGUILayout.LabelField("Debug", EditorStyles.boldLabel);
             EditorGUILayout.Toggle("Enable Debug Output", options.Debug);
             EditorGUILayout.Toggle("Only In Editor", options.DebugOnlyInEditor);

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -66,6 +66,17 @@ namespace Sentry.Unity.Editor
             EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
             EditorGUILayout.Space();
 
+            EditorGUILayout.ObjectField("Options Configuration", options.OptionsConfiguration,
+                typeof(ScriptableOptionsConfiguration), false);
+
+            EditorGUILayout.Space();
+            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
+            EditorGUILayout.Space();
+
+            EditorGUILayout.Space();
+            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
+            EditorGUILayout.Space();
+
             EditorGUILayout.LabelField("Debug", EditorStyles.boldLabel);
             EditorGUILayout.Toggle("Enable Debug Output", options.Debug);
             EditorGUILayout.Toggle("Only In Editor", options.DebugOnlyInEditor);

--- a/src/Sentry.Unity/ScriptableOptionsConfiguration.cs
+++ b/src/Sentry.Unity/ScriptableOptionsConfiguration.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Sentry.Unity
+{
+    public abstract class ScriptableOptionsConfiguration : ScriptableObject
+    {
+        public abstract void Configure(SentryUnityOptions options);
+    }
+}

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -44,14 +44,11 @@ namespace Sentry.Unity
         [field: SerializeField] public bool IsEnvironmentUser { get; set; }
 
         [field: SerializeField] public bool EnableOfflineCaching { get; set; }
-
-        // At least 1 item must be allowed in the cache.
-        [field: SerializeField] public int MaxCacheItems { get; set; } = 1;
+        [field: SerializeField] public int MaxCacheItems { get; set; } = 30;
         [field: SerializeField] public int InitCacheFlushTimeout { get; set; }
         [field: SerializeField] public float? SampleRate { get; set; }
         [field: SerializeField] public int ShutdownTimeout { get; set; }
-        // At least 1 item must be allowed in the queue.
-        [field: SerializeField] public int MaxQueueItems { get; set; } = 1;
+        [field: SerializeField] public int MaxQueueItems { get; set; } = 30;
         [field: SerializeField] public bool IosNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool AndroidNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool WindowsNativeSupportEnabled { get; set; } = true;

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -44,14 +44,19 @@ namespace Sentry.Unity
         [field: SerializeField] public bool IsEnvironmentUser { get; set; }
 
         [field: SerializeField] public bool EnableOfflineCaching { get; set; }
-        [field: SerializeField] public int MaxCacheItems { get; set; }
+
+        // At least 1 item must be allowed in the cache.
+        [field: SerializeField] public int MaxCacheItems { get; set; } = 1;
         [field: SerializeField] public int InitCacheFlushTimeout { get; set; }
         [field: SerializeField] public float? SampleRate { get; set; }
         [field: SerializeField] public int ShutdownTimeout { get; set; }
-        [field: SerializeField] public int MaxQueueItems { get; set; }
+        // At least 1 item must be allowed in the queue.
+        [field: SerializeField] public int MaxQueueItems { get; set; } = 1;
         [field: SerializeField] public bool IosNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool AndroidNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool WindowsNativeSupportEnabled { get; set; } = true;
+
+        [field: SerializeField] public ScriptableOptionsConfiguration? OptionsConfiguration { get; set; }
 
         [field: SerializeField] public bool Debug { get; set; }
         [field: SerializeField] public bool DebugOnlyInEditor { get; set; }
@@ -80,26 +85,24 @@ namespace Sentry.Unity
         {
             application ??= ApplicationAdapter.Instance;
 
-            var options = new SentryUnityOptions(application, isBuilding)
-            {
-                Enabled = scriptableOptions.Enabled,
-                Dsn = scriptableOptions.Dsn,
-                CaptureInEditor = scriptableOptions.CaptureInEditor,
-                EnableLogDebouncing = scriptableOptions.EnableLogDebouncing,
-                TracesSampleRate = scriptableOptions.TracesSampleRate,
-                AutoSessionTracking = scriptableOptions.AutoSessionTracking,
-                AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(scriptableOptions.AutoSessionTrackingInterval),
-                AttachStacktrace = scriptableOptions.AttachStacktrace,
-                MaxBreadcrumbs = scriptableOptions.MaxBreadcrumbs,
-                ReportAssembliesMode = scriptableOptions.ReportAssembliesMode,
-                SendDefaultPii = scriptableOptions.SendDefaultPii,
-                IsEnvironmentUser = scriptableOptions.IsEnvironmentUser,
-                MaxCacheItems = scriptableOptions.MaxCacheItems,
-                InitCacheFlushTimeout = TimeSpan.FromMilliseconds(scriptableOptions.InitCacheFlushTimeout),
-                SampleRate = scriptableOptions.SampleRate,
-                ShutdownTimeout = TimeSpan.FromMilliseconds(scriptableOptions.ShutdownTimeout),
-                MaxQueueItems = scriptableOptions.MaxQueueItems
-            };
+            var options = new SentryUnityOptions(application, isBuilding);
+            options.Enabled = scriptableOptions.Enabled;
+            options.Dsn = scriptableOptions.Dsn;
+            options.CaptureInEditor = scriptableOptions.CaptureInEditor;
+            options.EnableLogDebouncing = scriptableOptions.EnableLogDebouncing;
+            options.TracesSampleRate = scriptableOptions.TracesSampleRate;
+            options.AutoSessionTracking = scriptableOptions.AutoSessionTracking;
+            options.AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(scriptableOptions.AutoSessionTrackingInterval);
+            options.AttachStacktrace = scriptableOptions.AttachStacktrace;
+            options.MaxBreadcrumbs = scriptableOptions.MaxBreadcrumbs;
+            options.ReportAssembliesMode = scriptableOptions.ReportAssembliesMode;
+            options.SendDefaultPii = scriptableOptions.SendDefaultPii;
+            options.IsEnvironmentUser = scriptableOptions.IsEnvironmentUser;
+            options.MaxCacheItems = scriptableOptions.MaxCacheItems;
+            options.InitCacheFlushTimeout = TimeSpan.FromMilliseconds(scriptableOptions.InitCacheFlushTimeout);
+            options.SampleRate = scriptableOptions.SampleRate;
+            options.ShutdownTimeout = TimeSpan.FromMilliseconds(scriptableOptions.ShutdownTimeout);
+            options.MaxQueueItems = scriptableOptions.MaxQueueItems;
 
             if (!string.IsNullOrWhiteSpace(scriptableOptions.ReleaseOverride))
             {
@@ -125,6 +128,9 @@ namespace Sentry.Unity
             options.DiagnosticLevel = scriptableOptions.DiagnosticLevel;
 
             SentryOptionsUtility.TryAttachLogger(options);
+
+            scriptableOptions.OptionsConfiguration?.Configure(options);
+
             return options;
         }
     }

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -85,24 +85,25 @@ namespace Sentry.Unity
         {
             application ??= ApplicationAdapter.Instance;
 
-            var options = new SentryUnityOptions(application, isBuilding);
-            options.Enabled = scriptableOptions.Enabled;
-            options.Dsn = scriptableOptions.Dsn;
-            options.CaptureInEditor = scriptableOptions.CaptureInEditor;
-            options.EnableLogDebouncing = scriptableOptions.EnableLogDebouncing;
-            options.TracesSampleRate = scriptableOptions.TracesSampleRate;
-            options.AutoSessionTracking = scriptableOptions.AutoSessionTracking;
-            options.AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(scriptableOptions.AutoSessionTrackingInterval);
-            options.AttachStacktrace = scriptableOptions.AttachStacktrace;
-            options.MaxBreadcrumbs = scriptableOptions.MaxBreadcrumbs;
-            options.ReportAssembliesMode = scriptableOptions.ReportAssembliesMode;
-            options.SendDefaultPii = scriptableOptions.SendDefaultPii;
-            options.IsEnvironmentUser = scriptableOptions.IsEnvironmentUser;
-            options.MaxCacheItems = scriptableOptions.MaxCacheItems;
-            options.InitCacheFlushTimeout = TimeSpan.FromMilliseconds(scriptableOptions.InitCacheFlushTimeout);
-            options.SampleRate = scriptableOptions.SampleRate;
-            options.ShutdownTimeout = TimeSpan.FromMilliseconds(scriptableOptions.ShutdownTimeout);
-            options.MaxQueueItems = scriptableOptions.MaxQueueItems;
+            var options = new SentryUnityOptions(application, isBuilding)
+            {
+                Enabled = scriptableOptions.Enabled, Dsn = scriptableOptions.Dsn,
+                CaptureInEditor = scriptableOptions.CaptureInEditor,
+                EnableLogDebouncing = scriptableOptions.EnableLogDebouncing,
+                TracesSampleRate = scriptableOptions.TracesSampleRate,
+                AutoSessionTracking = scriptableOptions.AutoSessionTracking,
+                AutoSessionTrackingInterval = TimeSpan.FromMilliseconds(scriptableOptions.AutoSessionTrackingInterval),
+                AttachStacktrace = scriptableOptions.AttachStacktrace,
+                MaxBreadcrumbs = scriptableOptions.MaxBreadcrumbs,
+                ReportAssembliesMode = scriptableOptions.ReportAssembliesMode,
+                SendDefaultPii = scriptableOptions.SendDefaultPii,
+                IsEnvironmentUser = scriptableOptions.IsEnvironmentUser,
+                MaxCacheItems = scriptableOptions.MaxCacheItems,
+                InitCacheFlushTimeout = TimeSpan.FromMilliseconds(scriptableOptions.InitCacheFlushTimeout),
+                SampleRate = scriptableOptions.SampleRate,
+                ShutdownTimeout = TimeSpan.FromMilliseconds(scriptableOptions.ShutdownTimeout),
+                MaxQueueItems = scriptableOptions.MaxQueueItems
+            };
 
             if (!string.IsNullOrWhiteSpace(scriptableOptions.ReleaseOverride))
             {

--- a/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -40,6 +40,7 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains("IosNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("AndroidNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("WindowsNativeSupportEnabled", optionsAsString);
+            StringAssert.Contains("OptionsConfiguration", optionsAsString);
             StringAssert.Contains("Debug", optionsAsString);
             StringAssert.Contains("DebugOnlyInEditor", optionsAsString);
             StringAssert.Contains("DiagnosticLevel", optionsAsString);

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptions.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
+using Sentry.Extensibility;
 using Sentry.Unity.Json;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
@@ -19,6 +20,15 @@ namespace Sentry.Unity.Tests
                 productName: "TestApplication",
                 version: "0.1.0",
                 persistentDataPath: "test/persistent/data/path");
+        }
+
+        class TestOptionsConfiguration : ScriptableOptionsConfiguration
+        {
+            public bool GotCalled;
+            public override void Configure(SentryUnityOptions options)
+            {
+                GotCalled = true;
+            }
         }
 
         [SetUp]
@@ -116,6 +126,20 @@ namespace Sentry.Unity.Tests
             var optionsActual = ScriptableSentryUnityOptions.ToSentryUnityOptions(scriptableOptions, isBuilding, _fixture.Application);
 
             AssertOptions(expectedOptions, optionsActual);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ToSentryUnityOptions_HasOptionsConfiguration_GetsCalled(bool isBuilding)
+        {
+            var optionsConfiguration = ScriptableObject.CreateInstance<TestOptionsConfiguration>();
+            var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+            scriptableOptions.OptionsConfiguration = optionsConfiguration;
+
+            ScriptableSentryUnityOptions.ToSentryUnityOptions(scriptableOptions, isBuilding);
+
+            Assert.IsTrue(optionsConfiguration.GotCalled);
         }
 
         [Test]

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptions.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptions.cs
@@ -25,10 +25,7 @@ namespace Sentry.Unity.Tests
         class TestOptionsConfiguration : ScriptableOptionsConfiguration
         {
             public bool GotCalled;
-            public override void Configure(SentryUnityOptions options)
-            {
-                GotCalled = true;
-            }
+            public override void Configure(SentryUnityOptions options) => GotCalled = true;
         }
 
         [SetUp]


### PR DESCRIPTION
The idea is to allow users to programmatically interact with the Sentry options i.e. interact with BeforeSend.
We provide the users with a snippet that lets them create a scriptable object. The path `Assets/Resources/Sentry/` is provided.

![ConfigurableOptions](https://user-images.githubusercontent.com/25725783/154071004-a7fd03ff-4ba3-4bf6-bb38-3bf412b5a31d.jpg)

```
using Sentry.Unity;
using UnityEngine;

[CreateAssetMenu(fileName = "Assets/Resources/Sentry/OptionsConfiguration", menuName = "Sentry/OptionsConfiguration", order = 999)]
public class MyOptionsConfiguration : ScriptableOptionsConfiguration
{
    public override void Configure(SentryUnityOptions options)
    {
        // Your code here
    }
}
```