### PR TITLE
Don't run sentry-dotnet with multiple app instances at the same time (desktop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.14.1...3.15.0)
 - Windows - include sentry.dll & .pdb in debug symbol upload ([#641](https://github.com/getsentry/sentry-unity/pull/641))
 
+### Fixes
+
+- Windows - avoid sentry-dotnet issue when multiple app instances try to access the same cache directory ([#643](https://github.com/getsentry/sentry-unity/pull/643))
+
 ## 0.12.0
 
 ### Features

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -29,7 +29,7 @@ namespace Sentry.Unity
     public static class SentryInitialization
     {
 #if SENTRY_NATIVE_WINDOWS
-        private static FileStream _globalMutex;
+        private static FileStream _lockFile;
 #endif
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
@@ -54,14 +54,15 @@ namespace Sentry.Unity
                 {
                     try
                     {
-                        _globalMutex = new FileStream(Path.Combine(options.CacheDirectoryPath, "sentry-unity.lock"), FileMode.OpenOrCreate,
+                        _lockFile = new FileStream(Path.Combine(options.CacheDirectoryPath, "sentry-unity.lock"), FileMode.OpenOrCreate,
                                 FileAccess.ReadWrite, FileShare.None);
 
                         Application.quitting += () =>
                         {
                             try
                             {
-                                _globalMutex.Close();
+                                // We don't really need to close, Windows would do that anyway, but let's be nice.
+                                _lockFile.Close();
                             }
                             catch (Exception ex)
                             {

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -17,9 +17,6 @@ using Sentry.Unity.iOS;
 using Sentry.Unity.Android;
 #elif SENTRY_NATIVE_WINDOWS
 using Sentry.Unity.Native;
-using Sentry.Extensibility;
-using System;
-using System.IO;
 #endif
 
 [assembly: AlwaysLinkAssembly]
@@ -28,10 +25,6 @@ namespace Sentry.Unity
 {
     public static class SentryInitialization
     {
-#if SENTRY_NATIVE_WINDOWS
-        private static FileStream _lockFile;
-#endif
-
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Init()
         {
@@ -46,39 +39,6 @@ namespace Sentry.Unity
                 SentryNativeAndroid.Configure(options, sentryUnityInfo);
 #elif SENTRY_NATIVE_WINDOWS
                 SentryNative.Configure(options);
-
-                // On Standalone, we disable cache dir in case multiple app instances run over the same path.
-                // Note: we cannot use a named Mutex, because Unit doesn't support it. Instead, we create a file with `FileShare.None`.
-                // https://forum.unity.com/threads/unsupported-internal-call-for-il2cpp-mutex-createmutex_internal-named-mutexes-are-not-supported.387334/
-                if (options.CacheDirectoryPath != null)
-                {
-                    try
-                    {
-                        _lockFile = new FileStream(Path.Combine(options.CacheDirectoryPath, "sentry-unity.lock"), FileMode.OpenOrCreate,
-                                FileAccess.ReadWrite, FileShare.None);
-
-                        Application.quitting += () =>
-                        {
-                            try
-                            {
-                                // We don't really need to close, Windows would do that anyway, but let's be nice.
-                                _lockFile.Close();
-                            }
-                            catch (Exception ex)
-                            {
-                                options.DiagnosticLogger?.Log(SentryLevel.Warning,
-                                    "Exception while releasing the lockfile on the config directory.", ex);
-                            }
-                        };
-                    }
-                    catch (Exception ex)
-                    {
-                        options.DiagnosticLogger?.Log(SentryLevel.Warning, "An exception was thrown while trying to " +
-                            "acquire a lockfile on the config directory: .NET event cache will be disabled.", ex);
-                        options.CacheDirectoryPath = null;
-                        options.AutoSessionTracking = false;
-                    }
-                }
 #endif
 
                 SentryUnity.Init(options);

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -47,14 +47,13 @@ namespace Sentry.Unity
                     }
                     catch (Exception ex)
                     {
-                        options.DiagnosticLogger?.Log(SentryLevel.Warning, "An exception was thrown while trying to " +
+                        options.DiagnosticLogger?.LogWarning("An exception was thrown while trying to " +
                             "acquire a lockfile on the config directory: .NET event cache will be disabled.", ex);
                         options.CacheDirectoryPath = null;
                         options.AutoSessionTracking = false;
                     }
                 }
 
-                options.DiagnosticLogger?.LogDebug(options.ToString());
                 var sentryDotNet = SentrySdk.Init(options);
                 ApplicationAdapter.Instance.Quitting += () =>
                 {

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -38,7 +38,7 @@ namespace Sentry.Unity
                 // On Standalone, we disable cache dir in case multiple app instances run over the same path.
                 // Note: we cannot use a named Mutex, because Unit doesn't support it. Instead, we create a file with `FileShare.None`.
                 // https://forum.unity.com/threads/unsupported-internal-call-for-il2cpp-mutex-createmutex_internal-named-mutexes-are-not-supported.387334/
-                if (ApplicationAdapter.Instance.Platform == RuntimePlatform.WindowsPlayer && options.CacheDirectoryPath != null)
+                if (ApplicationAdapter.Instance.Platform is RuntimePlatform.WindowsPlayer && options.CacheDirectoryPath is not null)
                 {
                     try
                     {

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -1,7 +1,9 @@
 using System;
+using System.IO;
 using System.ComponentModel;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
+using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -10,6 +12,8 @@ namespace Sentry.Unity
     /// </summary>
     public static class SentryUnity
     {
+        private static FileStream? _lockFile;
+
         /// <summary>
         /// Initializes Sentry Unity SDK while configuring the options.
         /// </summary>
@@ -24,19 +28,54 @@ namespace Sentry.Unity
         /// <summary>
         /// Initializes Sentry Unity SDK while providing an options object.
         /// </summary>
-        /// <param name="sentryUnityOptions">The options object.</param>
+        /// <param name="options">The options object.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void Init(SentryUnityOptions sentryUnityOptions)
+        public static void Init(SentryUnityOptions options)
         {
-            SentryOptionsUtility.TryAttachLogger(sentryUnityOptions);
-            if (sentryUnityOptions.ShouldInitializeSdk())
+            SentryOptionsUtility.TryAttachLogger(options);
+            if (options.ShouldInitializeSdk())
             {
-                sentryUnityOptions.DiagnosticLogger?.LogDebug(sentryUnityOptions.ToString());
-                var sentryDotNet = SentrySdk.Init(sentryUnityOptions);
+                // On Standalone, we disable cache dir in case multiple app instances run over the same path.
+                // Note: we cannot use a named Mutex, because Unit doesn't support it. Instead, we create a file with `FileShare.None`.
+                // https://forum.unity.com/threads/unsupported-internal-call-for-il2cpp-mutex-createmutex_internal-named-mutexes-are-not-supported.387334/
+                if (ApplicationAdapter.Instance.Platform == RuntimePlatform.WindowsPlayer && options.CacheDirectoryPath != null)
+                {
+                    try
+                    {
+                        _lockFile = new FileStream(Path.Combine(options.CacheDirectoryPath, "sentry-unity.lock"), FileMode.OpenOrCreate,
+                                FileAccess.ReadWrite, FileShare.None);
+                    }
+                    catch (Exception ex)
+                    {
+                        options.DiagnosticLogger?.Log(SentryLevel.Warning, "An exception was thrown while trying to " +
+                            "acquire a lockfile on the config directory: .NET event cache will be disabled.", ex);
+                        options.CacheDirectoryPath = null;
+                        options.AutoSessionTracking = false;
+                    }
+                }
+
+                options.DiagnosticLogger?.LogDebug(options.ToString());
+                var sentryDotNet = SentrySdk.Init(options);
                 ApplicationAdapter.Instance.Quitting += () =>
                 {
-                    sentryUnityOptions.DiagnosticLogger?.LogDebug("Closing the sentry-dotnet SDK");
-                    sentryDotNet.Dispose();
+                    options.DiagnosticLogger?.LogDebug("Closing the sentry-dotnet SDK");
+                    try
+                    {
+                        sentryDotNet.Dispose();
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            // We don't really need to close, Windows would release the lock anyway, but let's be nice.
+                            _lockFile?.Close();
+                        }
+                        catch (Exception ex)
+                        {
+                            options.DiagnosticLogger?.Log(SentryLevel.Warning,
+                                "Exception while releasing the lockfile on the config directory.", ex);
+                        }
+                    }
                 };
             }
         }


### PR DESCRIPTION
Workaround for #264 

* [x] depends on #630 which changes smoke test so that it doesn't call init twice