### PR TITLE
Refactor InApp logic from Stack Traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Refactor InApp logic from Stack Traces ([#661](https://github.com/getsentry/sentry-unity/pull/661))
 - Whitespaces no longer cause issues when uploading symbols for Windows native  ([#655](https://github.com/getsentry/sentry-unity/pull/655))
 
 ## 0.13.0

--- a/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
@@ -73,7 +73,7 @@ namespace Sentry.Unity.Integrations
 
             if (stackTrace is not null)
             {
-                var sentryEvent = new SentryEvent(new UnityLogException(condition, stackTrace, _sentryOptions!))
+                var sentryEvent = new SentryEvent(new UnityLogException(condition, stackTrace, _sentryOptions))
                 {
                     Level = ToEventTagType(type)
                 };

--- a/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
@@ -73,7 +73,7 @@ namespace Sentry.Unity.Integrations
 
             if (stackTrace is not null)
             {
-                var sentryEvent = new SentryEvent(new UnityLogException(condition, stackTrace))
+                var sentryEvent = new SentryEvent(new UnityLogException(condition, stackTrace, _sentryOptions!))
                 {
                     Level = ToEventTagType(type)
                 };

--- a/src/Sentry.Unity/UnityLogException.cs
+++ b/src/Sentry.Unity/UnityLogException.cs
@@ -21,7 +21,6 @@ namespace Sentry.Unity
         private SentryOptions? _options { get; }
 
         public UnityLogException(string logString, string logStackTrace, SentryOptions? options)
-
         {
             LogString = logString;
             LogStackTrace = logStackTrace;

--- a/src/Sentry.Unity/UnityLogException.cs
+++ b/src/Sentry.Unity/UnityLogException.cs
@@ -132,7 +132,7 @@ namespace Sentry.Unity
                     Function = functionName,
                     LineNumber = lineNo == -1 ? null : lineNo
                 };
-                if (_options != null)
+                if (_options is not null)
                 {
                     stackFrame.ConfigureAppFrame(_options);
                 }

--- a/src/Sentry.Unity/UnityLogException.cs
+++ b/src/Sentry.Unity/UnityLogException.cs
@@ -20,7 +20,8 @@ namespace Sentry.Unity
 
         private SentryOptions? _options { get; }
 
-        public UnityLogException(string logString, string logStackTrace, SentryOptions options)
+        public UnityLogException(string logString, string logStackTrace, SentryOptions? options)
+
         {
             LogString = logString;
             LogStackTrace = logStackTrace;

--- a/src/Sentry.Unity/UnityLogException.cs
+++ b/src/Sentry.Unity/UnityLogException.cs
@@ -18,6 +18,15 @@ namespace Sentry.Unity
         public string LogString { get; }
         public string LogStackTrace { get; }
 
+        private SentryOptions? _options { get; }
+
+        public UnityLogException(string logString, string logStackTrace, SentryOptions options)
+        {
+            LogString = logString;
+            LogStackTrace = logStackTrace;
+            _options = options;
+        }
+
         public UnityLogException(string logString, string logStackTrace)
         {
             LogString = logString;
@@ -116,16 +125,19 @@ namespace Sentry.Unity
                 }
 
                 var filenameWithoutZeroes = StripZeroes(filename);
-                frames.Add(new SentryStackFrame
+                var stackFrame = new SentryStackFrame
                 {
                     FileName = TryResolveFileNameForMono(filenameWithoutZeroes),
                     AbsolutePath = filenameWithoutZeroes,
                     Function = functionName,
-                    LineNumber = lineNo == -1 ? null : lineNo,
-                    InApp = functionName != null
-                        && !functionName.StartsWith("UnityEngine", StringComparison.Ordinal)
-                        && !functionName.StartsWith("System", StringComparison.Ordinal)
-                });
+                    LineNumber = lineNo == -1 ? null : lineNo
+                };
+                if (_options != null)
+                {
+                    stackFrame.ConfigureAppFrame(_options);
+                }
+
+                frames.Add(stackFrame);
             }
 
             frames.Reverse();

--- a/test/Sentry.Unity.Tests/UnityEventExceptionProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventExceptionProcessorTests.cs
@@ -10,9 +10,11 @@ namespace Sentry.Unity.Tests
         {
             // arrange
             var unityEventProcessor = new UnityEventExceptionProcessor();
+            var options = new SentryUnityOptions();
             var ill2CppUnityLogException = new UnityLogException(
                 "one: two",
-                "BugFarm.ThrowNull () (at <00000000000000000000000000000000>:0)");
+                "BugFarm.ThrowNull () (at <00000000000000000000000000000000>:0)",
+                options);
             var sentryEvent = new SentryEvent();
 
             // act

--- a/test/Sentry.Unity.Tests/UnityLogExceptionTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogExceptionTests.cs
@@ -10,7 +10,7 @@ namespace Sentry.Unity.Tests
         [Test]
         public void ToSentryException_MarkedAsUnhandled()
         {
-            var sentryException = new UnityLogException().ToSentryException();
+            var sentryException = new UnityLogException("", "", new SentryUnityOptions()).ToSentryException();
 
             Assert.IsFalse(sentryException.Mechanism?.Handled);
         }
@@ -21,7 +21,7 @@ namespace Sentry.Unity.Tests
             string logStackTrace,
             SentryException sentryException)
         {
-            var actual = new UnityLogException(logString, logStackTrace).ToSentryException();
+            var actual = new UnityLogException(logString, logStackTrace, new SentryUnityOptions()).ToSentryException();
 
             AssertEqual(sentryException, actual);
         }

--- a/test/Sentry.Unity.Tests/UnityLogExceptionTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogExceptionTests.cs
@@ -374,7 +374,6 @@ Expected: False == True",
 
             var actual = new UnityLogException(logString, logStackTrace, new SentryUnityOptions()).ToSentryException();
 
-
             var firstStackTrace = actual!.Stacktrace!.Frames[0];
             {
                 Assert.AreEqual(0, firstStackTrace.LineNumber);

--- a/test/Sentry.Unity.Tests/UnityLogExceptionTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogExceptionTests.cs
@@ -363,5 +363,46 @@ Expected: False == True",
                 Assert.Null(actual.Mechanism);
             }
         }
+
+        [Test]
+        public void ToSentryException_MonoStackTrace_InAppFalse()
+        {
+            var logString = "TlsException: Handshake failed - error code: UNITYTLS_INTERNAL_ERROR, verify result: UNITYTLS_X509VERIFY_FLAG_NOT_TRUSTED";
+            var expectedMessaage = "Handshake failed - error code: UNITYTLS_INTERNAL_ERROR, verify result: UNITYTLS_X509VERIFY_FLAG_NOT_TRUSTED";
+            var logStackTrace = "Mono.Unity.UnityTlsContext.ProcessHandshake () (at <ef151b6abb5d474cb2c1cb8906a8b5a4>:0)";
+            var expectedFunction = "Mono.Unity.UnityTlsContext.ProcessHandshake ()";
+
+            var actual = new UnityLogException(logString, logStackTrace, new SentryUnityOptions()).ToSentryException();
+
+
+            var firstStackTrace = actual!.Stacktrace!.Frames[0];
+            {
+                Assert.AreEqual(0, firstStackTrace.LineNumber);
+                Assert.AreEqual(expectedMessaage, actual.Value);
+                Assert.False(firstStackTrace.InApp);
+                Assert.AreEqual(expectedFunction, firstStackTrace.Function);
+            }
+        }
+
+        [Test]
+        public void ToSentryException_IncludeMonoStackTrace_InAppTrue()
+        {
+            var logString = "TlsException: Handshake failed - error code: UNITYTLS_INTERNAL_ERROR, verify result: UNITYTLS_X509VERIFY_FLAG_NOT_TRUSTED";
+            var expectedMessaage = "Handshake failed - error code: UNITYTLS_INTERNAL_ERROR, verify result: UNITYTLS_X509VERIFY_FLAG_NOT_TRUSTED";
+            var logStackTrace = "Mono.Unity.UnityTlsContext.ProcessHandshake () (at <ef151b6abb5d474cb2c1cb8906a8b5a4>:0)";
+            var expectedFunction = "Mono.Unity.UnityTlsContext.ProcessHandshake ()";
+
+            var options = new SentryUnityOptions();
+            options.AddInAppInclude("Mono");
+            var actual = new UnityLogException(logString, logStackTrace, options).ToSentryException();
+
+            var firstStackTrace = actual!.Stacktrace!.Frames[0];
+            {
+                Assert.AreEqual(0, firstStackTrace.LineNumber);
+                Assert.AreEqual(expectedMessaage, actual.Value);
+                Assert.True(firstStackTrace.InApp);
+                Assert.AreEqual(expectedFunction, firstStackTrace.Function);
+            }
+        }
     }
 }


### PR DESCRIPTION
This replaces the hardcoded logic to decide if the Frame is InApp or not by the one used by the main SDK.

One question was raising during the development of this PR

Should we add the code
`            System.Diagnostics.Debug.Fail("This UnityLogException constructor should not be used, please use the one that gives the SentryOption as an argument.");
`

On 
```
        internal UnityLogException() : base()
        {
            LogString = "";
            LogStackTrace = "";
        }

        private UnityLogException(string message) : base(message)
        {
            LogString = "";
            LogStackTrace = "";
        }

        private UnityLogException(string message, Exception innerException) : base(message, innerException)
        {
            LogString = "";
            LogStackTrace = "";
        }
```

Since they are not intended to be use by us?

Close #575