### PR TITLE
Feat: desktop crash support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,12 +22,15 @@ package-dev/**/*.meta
 package-dev/**/*.framework
 package-dev/**/*.pdb
 package-dev/**/*.xml
+package-dev/**/*.dylib
+package-dev/**/*.dSYM
 package-dev/**/TestSentryOptions.json
 package-dev/Tests/Editor/TestFiles/
 package-dev/Plugins/*/Sentry/crashpad_handler*
 
 # Adding .meta to control target platforms for all of our DLLs
 !package-dev/**/Sentry*.dll.meta
+!package-dev/**/libsentry.dylib.meta
 
 # required to be marked as iOS only
 !package-dev/**/*.framework.meta

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,7 @@
     <SentryAndroidArtifactsDestination>$(SentryArtifactsDestination)/Android/Sentry/</SentryAndroidArtifactsDestination>
     <!-- Native -->
     <SentryNativeRoot>$(RepoRoot)modules/sentry-native/</SentryNativeRoot>
+    <SentrymacOSArtifactsDestination>$(SentryArtifactsDestination)/macOS/Sentry/</SentrymacOSArtifactsDestination>
     <SentryWindowsArtifactsDestination>$(SentryArtifactsDestination)/Windows/Sentry/</SentryWindowsArtifactsDestination>
   </PropertyGroup>
 
@@ -117,8 +118,9 @@ Expected to exist:
     <RemoveDir Directories="$(SentryAndroidArtifactsDestination)" ContinueOnError="true" />
   </Target>
 
-  <Target Name="CleanWindowsSDK" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
+  <Target Name="CleanNativeSDK" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
     <RemoveDir Directories="$(SentryNativeRoot)build/" ContinueOnError="true" />
+    <RemoveDir Directories="$(SentrymacOSArtifactsDestination)" ContinueOnError="true" />
     <RemoveDir Directories="$(SentryWindowsArtifactsDestination)" ContinueOnError="true" />
   </Target>
 
@@ -168,6 +170,26 @@ Expected to exist:
     <Error Condition="!Exists('$(SentryAndroidArtifactsDestination)')" Text="Failed to build the Android SDK."></Error>
   </Target>
 
+  <!-- Build the Sentry Native SDK for macOS: dotnet msbuild /t:BuildmacOSSDK src/Sentry.Unity -->
+  <Target Name="BuildmacOSSDK" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
+          And $([MSBuild]::IsOsPlatform('OSX'))
+          And !Exists('$(SentrymacOSArtifactsDestination)')" DependsOnTargets="BuildNativeSDK" BeforeTargets="BeforeBuild">
+    <Error Condition="!Exists('$(SentryNativeRoot)')" Text="Couldn't find the Native root at $(SentryNativeRoot)."></Error>
+    <Message Importance="High" Text="Copying artifacts of Sentry Native SDK for macOS to UPM package."></Message>
+
+    <ItemGroup>
+      <NativeSdkArtifacts Include="$(SentryNativeRoot)build/crashpad_build/handler/crashpad_handler" />
+      <NativeSdkArtifacts Include="$(SentryNativeRoot)build/libsentry.dylib" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <NativeSdkDebugSymbols Include="$(SentryNativeRoot)build/libsentry.dylib.dSYM/**/*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(NativeSdkArtifacts)" DestinationFiles="@(NativeSdkArtifacts->'$(SentrymacOSArtifactsDestination)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(NativeSdkDebugSymbols)" DestinationFiles="$(SentrymacOSArtifactsDestination)/libsentry.dylib.dSYM/%(RecursiveDir)%(Filename)%(Extension)" />
+  </Target>
+
   <!-- Build the Sentry Native SDK for Windows: dotnet msbuild /t:BuildWindowsSDK src/Sentry.Unity -->
   <Target Name="BuildWindowsSDK" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
           And $([MSBuild]::IsOsPlatform('Windows'))
@@ -187,7 +209,11 @@ Expected to exist:
   <Target Name="BuildNativeSDK">
     <Error Condition="!Exists('$(SentryNativeRoot)')" Text="Couldn't find the Native root at $(SentryNativeRoot)."></Error>
 
