### PR TITLE
CI: support a manual run and run on all pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,9 @@ name: CI
 on:
   push:
     paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-    branches:
-      - main
-      - release/**
-  pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
+      - '**.md'
+      - '**.txt'
+  workflow_dispatch:  # e.g. to manually trigger on foreign PRs
 
 env:
   LOWEST_SUPPORTED_UNITY_VERSION: 2019


### PR DESCRIPTION
#skip-changelog

turns out the recent change wasn't so good... we still don't get proper CI on 3rd-party PRs and now we also don't get CI on changes by the unity-update action. This should fix that and with the change of the license secret to allow 3rd-party branches, we could even use it to manually trigger a run on those branches (hopefully)