### PR TITLE
feat: Added override for Sentry CLI URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Allow configuring the Sentry URL ([#666](https://github.com/getsentry/sentry-unity/pull/666))
+- Adding override for Sentry CLI URL ([#666](https://github.com/getsentry/sentry-unity/pull/666))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Allow configuring the Sentry URL ([#666](https://github.com/getsentry/sentry-unity/pull/666))
+
 ### Fixes
 
 - Whitespaces no longer cause issues when uploading symbols for Windows native  ([#655](https://github.com/getsentry/sentry-unity/pull/655))

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
@@ -19,6 +19,10 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
 
             EditorGUILayout.EndToggleGroup();
 
+            cliOptions.Url = EditorGUILayout.TextField(
+                new GUIContent("Sentry URL", "Fully qualified URL to the Sentry server (defaults to https://sentry.io/)"),
+                cliOptions.Url);
+
             cliOptions.Auth = EditorGUILayout.TextField(
                 new GUIContent("Auth Token", "The authorization token from your user settings in Sentry"),
                 cliOptions.Auth);

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
@@ -19,10 +19,6 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
 
             EditorGUILayout.EndToggleGroup();
 
-            cliOptions.Url = EditorGUILayout.TextField(
-                new GUIContent("Sentry URL", "Fully qualified URL to the Sentry server (defaults to https://sentry.io/)"),
-                cliOptions.Url);
-
             cliOptions.Auth = EditorGUILayout.TextField(
                 new GUIContent("Auth Token", "The authorization token from your user settings in Sentry"),
                 cliOptions.Auth);
@@ -34,6 +30,11 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             cliOptions.Project = EditorGUILayout.TextField(
                 new GUIContent("Project Name", "The project name in Sentry"),
                 cliOptions.Project);
+
+            cliOptions.UrlOverride = EditorGUILayout.TextField(
+                new GUIContent("Override Sentry URL", "Fully qualified URL to the Sentry server " +
+                                                      "(defaults to https://sentry.io/)"),
+                cliOptions.UrlOverride);
         }
     }
 }

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -84,7 +84,7 @@ namespace Sentry.Unity.Editor.Native
                 }
                 else
                 {
-                    logger.LogWarning($"Coudn't find '{name}' - debug symbol upload will be incomplete");
+                    logger.LogWarning($"Couldn't find '{name}' - debug symbol upload will be incomplete");
                     return false;
                 }
             };
@@ -112,6 +112,11 @@ namespace Sentry.Unity.Editor.Native
                     CreateNoWindow = true
                 }
             };
+
+            if (cliOptions.Url != null)
+            {
+                process.StartInfo.EnvironmentVariables["SENTRY_URL"] = cliOptions.Url;
+            }
 
             process.StartInfo.EnvironmentVariables["SENTRY_ORG"] = cliOptions.Organization;
             process.StartInfo.EnvironmentVariables["SENTRY_PROJECT"] = cliOptions.Project;

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -113,9 +113,9 @@ namespace Sentry.Unity.Editor.Native
                 }
             };
 
-            if (cliOptions.Url != null)
+            if (!string.IsNullOrEmpty(cliOptions.UrlOverride))
             {
-                process.StartInfo.EnvironmentVariables["SENTRY_URL"] = cliOptions.Url;
+                process.StartInfo.EnvironmentVariables["SENTRY_URL"] = cliOptions.UrlOverride;
             }
 
             process.StartInfo.EnvironmentVariables["SENTRY_ORG"] = cliOptions.Organization;

--- a/src/Sentry.Unity.Editor/SentryCli.cs
+++ b/src/Sentry.Unity.Editor/SentryCli.cs
@@ -21,9 +21,9 @@ namespace Sentry.Unity.Editor
             var propertiesFile = Path.Combine(propertiesPath, "sentry.properties");
             using var properties = File.CreateText(propertiesFile);
 