-    <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake -B build -D SENTRY_BACKEND=crashpad -S ."></Exec>
+    <Exec Command="which python3" ConsoleToMSBuild="true" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="PythonExecutable" />
+    </Exec>
+
+    <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake -B build -D SENTRY_BACKEND=crashpad -D CMAKE_OSX_ARCHITECTURES=&quot;arm64;x86_64&quot; -D PYTHON_EXECUTABLE=$(PythonExecutable) -S ."></Exec>
     <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake --build build --target sentry --config RelWithDebInfo --parallel"></Exec>
     <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake --build build --target crashpad_handler --config Release --parallel"></Exec>
   </Target>

--- a/package-dev/Plugins/macOS/Sentry/libsentry.dylib.dSYM/Contents/Resources/DWARF/libsentry.dylib.meta
+++ b/package-dev/Plugins/macOS/Sentry/libsentry.dylib.dSYM/Contents/Resources/DWARF/libsentry.dylib.meta
@@ -1,0 +1,63 @@
+fileFormatVersion: 2
+guid: 600df94d8e1de4988ba93329137e1420
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Plugins/macOS/Sentry/libsentry.dylib.meta
+++ b/package-dev/Plugins/macOS/Sentry/libsentry.dylib.meta
@@ -1,0 +1,81 @@
+fileFormatVersion: 2
+guid: bfb2b5d283ee041ae90a408bd7afd91a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Runtime/Sentry.Unity.Native.dll.meta
+++ b/package-dev/Runtime/Sentry.Unity.Native.dll.meta
@@ -19,7 +19,7 @@ PluginImporter:
         Exclude Android: 1
         Exclude Editor: 0
         Exclude Linux64: 1
-        Exclude OSXUniversal: 1
+        Exclude OSXUniversal: 0
         Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
@@ -53,9 +53,9 @@ PluginImporter:
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: Win
     second:

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -3,8 +3,13 @@
 #define SENTRY_NATIVE_IOS
 #elif UNITY_ANDROID
 #define SENTRY_NATIVE_ANDROID
+// After enabling support for Linux, we can use UNITY_STANDALONE:
+// #elif UNITY_STANDALONE && ENABLE_IL2CPP
+// #define SENTRY_NATIVE_STANDALONE
 #elif UNITY_STANDALONE_WIN && ENABLE_IL2CPP
-#define SENTRY_NATIVE_WINDOWS
+#define SENTRY_NATIVE_STANDALONE
+#elif UNITY_STANDALONE_OSX && ENABLE_IL2CPP
+#define SENTRY_NATIVE_STANDALONE
 #elif UNITY_WEBGL
 #define SENTRY_WEBGL
 #endif
@@ -15,9 +20,9 @@ using UnityEngine.Scripting;
 
 #if SENTRY_NATIVE_IOS
 using Sentry.Unity.iOS;
-#elif UNITY_ANDROID
+#elif SENTRY_NATIVE_ANDROID
 using Sentry.Unity.Android;
-#elif SENTRY_NATIVE_WINDOWS
+#elif SENTRY_NATIVE_STANDALONE
 using Sentry.Unity.Native;
 #elif SENTRY_WEBGL
 using Sentry.Unity.WebGL;
@@ -41,7 +46,7 @@ namespace Sentry.Unity
                 SentryNativeIos.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
                 SentryNativeAndroid.Configure(options, sentryUnityInfo);
-#elif SENTRY_NATIVE_WINDOWS
+#elif SENTRY_NATIVE_STANDALONE
                 SentryNative.Configure(options);
 #elif SENTRY_WEBGL
                 SentryWebGL.Configure(options);

--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -38,6 +38,7 @@ MonoBehaviour:
   <IosNativeSupportEnabled>k__BackingField: 1
   <AndroidNativeSupportEnabled>k__BackingField: 1
   <WindowsNativeSupportEnabled>k__BackingField: 1
+  <MacosNativeSupportEnabled>k__BackingField: 1
   <OptionsConfiguration>k__BackingField: {fileID: 11400000, guid: bda1a724b0875436aade31393b0129c0,
     type: 2}
   <Debug>k__BackingField: 1

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -59,9 +59,12 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                 options.AndroidNativeSupportEnabled);
 
             options.WindowsNativeSupportEnabled = EditorGUILayout.Toggle(
-                new GUIContent("Windows Native Support", "Whether to enable Native Windows support to " +
-                                                         "capture errors written in languages such as C and C++."),
+                new GUIContent("Windows Native Support", "Whether to enable native crashes support on Windows."),
                 options.WindowsNativeSupportEnabled);
