### PR TITLE
fix: Explicitly copy SentryNativeBridge during build post process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ package-dev/Plugins/*/Sentry/crashpad_handler*
 # required to be marked as iOS only
 !package-dev/**/*.framework.meta
 
+# required to be excluded on all platforms because we don't want Unity to copy it during build
+!package-dev/**/SentryNativeBridge.m.meta
+
 # Android SDK files
 package-dev/Plugins/Android/Sentry/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- iOS builds no longer break when native support disabled or not available ([#592](https://github.com/getsentry/sentry-unity/pull/592))
+
 ## 0.11.0
 
 ### Features

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m.meta
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m.meta
@@ -1,0 +1,85 @@
+fileFormatVersion: 2
+guid: 2d1ed50513f884127bb69e8780664ed1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -32,6 +32,7 @@ namespace Sentry.Unity.Editor.iOS
 
                 using var sentryXcodeProject = SentryXcodeProject.Open(pathToProject);
                 sentryXcodeProject.AddSentryFramework();
+                sentryXcodeProject.AddSentryNativeBridge();
 
                 if (options?.Validate() != true)
                 {

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -10,11 +10,13 @@ namespace Sentry.Unity.Editor.iOS
 {
     internal class SentryXcodeProject : IDisposable
     {
-        private const string FrameworkName = "Sentry.framework";
+        internal const string FrameworkName = "Sentry.framework";
+        internal const string BridgeName = "SentryNativeBridge.m";
+        internal const string OptionsName = "SentryOptions.m";
         internal const string SymbolUploadPhaseName = "SymbolUpload";
 
         private readonly string _mainPath = Path.Combine("MainApp", "main.mm");
-        private readonly string _optionsPath = Path.Combine("MainApp", "SentryOptions.m");
+        private readonly string _optionsPath = Path.Combine("MainApp", OptionsName);
 
         private readonly string _projectRoot;
         private readonly PBXProject _project;
@@ -79,6 +81,13 @@ namespace Sentry.Unity.Editor.iOS
             _project.SetBuildProperty(_unityFrameworkTargetGuid, "DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym");
 
             _project.AddBuildProperty(_mainTargetGuid, "OTHER_LDFLAGS", "-ObjC");
+        }
+
+        public void AddSentryNativeBridge()
+        {
+            var relativeBridgePath = Path.Combine("Libraries", SentryPackageInfo.GetName(), BridgeName);
+            var bridgeGuid = _project.AddFile(relativeBridgePath, relativeBridgePath);
+            _project.AddFileToBuild(_unityFrameworkTargetGuid, bridgeGuid);
         }
 
         internal void SetSearchPathBuildProperty(string path)

--- a/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
@@ -8,49 +8,87 @@ namespace Sentry.Unity.Editor.iOS.Tests
 {
     public class BuildPostProcessorTests
     {
-        private string _testDirectoryPath = null!;
-        private string _sentryFrameworkPath = null!;
+        private string _testDirectoryRoot = null!;
+        private string _testFrameworkPath = null!;
+        private string _testFilePath = null!;
         private string _xcodeProjectPath = null!;
 
         [SetUp]
         public void Setup()
         {
-            _testDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 4));
-            _sentryFrameworkPath = Path.Combine(_testDirectoryPath, "Sentry.framework");
-            _xcodeProjectPath = Path.Combine(_testDirectoryPath, "XcodeProject");
+            _testDirectoryRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString().Substring(0, 4));
+            _testFrameworkPath = Path.Combine(_testDirectoryRoot, "Test.framework");
+            _testFilePath = Path.Combine(_testDirectoryRoot, "Test.m");
+            _xcodeProjectPath = Path.Combine(_testDirectoryRoot, "XcodeProject");
 
-            Directory.CreateDirectory(_testDirectoryPath);
-            Directory.CreateDirectory(_sentryFrameworkPath);
+            Directory.CreateDirectory(_testDirectoryRoot);
+            Directory.CreateDirectory(_testFrameworkPath);
+            File.Create(_testFilePath).Close();
             Directory.CreateDirectory(_xcodeProjectPath);
         }
 
         [TearDown]
-        public void TearDown() => Directory.Delete(_testDirectoryPath, true);
+        public void TearDown() => Directory.Delete(_testDirectoryRoot, true);
 
         [Test]
-        public void CopyFrameworkToBuildDirectory_CopiesFramework()
+        public void CopyFrameworkToXcodeProject_CopyFramework_DirectoryExists()
         {
-            BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, _sentryFrameworkPath, new TestLogger());
+            var targetPath = Path.Combine(_xcodeProjectPath, "SomeDirectory", "Test.framework");
 
-            Assert.IsTrue(Directory.Exists(Path.Combine(_xcodeProjectPath, "Frameworks", "Sentry.framework")));
+            BuildPostProcess.CopyFramework( _testFrameworkPath, targetPath, new TestLogger());
+
+            Assert.IsTrue(Directory.Exists(targetPath));
         }
 
         [Test]
-        public void CopyFrameworkToBuildDirectory_FrameworkAlreadyCopied_LogsSkipMessage()
+        public void CopyFramework_FrameworkAlreadyExists_LogsSkipMessage()
         {
             var testLogger = new TestLogger();
+            var targetPath = Path.Combine(_xcodeProjectPath, "SomeDirectory", "Test.framework");
 
-            BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, _sentryFrameworkPath, testLogger);
-            BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, _sentryFrameworkPath, testLogger);
+            BuildPostProcess.CopyFramework(_testFrameworkPath, targetPath, testLogger);
+            BuildPostProcess.CopyFramework(_testFrameworkPath, targetPath, testLogger);
 
             Assert.IsTrue(testLogger.Logs.Any(log =>
                 log.logLevel == SentryLevel.Debug &&
-                log.message.Contains("'Sentry.framework' has already copied")));
+                log.message.Contains("has already been copied to")));
         }
 
         [Test]
