### PR TITLE
fix: AndroidManifest update should remove old items first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Whitespaces no longer cause issues when uploading symbols for Windows native  ([#655](https://github.com/getsentry/sentry-unity/pull/655))
+- AndroidManifest update removes previous `io.sentry` entries ([#652](https://github.com/getsentry/sentry-unity/pull/652))
 
 ## 0.13.0
 

--- a/samples/unity-of-bugs/Assets/Editor/AndroidManifestUpdater.cs
+++ b/samples/unity-of-bugs/Assets/Editor/AndroidManifestUpdater.cs
@@ -16,15 +16,23 @@ public class AndroidManifestUpdater : IPostGenerateGradleAndroidProject
         }
 
         Debug.Log($"AndroidManifestUpdater: Updating {manifestName}");
+        var replacement = "<application android:usesCleartextTraffic=\"true\"";
         var text = File.ReadAllText(manifestPath);
-        var newText = text.Replace("<application", "<application android:usesCleartextTraffic=\"true\"");
-        if (text.Equals(newText))
+        if (text.Contains(replacement))
         {
-            Debug.LogError($"AndroidManifestUpdater: Failed find the <application> tag");
+            Debug.Log($"AndroidManifestUpdater: Already contains the configuration, nothing to do.");
         }
         else
         {
-            File.WriteAllText(manifestPath, newText);
+            var newText = text.Replace("<application", replacement);
+            if (text.Equals(newText))
+            {
+                Debug.LogError($"AndroidManifestUpdater: Failed to update the <application> tag");
+            }
+            else
+            {
+                File.WriteAllText(manifestPath, newText);
+            }
         }
     }
 }

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -236,7 +236,7 @@ namespace Sentry.Unity.Editor.Android
 
         public AndroidManifest(string path, IDiagnosticLogger? logger) : base(path)
         {
-            _applicationElement = (XmlElement) SelectSingleNode("/manifest/application");
+            _applicationElement = (XmlElement)SelectSingleNode("/manifest/application");
             _logger = logger;
         }
 

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -261,6 +261,41 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
+        public void ModifyManifest_RepeatedRunProducesSameResult()
+        {
+            var sut = _fixture.GetSut();
+            var manifest1 = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
+            var manifest2 = WithAndroidManifest((basePath) =>
+            {
+                sut.ModifyManifest(basePath);
+                sut.ModifyManifest(basePath);
+            });
+
+            Debug.Log(manifest2);
+            Assert.True(manifest1.Contains("sentry.dsn"));
+            Assert.AreEqual(manifest1, manifest2);
+        }
+
+        [Test]
+        public void ModifyManifest_RepeatedRunRemovesConfigs()
+        {
+            var fixture2 = new Fixture();
+            fixture2.SentryUnityOptions = null;
+            var manifest1 = WithAndroidManifest(basePath => _fixture.GetSut().ModifyManifest(basePath));
+            var manifest2 = WithAndroidManifest((basePath) =>
+            {
+                _fixture.GetSut().ModifyManifest(basePath);
+                fixture2.GetSut().ModifyManifest(basePath);
+            });
+
+            Debug.Log($"Manifest 1 (before):\n{manifest1}");
+            Debug.Log($"Manifest 2 (after):\n{manifest2}");
+            Assert.True(manifest1.Contains("sentry.dsn"));
+            Assert.False(manifest2.Contains("sentry.dsn"));
+        }
+
+
+        [Test]
         public void SetupSymbolsUpload_ScriptingBackendNotIL2CPP_LogsAndReturns()
         {
             _fixture.ScriptingImplementation = ScriptingImplementation.Mono2x;


### PR DESCRIPTION
fixes #638 

TODO:
* [x] update changelog after https://github.com/getsentry/sentry-unity/commit/fc178572e5f62a7c08fc72d92dd2902e34dc4aa5 is merged