### PR TITLE
Bump minimun version on readme to 2019.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A video explaining the project and showing the early support:
 
 ## Legacy SDK
 
-If you are using Unity 5.6 or building WebGL players, these are not supported by this SDK. WebGL support will be added later, but there are no plans to support versions of Unity older than **2018.1**.
+If you are using Unity 5.6 or building WebGL players, these are not supported by this SDK. WebGL support will be added later, but there are no plans to support versions of Unity older than **2019.4**.
 
 Sentry offered a minimalistic but stable SDK called [_sentry-unity-lite_](https://github.com/getsentry/sentry-unity-lite). It's available on a different repository. That SDK is now deprecated but is still compatible with Sentry server.
 


### PR DESCRIPTION
Just a nit so folks don't try 2018 versions higher than 2018.1 and old versions of 2019

#skip-changelog.