-            if (sentryCliOptions.Url != null)
+            if (!string.IsNullOrEmpty(sentryCliOptions.UrlOverride))
             {
-                properties.WriteLine($"defaults.url={sentryCliOptions.Url}");
+                properties.WriteLine($"defaults.url={sentryCliOptions.UrlOverride}");
             }
 
             properties.WriteLine($"defaults.org={sentryCliOptions.Organization}");

--- a/src/Sentry.Unity.Editor/SentryCli.cs
+++ b/src/Sentry.Unity.Editor/SentryCli.cs
@@ -20,6 +20,12 @@ namespace Sentry.Unity.Editor
         {
             var propertiesFile = Path.Combine(propertiesPath, "sentry.properties");
             using var properties = File.CreateText(propertiesFile);
+
+            if (sentryCliOptions.Url != null)
+            {
+                properties.WriteLine($"defaults.url={sentryCliOptions.Url}");
+            }
+
             properties.WriteLine($"defaults.org={sentryCliOptions.Organization}");
             properties.WriteLine($"defaults.project={sentryCliOptions.Project}");
             properties.WriteLine($"auth.token={sentryCliOptions.Auth}");

--- a/src/Sentry.Unity.Editor/SentryCliOptions.cs
+++ b/src/Sentry.Unity.Editor/SentryCliOptions.cs
@@ -17,6 +17,7 @@ namespace Sentry.Unity.Editor
 
         [field: SerializeField] public bool UploadSymbols { get; set; } = true;
         [field: SerializeField] public bool UploadDevelopmentSymbols { get; set; } = false;
+        [field: SerializeField] public string? Url { get; set; }
         [field: SerializeField] public string? Auth { get; set; }
         [field: SerializeField] public string? Organization { get; set; }
         [field: SerializeField] public string? Project { get; set; }

--- a/src/Sentry.Unity.Editor/SentryCliOptions.cs
+++ b/src/Sentry.Unity.Editor/SentryCliOptions.cs
@@ -17,7 +17,7 @@ namespace Sentry.Unity.Editor
 
         [field: SerializeField] public bool UploadSymbols { get; set; } = true;
         [field: SerializeField] public bool UploadDevelopmentSymbols { get; set; } = false;
-        [field: SerializeField] public string? Url { get; set; }
+        [field: SerializeField] public string? UrlOverride { get; set; }
         [field: SerializeField] public string? Auth { get; set; }
         [field: SerializeField] public string? Organization { get; set; }
         [field: SerializeField] public string? Project { get; set; }

--- a/test/Sentry.Unity.Editor.Tests/SentryCliTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/SentryCliTests.cs
@@ -61,7 +61,9 @@ namespace Sentry.Unity.Editor.Tests
         }
 
         [Test]
-        public void CreateSentryProperties_PropertyFileCreatedAndContainsSentryCliOptions()
+        [TestCase("")]
+        [TestCase("urlOverride")]
+        public void CreateSentryProperties_PropertyFileCreatedAndContainsSentryCliOptions(string urlOverride)
         {
             var propertiesDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(propertiesDirectory);
@@ -70,6 +72,7 @@ namespace Sentry.Unity.Editor.Tests
             sentryCliTestOptions.Auth = Guid.NewGuid().ToString();
             sentryCliTestOptions.Organization = Guid.NewGuid().ToString();
             sentryCliTestOptions.Project = Guid.NewGuid().ToString();
+            sentryCliTestOptions.UrlOverride = urlOverride;
 
             SentryCli.CreateSentryProperties(propertiesDirectory, sentryCliTestOptions);
 
@@ -78,6 +81,11 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains(sentryCliTestOptions.Auth, properties);
             StringAssert.Contains(sentryCliTestOptions.Organization, properties);
             StringAssert.Contains(sentryCliTestOptions.Project, properties);
+
+            if (!string.IsNullOrEmpty(sentryCliTestOptions.UrlOverride))
+            {
+                StringAssert.Contains(urlOverride, properties);
+            }
 
             Directory.Delete(propertiesDirectory, true);
         }


### PR DESCRIPTION
This is useful for self-hosted users, as well as for local testing ;-)