+
+            options.MacosNativeSupportEnabled = EditorGUILayout.Toggle(
+                new GUIContent("macOS Native Support", "Whether to enable native crashes support on macOS."),
+                options.MacosNativeSupportEnabled);
         }
 
 

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -13,7 +13,7 @@ namespace Sentry.Unity.Editor.Native
         [PostProcessBuild(1)]
         public static void OnPostProcessBuild(BuildTarget target, string executablePath)
         {
-            if (target is not (BuildTarget.StandaloneWindows or BuildTarget.StandaloneWindows64))
+            if (EditorUserBuildSettings.selectedBuildTargetGroup is not BuildTargetGroup.Standalone)
             {
                 return;
             }
@@ -35,9 +35,9 @@ namespace Sentry.Unity.Editor.Native
                     return;
                 }
 
-                if (!options.WindowsNativeSupportEnabled)
+                if (!IsEnabledForPlatform(target, options))
                 {
-                    logger.LogDebug("Windows Native support disabled through the options.");
+                    logger.LogDebug("Native support for the current platform is disabled in the configuration.");
                     return;
                 }
 
@@ -52,6 +52,13 @@ namespace Sentry.Unity.Editor.Native
                 throw new BuildFailedException("Sentry Native BuildPostProcess failed");
             }
         }
