### PR TITLE
feat: Added custom options configuration to samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Samples include programmatic options configuration snippet ([#568](https://github.com/getsentry/sentry-unity/pull/568))
 - Support for programmatic options configuration ([#564](https://github.com/getsentry/sentry-unity/pull/564))
 
 ## 0.10.0

--- a/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "Assets/Resources/Sentry/CustomOptionsConfiguration", menuName = "Sentry/CustomOptionsConfiguration", order = 999)]
 public class CustomOptionsConfiguration : ScriptableOptionsConfiguration
 {
+    // This method gets called when you instantiated the scriptable object and added it to the configuration window
     public override void Configure(SentryUnityOptions options)
     {
         // NOTE: You have complete access to the options object here but changes to the options will not make it

--- a/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
@@ -7,8 +7,9 @@ public class CustomOptionsConfiguration : ScriptableOptionsConfiguration
     // This method gets called when you instantiated the scriptable object and added it to the configuration window
     public override void Configure(SentryUnityOptions options)
     {
-        // NOTE: You have complete access to the options object here but changes to the options will not make it
-        // to the native layer because the native layer is configured during build time.
+        // NOTE: Changes to the options object done here will not affect native crashes. The native SDKs only take 
+        // options defined in the Sentry editor configuration window. 
+        // Learn more at: https://docs.sentry.io/platforms/unity/native-support/configuration/
 
         options.BeforeSend = sentryEvent =>
         {

--- a/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
@@ -1,0 +1,22 @@
+using Sentry.Unity;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Assets/Resources/Sentry/CustomOptionsConfiguration", menuName = "Sentry/CustomOptionsConfiguration", order = 999)]
+public class CustomOptionsConfiguration : ScriptableOptionsConfiguration
+{
+    public override void Configure(SentryUnityOptions options)
+    {
+        // NOTE: You have complete access to the options object here but changes to the options will not make it
+        // to the native layer because the native layer is configured during build time.
+
+        options.BeforeSend = sentryEvent =>
+        {
+            if (sentryEvent.Tags.ContainsKey("SomeTag"))
+            {
+                return null;
+            }
+
+            return sentryEvent;
+        };
+    }
+}

--- a/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs
@@ -14,6 +14,7 @@ public class CustomOptionsConfiguration : ScriptableOptionsConfiguration
         {
             if (sentryEvent.Tags.ContainsKey("SomeTag"))
             {
+                // Don't send events with a tag SomeTag to Sentry
                 return null;
             }
 

--- a/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs.meta
+++ b/samples/unity-of-bugs/Assets/Scripts/CustomOptionsConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf00f463fb8394bd4aaa371f7db39685
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -325,6 +325,8 @@ Samples~/unity-of-bugs/Scripts/AdditionalButtons.cs
 Samples~/unity-of-bugs/Scripts/AdditionalButtons.cs.meta
 Samples~/unity-of-bugs/Scripts/BugFarmButtons.cs
 Samples~/unity-of-bugs/Scripts/BugFarmButtons.cs.meta
+Samples~/unity-of-bugs/Scripts/CustomOptionsConfiguration.cs
+Samples~/unity-of-bugs/Scripts/CustomOptionsConfiguration.cs.meta
 Samples~/unity-of-bugs/Scripts/NativeSupport.meta
 Samples~/unity-of-bugs/Scripts/SceneButtons.cs
 Samples~/unity-of-bugs/Scripts/SceneButtons.cs.meta


### PR DESCRIPTION
Unfortunately, we ship our sample with just the scenes and scripts. So the user has to add an instance of the scriptable object to their own configuration window by hand.