### PR TITLE
Added ability to specify additional debug symbol paths

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
@@ -1,10 +1,24 @@
 using UnityEditor;
+using UnityEditorInternal;
 using UnityEngine;
 
 namespace Sentry.Unity.Editor.ConfigurationWindow
 {
     internal static class DebugSymbolsTab
     {
+        private static readonly ReorderableList SymbolList = new ReorderableList(null, typeof( string ))
+        {
+            drawHeaderCallback = rect => EditorGUI.LabelField(rect, "Additional Symbol Paths"),
+            drawElementCallback = (rect, elementIdx, _, _) =>
+            {
+                rect = EditorGUI.PrefixLabel(rect, new GUIContent($"Element {elementIdx}"));
+
+                var element = SymbolList!.list[elementIdx];
+                var symbolList = EditorGUI.TextField(rect, (string)element);
+                SymbolList.list[elementIdx] = symbolList;
+            }
+        };
+
         internal static void Display(SentryCliOptions cliOptions)
         {
             cliOptions.UploadSymbols = EditorGUILayout.BeginToggleGroup(
@@ -30,6 +44,9 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             cliOptions.Project = EditorGUILayout.TextField(
                 new GUIContent("Project Name", "The project name in Sentry"),
                 cliOptions.Project);
+
+            SymbolList.list = cliOptions.AdditionalSymbolPaths;
+            SymbolList.DoLayoutList();
         }
     }
 }

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -98,6 +98,14 @@ namespace Sentry.Unity.Editor.Native
             // Note: using Path.GetFullPath as suggested by https://docs.unity3d.com/Manual/upm-assets.html
             addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/Windows/Sentry/sentry.pdb"));
 
+            if (cliOptions.AdditionalSymbolPaths != null)
+            {
+                foreach (var symbol in cliOptions.AdditionalSymbolPaths)
+                {
+                    addPath(symbol);
+                }
+            }
+
             // Configure the process using the StartInfo properties.
             var process = new Process
             {

--- a/src/Sentry.Unity.Editor/SentryCliOptions.cs
+++ b/src/Sentry.Unity.Editor/SentryCliOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Sentry.Extensibility;
 using UnityEditor;
 using UnityEngine;
@@ -20,6 +21,7 @@ namespace Sentry.Unity.Editor
         [field: SerializeField] public string? Auth { get; set; }
         [field: SerializeField] public string? Organization { get; set; }
         [field: SerializeField] public string? Project { get; set; }
+        [field: SerializeField] public List<string>? AdditionalSymbolPaths { get; set; }
 
         internal static string GetConfigPath(string? notDefaultConfigName = null)
             => $"Assets/Plugins/Sentry/{notDefaultConfigName ?? ConfigName}.asset";

--- a/src/Sentry.Unity.Editor/SentryCliOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/SentryCliOptionsEditor.cs
@@ -1,10 +1,30 @@
 using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
 
 namespace Sentry.Unity.Editor
 {
     [CustomEditor(typeof(SentryCliOptions))]
     public class SentryCliOptionsEditor : UnityEditor.Editor
     {
+        private ReorderableList? _symbolList;
+
+        private void OnEnable()
+        {
+            _symbolList = new ReorderableList(null, typeof( string ))
+            {
+                drawHeaderCallback = rect => EditorGUI.LabelField(rect, "Additional Symbol Paths"),
+                drawElementCallback = (rect, elementIdx, _, _) =>
+                {
+                    rect = EditorGUI.PrefixLabel(rect, new GUIContent($"Element {elementIdx}"));
+
+                    var element = _symbolList!.list[elementIdx];
+                    var symbolList = EditorGUI.TextField(rect, (string)element);
+                    _symbolList.list[elementIdx] = symbolList;
+                }
+            };
+        }
+
         public override void OnInspectorGUI()
         {
             if (target is not SentryCliOptions cliOptions)
@@ -19,6 +39,9 @@ namespace Sentry.Unity.Editor
             EditorGUILayout.TextField("Auth-Token", cliOptions.Auth);
             EditorGUILayout.TextField("Org-Slug", cliOptions.Organization);
             EditorGUILayout.TextField("Project Name", cliOptions.Project);
+
+            _symbolList!.list = cliOptions.AdditionalSymbolPaths;
+            _symbolList.DoLayoutList();
 
             EditorGUI.EndDisabledGroup();
         }


### PR DESCRIPTION
This change exposes a list in the DebugSymbolsTab and SentryCliOptionsEditor in which the user can enter custom symbol paths.
My personal use case for this is to specify the **lib_burst_generated.pdb** that burst generates during compilation.