### PR TITLE
chore: Bump to 2020.3.28 & 2021.2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         # 2022.1.0a12 removed until S.T.J issues fixed
-        unity-version: [2019.4.34f1, 2020.3.27f1, 2021.2.10f1]
+        unity-version: [2019.4.34f1, 2020.3.28f1, 2021.2.11f1]
         include:
           - os: windows-latest
             unity-installation-path: C:/Program Files/Unity/
@@ -66,10 +66,10 @@ jobs:
             unity-config-path: /Library/Application Support/Unity/config/
           - unity-version: 2019.4.34f1
             unity-version-changeset: 6a9faed444f2
-          - unity-version: 2020.3.27f1
-            unity-version-changeset: e759542391ea
-          - unity-version: 2021.2.10f1
-            unity-version-changeset: ee872746220e
+          - unity-version: 2020.3.28f1
+            unity-version-changeset: f5400f52e03f
+          - unity-version: 2021.2.11f1
+            unity-version-changeset: e50cafbb4399
           # - unity-version: 2022.1.0a12
           #   unity-version-changeset: 816252c3efbb
     env:
@@ -335,7 +335,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [21, 27, 29, 30]
-        unity-version: [2019.4.34f1, 2020.3.27f1, 2021.2.10f1]
+        unity-version: [2019.4.34f1, 2020.3.28f1, 2021.2.11f1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
@@ -356,15 +356,15 @@ jobs:
           {
             $avdTarget = "google_apis"
           }
-          Write-Host "steps.select-avd-target.outputs.target is $avdTarget" 
+          Write-Host "steps.select-avd-target.outputs.target is $avdTarget"
           echo "::set-output name=target::$avdTarget"
 
       - name: Android emulator setup + Smoke test
         id: smoke-test
         continue-on-error: true
         timeout-minutes: 10
-        # API 21 is no longer supported on Unity 2021.2.10f1
-        if: ${{ (matrix.unity-version != '2021.2.10f1' || matrix.api-level != '21') }}
+        # API 21 is no longer supported on Unity 2021.2.11f1
+        if: ${{ (matrix.unity-version != '2021.2.11f1' || matrix.api-level != '21') }}
         uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
         with:
           api-level: ${{ matrix.api-level }}
@@ -389,8 +389,8 @@ jobs:
         id: smoke-test-retry
         continue-on-error: true
         timeout-minutes: 10
-        # API 21 is no longer supported on Unity 2021.2.10f1 and we only want to retry the tests if the previous fail happened on the emulator startup.
-        if: ${{ (matrix.unity-version != '2021.2.10f1' || matrix.api-level != '21') && steps.smoke-test.outputs.smoke-status != 'Completed'  }}
+        # API 21 is no longer supported on Unity 2021.2.11f1 and we only want to retry the tests if the previous fail happened on the emulator startup.
+        if: ${{ (matrix.unity-version != '2021.2.11f1' || matrix.api-level != '21') && steps.smoke-test.outputs.smoke-status != 'Completed'  }}
         uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
         with:
           api-level: ${{ matrix.api-level }}
@@ -423,7 +423,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         unity-version: [2019.4.34f1, 2020.3.27f1, 2021.2.10f1]
+         unity-version: [2019.4.34f1, 2020.3.28f1, 2021.2.11f1]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
@@ -455,7 +455,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         unity-version: [2019.4.34f1, 2020.3.27f1, 2021.2.10f1]
+         unity-version: [2019.4.34f1, 2020.3.28f1, 2021.2.11f1]
          # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
          ios-runtime: ["12.0", "12.4", "13.0", "14.1", latest]
     steps:


### PR DESCRIPTION
Context: Trying to stay current to catch any issues like https://github.com/getsentry/sentry-unity/issues/550 that come up with new versions as early as possible.

#skip-changelog