### PR TITLE
Added parentheses to symbol paths which are passed to sentry-cli

### DIFF
--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -78,7 +78,7 @@ namespace Sentry.Unity.Editor.Native
                 var fullPath = Path.Combine(projectDir, name);
                 if (Directory.Exists(fullPath) || File.Exists(fullPath))
                 {
-                    paths += " " + name;
+                    paths += $" \"{name}\"";
                     logger.LogDebug($"Adding '{name}' to the debug-info upload");
                     return true;
                 }


### PR DESCRIPTION
Adding parentheses to symbol paths fixes an issue where some symbols wouldn't be picked up when the project had a whitespace in its name.

#skip-changelog