-        public void CopyFrameworkToBuildDirectory_FailedToCopyFramework_ThrowsFileNotFoundException() =>
+        public void CopyFramework_FailedToCopy_ThrowsDirectoryNotFoundException() =>
+            Assert.Throws<DirectoryNotFoundException>(() =>
+                BuildPostProcess.CopyFramework("non-existent-path.framework",
+                    Path.Combine(_xcodeProjectPath, "SomeDirectory", "Test.framework"), new TestLogger()));
+
+
+        [Test]
+        public void CopyFile_CopyFile_FileExists()
+        {
+            var targetPath = Path.Combine(_xcodeProjectPath, "SomeDirectory", "Test.m");
+
+            BuildPostProcess.CopyFile( _testFilePath, targetPath, new TestLogger());
+
+            Assert.IsTrue(File.Exists(targetPath));
+        }
+
+        [Test]
+        public void CopyFile_FileAlreadyExists_LogsSkipMessage()
+        {
+            var testLogger = new TestLogger();
+            var targetPath = Path.Combine(_xcodeProjectPath, "SomeDirectory", "Test.m");
+
+            BuildPostProcess.CopyFile(_testFilePath, targetPath, testLogger);
+            BuildPostProcess.CopyFile(_testFilePath, targetPath, testLogger);
+
+            Assert.IsTrue(testLogger.Logs.Any(log =>
+                log.logLevel == SentryLevel.Debug &&
+                log.message.Contains("has already been copied to")));
+        }
+
+        [Test]
+        public void CopyFile_FailedToCopyFile_ThrowsFileNotFoundException() =>
             Assert.Throws<FileNotFoundException>(() =>
-                BuildPostProcess.CopyFrameworkToBuildDirectory(_xcodeProjectPath, "non-existent-path", new TestLogger()));
+                BuildPostProcess.CopyFile("non-existent-path.m",
+                    Path.Combine(_xcodeProjectPath, "NewDirectory", "Test.m"), new TestLogger()));
     }
 }

--- a/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
@@ -84,7 +84,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
 
             xcodeProject.AddSentryFramework();
 
-            StringAssert.Contains(@"OTHER_LDFLAGS = ""-ObjC"";", xcodeProject.ProjectToString());
+            StringAssert.Contains(SentryXcodeProject.FrameworkName, xcodeProject.ProjectToString());
         }
 
         [Test]
@@ -101,6 +101,17 @@ namespace Sentry.Unity.Editor.iOS.Tests
         }
 
         [Test]
+        public void AddSentryNativeBridges_FrameworkSearchPathAlreadySet_DoesNotGetOverwritten()
+        {
+            var xcodeProject = _fixture.GetSut();
+            xcodeProject.ReadFromProjectFile();
+
+            xcodeProject.AddSentryNativeBridge();
+
+            StringAssert.Contains(SentryXcodeProject.BridgeName, xcodeProject.ProjectToString());
+        }
+
+        [Test]
         public void CreateNativeOptions_CleanXcodeProject_NativeOptionsAdded()
         {
             var xcodeProject = _fixture.GetSut();
@@ -108,7 +119,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
 
             xcodeProject.AddNativeOptions(_fixture.Options);
 
-            StringAssert.Contains("SentryOptions.m", xcodeProject.ProjectToString());
+            StringAssert.Contains(SentryXcodeProject.OptionsName, xcodeProject.ProjectToString());
         }
 
         [Test]


### PR DESCRIPTION
Due to the `.meta` import settings for the `SentryNativeBridge.m` Unity copied it over to the generated Xcode project whether NativeSupport was enabled/available or not.
We now exclude it on any platform and copy it over during build post-processing.

Stops https://github.com/getsentry/sentry-unity/issues/588 from breaking.