### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ You'll need the following modules to be added in order to use Sentry Unity:
   * macOS zsh: `export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"`
   * Windows: `setx ANDROID_HOME "C:\Program Files (x86)\Android\android-sdk"` for a machine wide install, `setx ANDROID_HOME "%localappdata%\Android\Sdk"` for a user level install.
 
+### Setup for building Sentry Native
+
+Sentry Native is a sub module from Sentry Unity and for building it, currently requires the following tools:
+
+* Install [CMake](https://cmake.org/download/).
+* A supported C/C++ compiler.
+
 ## Build the project
 
 On the root of the repository, write:


### PR DESCRIPTION
I noticed that `dotnet build` throws an error if CMake or a C++ compiler isn't installed since they are required to configure sentry-native.
So I added the mention of CMake and the C++ compiler (Could specify that it needs to be compatible with C++14).

#skip-changelog.