### PR TITLE
feat: Editor support for options configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Config window support for programmatic options configuration ([#569](https://github.com/getsentry/sentry-unity/pull/569))
 - Support for programmatic options configuration ([#564](https://github.com/getsentry/sentry-unity/pull/564))
 
 ## 0.10.0

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -1,6 +1,4 @@
-using System.IO;
 using UnityEditor;
-using UnityEditor.PackageManager;
 using UnityEngine;
 
 namespace Sentry.Unity.Editor.ConfigurationWindow
@@ -64,19 +62,8 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                 new GUIContent("Windows Native Support", "Whether to enable Native Windows support to " +
                                                          "capture errors written in languages such as C and C++."),
                 options.WindowsNativeSupportEnabled);
-
-            EditorGUILayout.Space();
-            EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
-            EditorGUILayout.Space();
-
-            GUILayout.Label("Programmatic Options Configuration", EditorStyles.boldLabel);
-
-            options.OptionsConfiguration = EditorGUILayout.ObjectField(
-                new GUIContent("Options Configuration", "A scriptable object that inherits from " +
-                                                        "'ScriptableOptionsConfiguration' that allows you to " +
-                                                        "programmatically modify Sentry options i.e. implement the " +
-                                                        "'BeforeSend' callback."),
-                    options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false) as ScriptableOptionsConfiguration;
         }
+
+
     }
 }

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -60,8 +60,8 @@ public class {scriptName} : ScriptableOptionsConfiguration
     // This method gets called when you instantiated the scriptable object and added it to the configuration window
     public override void Configure(SentryUnityOptions options)
     {{
-        // NOTE: You have complete access to the options object here but changes to the options will not make it
-        // to the native layer because the native layer is configured during build time.
+        // NOTE: Native support is already initialized by the time this method runs, so Unity bugs are captured. 
+        // That means changes done to the 'options' here will only affect events from C# scripts.
 
         // Your code here
     }}

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor.ConfigurationWindow
+{
+    internal static class OptionsConfigurationTab
+    {
+        private const string CreateScriptableObjectFlag = "CreateScriptableOptionsObject";
+        private const string ScriptNameKey = "ScriptableOptionsName";
+
+        public static void Display(ScriptableSentryUnityOptions options)
+        {
+            GUILayout.Label("Programmatic Options Configuration", EditorStyles.boldLabel);
+
+            options.OptionsConfiguration = EditorGUILayout.ObjectField(
+                    new GUIContent("Options Configuration", "A scriptable object that inherits from " +
+                                                            "'ScriptableOptionsConfiguration' that allows you to " +
+                                                            "programmatically modify Sentry options i.e. implement " +
+                                                            "the 'BeforeSend' callback."),
+                    options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false)
+                as ScriptableOptionsConfiguration;
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox("The options configuration allows you to programmatically modify " +
+                                    "the Sentry options object during runtime initialization of the SDK. " +
+                                    "Clicking the button below will create a scriptable object template at your " +
+                                    "targeted location and create an instance at 'Assets/Resources/Sentry/'.", MessageType.Info);
+            EditorGUILayout.Space();
+
+            if (GUILayout.Button("Create options configuration"))
+            {
+                CreateOptionsConfigurationScript();
+            }
+        }
+
+        internal static void CreateOptionsConfigurationScript()
+        {
+            var scriptPath = EditorUtility.SaveFilePanel("Sentry Options Configuration", "Assets", "SentryOptionsConfiguration", "cs");
+            if(String.IsNullOrEmpty(scriptPath))
+            {
+                return;
+            }
+
+            if (scriptPath.StartsWith(Application.dataPath))
+            {
+                // AssetDatabase prefers a relative path
+                scriptPath = "Assets" + scriptPath.Substring(Application.dataPath.Length);
+            }
+
+            var scriptName = Path.GetFileNameWithoutExtension(scriptPath);
+
+            File.WriteAllText(scriptPath, $@"using Sentry.Unity;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = ""Assets/Resources/Sentry/{scriptName}.cs"", menuName = ""Sentry/{scriptName}"", order = 999)]
+public class {scriptName} : ScriptableOptionsConfiguration
+{{
+    // This method gets called when you instantiated the scriptable object and added it to the configuration window
+    public override void Configure(SentryUnityOptions options)
+    {{
+        // NOTE: You have complete access to the options object here but changes to the options will not make it
+        // to the native layer because the native layer is configured during build time.
+
+        // Your code here
+    }}
+}}");
+
+            // The created script has to be compiled and the scriptable object can't immediately be instantiated.
+            // So instead we work around this by setting a 'ShouldCreateOptionsObject' flag in the EditorPrefs to
+            // trigger the creation after the scripts reloaded.
+            EditorPrefs.SetBool(CreateScriptableObjectFlag, true);
+            EditorPrefs.SetString(ScriptNameKey, scriptName);
+
+            AssetDatabase.ImportAsset(scriptPath);
+            Selection.activeObject = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(scriptPath);
+        }
+
+        [UnityEditor.Callbacks.DidReloadScripts]
+        private static void OnScriptsReloaded()
+        {
+            if (!EditorPrefs.GetBool(CreateScriptableObjectFlag))
+            {
+                return;
+            }
+
+            var scriptName = EditorPrefs.GetString(ScriptNameKey);
+            EditorPrefs.DeleteKey(CreateScriptableObjectFlag);
+            EditorPrefs.DeleteKey(ScriptNameKey);
+
+            var optionsConfigurationObject = ScriptableObject.CreateInstance(scriptName);
+            AssetDatabase.CreateAsset(optionsConfigurationObject, $"Assets/Resources/Sentry/{scriptName}.asset");
+            AssetDatabase.Refresh();
+
+            // Don't overwrite already set OptionsConfiguration
+            var options = SentryWindow.Instance.Options;
+            if (options.OptionsConfiguration == null)
+            {
+                options.OptionsConfiguration = (ScriptableOptionsConfiguration)optionsConfigurationObject;
+            }
+        }
+    }
+}

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -38,7 +38,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
         internal static void CreateOptionsConfigurationScript()
         {
             var scriptPath = EditorUtility.SaveFilePanel("Sentry Options Configuration", "Assets", "SentryOptionsConfiguration", "cs");
-            if(String.IsNullOrEmpty(scriptPath))
+            if (String.IsNullOrEmpty(scriptPath))
             {
                 return;
             }

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -15,7 +15,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
         public static SentryWindow OpenSentryWindow()
         {
             var window = (SentryWindow)GetWindow(typeof(SentryWindow));
-            window.minSize = new Vector2(1800, 350);
+            window.minSize = new Vector2(600, 350);
             return window;
         }
 

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using Sentry.Extensibility;
-using Sentry.Unity.Editor.ConfigurationWindow;
 using Sentry.Unity.Json;
 using UnityEditor;
 using UnityEngine;
@@ -16,9 +15,11 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
         public static SentryWindow OpenSentryWindow()
         {
             var window = (SentryWindow)GetWindow(typeof(SentryWindow));
-            window.minSize = new Vector2(600, 350);
+            window.minSize = new Vector2(1800, 350);
             return window;
         }
+
+        public static SentryWindow Instance => GetWindow<SentryWindow>();
 
         protected virtual string SentryOptionsAssetName { get; } = ScriptableSentryUnityOptions.ConfigName;
 
@@ -28,7 +29,15 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
         public event Action<ValidationError> OnValidationError = _ => { };
 
         private int _currentTab = 0;
-        private string[] _tabs = new[] { "Core", "Enrichment", "Transport", "Advanced", "Debug Symbols" };
+        private readonly string[] _tabs =
+        {
+            "Core",
+            "Enrichment",
+            "Transport",
+            "Advanced",
+            "Options Config",
+            "Debug Symbols"
+        };
 
         private void Awake()
         {
@@ -135,6 +144,9 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                     AdvancedTab.Display(Options);
                     break;
                 case 4:
+                    OptionsConfigurationTab.Display(Options);
+                    break;
+                case 5:
                     DebugSymbolsTab.Display(CliOptions);
                     break;
                 default:


### PR DESCRIPTION
The goal is to have the least amount of steps between the config window and a user that just wants to write code.
The added `options config` tab allows the user to add the scriptable object that gets called during runtime initialization.
The button does:
1. Creates a script from a template at a user-selected location
2. Instantiates the scriptable object from the script and assigns it

Multiple button clicks allow for replacing of the script.
Already assigned scriptable objects do not get overwritten in the config window.
![OptionsConfiguration](https://user-images.githubusercontent.com/25725783/154316256-6c5ab1f8-a803-469c-8fec-22e4b23be64d.jpg)