+
+        private static bool IsEnabledForPlatform(BuildTarget target, SentryUnityOptions options) => target switch
+        {
+            BuildTarget.StandaloneWindows64 => options.WindowsNativeSupportEnabled,
+            BuildTarget.StandaloneOSX => options.MacosNativeSupportEnabled,
+            _ => false,
+        };
 
         private static void AddCrashHandler(IDiagnosticLogger logger, string projectDir)
         {

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -65,6 +65,7 @@ namespace Sentry.Unity.Editor
             EditorGUILayout.Toggle("iOS Native Support", options.IosNativeSupportEnabled);
             EditorGUILayout.Toggle("Android Native Support", options.AndroidNativeSupportEnabled);
             EditorGUILayout.Toggle("Windows Native Support", options.WindowsNativeSupportEnabled);
+            EditorGUILayout.Toggle("macOS Native Support", options.MacosNativeSupportEnabled);
 
             EditorGUILayout.Space();
             EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -1,6 +1,7 @@
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Sentry.Unity.Native
 {
@@ -17,7 +18,12 @@ namespace Sentry.Unity.Native
         /// <param name="options">The Sentry Unity options to use.</param>
         public static void Configure(SentryUnityOptions options)
         {
-            if (options.WindowsNativeSupportEnabled)
+            if (ApplicationAdapter.Instance.Platform switch
+            {
+                RuntimePlatform.WindowsPlayer => options.WindowsNativeSupportEnabled,
+                RuntimePlatform.OSXPlayer => options.MacosNativeSupportEnabled,
+                _ => false,
+            })
             {
                 SentryNativeBridge.Init(options);
                 ApplicationAdapter.Instance.Quitting += () =>

--- a/src/Sentry.Unity.Native/SentryNativeBridge.cs
+++ b/src/Sentry.Unity.Native/SentryNativeBridge.cs
@@ -10,16 +10,9 @@ namespace Sentry.Unity
     /// <summary>
     /// P/Invoke to `sentry-native` functions.
     /// </summary>
-    /// <remarks>
-    /// The `sentry-native` SDK on Android is brought in through the `sentry-android-ndk`
-    /// maven package.
-    /// On Standalone players on Windows and Linux it's build directly for those platforms.
-    /// </remarks>
-    /// <see href="https://github.com/getsentry/sentry-java"/>
     /// <see href="https://github.com/getsentry/sentry-native"/>
     public static class SentryNativeBridge
     {
-
         public static bool CrashedLastRun;
 
         public static void Init(SentryUnityOptions options)
@@ -173,19 +166,22 @@ namespace Sentry.Unity
             // vsnprintf (to find out the length of the resulting buffer) & vsprintf (to actually format the message).
             if (message.Contains("%"))
             {
-                var formattedLength = vsnprintf(null, UIntPtr.Zero, message, args);
-                var buffer = new StringBuilder(formattedLength + 1);
-                vsprintf(buffer, message, args);
-                message = buffer.ToString();
+                // TODO macOS & Linux support
+                // var formattedLength = vsnprintf(null, UIntPtr.Zero, message, args);
+                // var buffer = new StringBuilder(formattedLength + 1);
+                // vsprintf(buffer, message, args);
+                // message = buffer.ToString();
             }
             logger.Log(level, $"Native: {message}");
         }
 
-        [DllImport("msvcrt.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int vsprintf(StringBuilder buffer, string format, IntPtr args);
+        // [DllImport("msvcrt.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        // [DllImport("__Internal", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        // private static extern int vsprintf(StringBuilder buffer, string format, IntPtr args);
 
-        [DllImport("msvcrt.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int vsnprintf(string? buffer, UIntPtr bufferSize, string format, IntPtr args);
+        // [DllImport("msvcrt.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        // [DllImport("__Internal", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        // private static extern int vsnprintf(string? buffer, UIntPtr bufferSize, string format, IntPtr args);
 
         [DllImport("sentry")]
         private static extern void sentry_init(IntPtr options);

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -56,6 +56,7 @@ namespace Sentry.Unity
         [field: SerializeField] public bool IosNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool AndroidNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool WindowsNativeSupportEnabled { get; set; } = true;
+        [field: SerializeField] public bool MacosNativeSupportEnabled { get; set; } = true;
 
         [field: SerializeField] public ScriptableOptionsConfiguration? OptionsConfiguration { get; set; }
 
@@ -129,6 +130,7 @@ namespace Sentry.Unity
             options.IosNativeSupportEnabled = scriptableOptions.IosNativeSupportEnabled;
             options.AndroidNativeSupportEnabled = scriptableOptions.AndroidNativeSupportEnabled;
             options.WindowsNativeSupportEnabled = scriptableOptions.WindowsNativeSupportEnabled;
+            options.MacosNativeSupportEnabled = scriptableOptions.MacosNativeSupportEnabled;
 
             options.Debug = scriptableOptions.Debug;
             options.DebugOnlyInEditor = scriptableOptions.DebugOnlyInEditor;

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -43,6 +43,7 @@ namespace Sentry.Unity
             scriptableOptions.IosNativeSupportEnabled = options.IosNativeSupportEnabled;
             scriptableOptions.AndroidNativeSupportEnabled = options.AndroidNativeSupportEnabled;
             scriptableOptions.WindowsNativeSupportEnabled = options.WindowsNativeSupportEnabled;
+            scriptableOptions.MacosNativeSupportEnabled = options.MacosNativeSupportEnabled;
 
             scriptableOptions.Debug = true;
             scriptableOptions.DebugOnlyInEditor = true;

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -38,6 +38,7 @@ namespace Sentry.Unity
                 // On Standalone, we disable cache dir in case multiple app instances run over the same path.
                 // Note: we cannot use a named Mutex, because Unit doesn't support it. Instead, we create a file with `FileShare.None`.
                 // https://forum.unity.com/threads/unsupported-internal-call-for-il2cpp-mutex-createmutex_internal-named-mutexes-are-not-supported.387334/
+                // TODO macOS & Linux implementation
                 if (ApplicationAdapter.Instance.Platform is RuntimePlatform.WindowsPlayer && options.CacheDirectoryPath is not null)
                 {
                     try

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -108,6 +108,11 @@ namespace Sentry.Unity
         /// </summary>
         public bool WindowsNativeSupportEnabled { get; set; } = true;
 
+        /// <summary>
+        /// Whether the SDK should add native support for MacOS
+        /// </summary>
+        public bool MacosNativeSupportEnabled { get; set; } = true;
+
         public SentryUnityOptions() : this(ApplicationAdapter.Instance, false)
         {
         }

--- a/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -44,6 +44,7 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains("IosNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("AndroidNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("WindowsNativeSupportEnabled", optionsAsString);
+            StringAssert.Contains("MacosNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("OptionsConfiguration", optionsAsString);
             StringAssert.Contains("Debug", optionsAsString);
             StringAssert.Contains("DebugOnlyInEditor", optionsAsString);


### PR DESCRIPTION
This was the first stab at native support for non-windows platforms. Since then, the approach for mac has changed (twice now) and is implemented by #710. After mac support is merged, this PR needs to be updated because there are conflicts. Afterwards, this will become a PR for the Linux support.

* ~macOS support - closes #693~ - now replaced by #710
   - https://sentry.io/organizations/sentry-sdks/issues/3216781947/?project=5439417&query=is%3Aunresolved
   - https://sentry.io/organizations/sentry-sdks/issues/3216795055/?project=5439417&query=is%3Aunresolved~
* Linux support - closes #694