### PR TITLE
Refactor: editor for custom options

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -18,13 +18,12 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                                     "This allows you to override configuration otherwise unavailable from the " +
                                     "editor UI, e.g. set a custom BeforeSend callback. \n\n" +
                                     // TODO other platforms
-                                    // "Because Sentry Unity integration includes both managed c# Unity SDK and a " +
+                                    // "Because Sentry Unity integration includes both managed C# Unity SDK and a " +
                                     // "platform specific one, you can specify the respective overrides separately.\n\n" +
                                     "You can either select an existing script, or create a new one by clicking the " +
                                     "'New' button, which will create one from a template at a selected location.",
                                     MessageType.Info);
 
-            EditorGUILayout.Space();
             EditorGUILayout.Space();
 
             OptionsConfigurationDotNet.Display(options);
@@ -40,7 +39,10 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
         {
             GUILayout.BeginHorizontal();
             options.OptionsConfiguration = EditorGUILayout.ObjectField(
-                    new GUIContent(".net (c#)"), options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false)
+                    new GUIContent(".NET (C#)", "A scriptable object that inherits from " +
+                                                            "'ScriptableOptionsConfiguration' and allows you to " +
+                                                            "programmatically modify Sentry options."), 
+                    options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false)
                 as ScriptableOptionsConfiguration;
             if (GUILayout.Button("New", GUILayout.ExpandWidth(false)))
             {

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -17,34 +17,37 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                                     "the Sentry options object during runtime initialization of the SDK. " +
                                     "This allows you to override configuration otherwise unavailable from the " +
                                     "editor UI, e.g. set a custom BeforeSend callback. \n\n" +
-                                    "Because Sentry Unity integration includes both managed c# Unity SDK and a " +
-                                    "platform specific one, you can specify the respective overrides separately.\n\n" +
+                                    // TODO other platforms
+                                    // "Because Sentry Unity integration includes both managed c# Unity SDK and a " +
+                                    // "platform specific one, you can specify the respective overrides separately.\n\n" +
                                     "You can either select an existing script, or create a new one by clicking the " +
                                     "'New' button, which will create one from a template at a selected location.",
                                     MessageType.Info);
 
             EditorGUILayout.Space();
+            EditorGUILayout.Space();
 
-            { // c#
-                EditorGUILayout.Space();
-                GUILayout.BeginHorizontal();
-                options.OptionsConfiguration = EditorGUILayout.ObjectField(
-                        new GUIContent(".net (c#)"), options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false)
-                    as ScriptableOptionsConfiguration;
-                if (GUILayout.Button("New", GUILayout.ExpandWidth(false)))
-                {
-                    OptionsConfigurationDotNet.CreateScript();
-                }
-                GUILayout.EndHorizontal();
-            }
+            OptionsConfigurationDotNet.Display(options);
         }
-
     }
 
     internal static class OptionsConfigurationDotNet
     {
         private const string CreateScriptableObjectFlag = "CreateScriptableOptionsObject";
         private const string ScriptNameKey = "ScriptableOptionsName";
+
+        public static void Display(ScriptableSentryUnityOptions options)
+        {
+            GUILayout.BeginHorizontal();
+            options.OptionsConfiguration = EditorGUILayout.ObjectField(
+                    new GUIContent(".net (c#)"), options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false)
+                as ScriptableOptionsConfiguration;
+            if (GUILayout.Button("New", GUILayout.ExpandWidth(false)))
+            {
+                OptionsConfigurationDotNet.CreateScript();
+            }
+            GUILayout.EndHorizontal();
+        }
 
         internal static void CreateScript()
         {

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -41,7 +41,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             options.OptionsConfiguration = EditorGUILayout.ObjectField(
                     new GUIContent(".NET (C#)", "A scriptable object that inherits from " +
                                                             "'ScriptableOptionsConfiguration' and allows you to " +
-                                                            "programmatically modify Sentry options."), 
+                                                            "programmatically modify Sentry options."),
                     options.OptionsConfiguration, typeof(ScriptableOptionsConfiguration), false)
                 as ScriptableOptionsConfiguration;
             if (GUILayout.Button("New", GUILayout.ExpandWidth(false)))

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -67,7 +67,7 @@ namespace Sentry.Unity.Editor
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Options Configuration", EditorStyles.boldLabel);
-            EditorGUILayout.ObjectField(".net (c#)", options.OptionsConfiguration,
+            EditorGUILayout.ObjectField(".NET (C#)", options.OptionsConfiguration,
                 typeof(ScriptableOptionsConfiguration), false);
 
             EditorGUILayout.Space();

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -66,7 +66,8 @@ namespace Sentry.Unity.Editor
             EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
             EditorGUILayout.Space();
 
-            EditorGUILayout.ObjectField("Options Configuration", options.OptionsConfiguration,
+            EditorGUILayout.LabelField("Options Configuration", EditorStyles.boldLabel);
+            EditorGUILayout.ObjectField(".net (c#)", options.OptionsConfiguration,
                 typeof(ScriptableOptionsConfiguration), false);
 
             EditorGUILayout.Space();


### PR DESCRIPTION
I've started looking into custom options and though I'm moving on to other issues, we could at least merge the editor refactorings. The idea is to add a new script-select for each supported platform.

Part of #609 

<img width="595" alt="image" src="https://user-images.githubusercontent.com/6349682/157676881-fe66873f-d658-4015-ba64-5f685d94505e.png">

#skip-changelog