### PR TITLE
fix: DebugOnlyInEditor applies to .NET SDK

### DIFF
--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -99,14 +99,10 @@ namespace Sentry.Unity.Editor.Android
 
             options.DiagnosticLogger?.LogDebug("Setting DSN: {0}", options.Dsn);
             androidManifest.SetDsn(options.Dsn!);
-            if (!options.DebugOnlyInEditor)
+            if (options.Debug)
             {
                 options.DiagnosticLogger?.LogDebug("Setting Debug: {0}", options.Debug);
                 androidManifest.SetDebug(options.Debug);
-            }
-            else
-            {
-                options.DiagnosticLogger?.LogDebug("Not setting debug flag because DebugOnlyInEditor is true");
             }
 
             if (options.Release is not null)

--- a/src/Sentry.Unity/Json/JsonSentryUnityOptions.cs
+++ b/src/Sentry.Unity/Json/JsonSentryUnityOptions.cs
@@ -35,10 +35,6 @@ namespace Sentry.Unity.Json
             {
                 options.Debug = debug.GetBoolean();
             }
-            if (json.GetPropertyOrNull("debugOnlyInEditor") is { } debugOnlyInEditor)
-            {
-                options.DebugOnlyInEditor = debugOnlyInEditor.GetBoolean();
-            }
             if (json.GetEnumOrNull<SentryLevel>("diagnosticLevel") is { } diagnosticLevel)
             {
                 options.DiagnosticLevel = diagnosticLevel;
@@ -81,7 +77,6 @@ namespace Sentry.Unity.Json
 
             scriptableOptions.CaptureInEditor = jsonOptions.CaptureInEditor;
             scriptableOptions.Debug = jsonOptions.Debug;
-            scriptableOptions.DebugOnlyInEditor = jsonOptions.DebugOnlyInEditor;
             scriptableOptions.DiagnosticLevel = jsonOptions.DiagnosticLevel;
             scriptableOptions.AttachStacktrace = jsonOptions.AttachStacktrace;
 

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -130,8 +130,9 @@ namespace Sentry.Unity
             options.AndroidNativeSupportEnabled = scriptableOptions.AndroidNativeSupportEnabled;
             options.WindowsNativeSupportEnabled = scriptableOptions.WindowsNativeSupportEnabled;
 
-            options.Debug = scriptableOptions.Debug;
-            options.DebugOnlyInEditor = scriptableOptions.DebugOnlyInEditor;
+            // Because SentryOptions.Debug is used inside the .NET SDK to setup the ConsoleLogger we
+            // need to set it here directly.
+            options.Debug = ShouldDebug(scriptableOptions, application.IsEditor && !isBuilding);
             options.DiagnosticLevel = scriptableOptions.DiagnosticLevel;
 
             SentryOptionsUtility.TryAttachLogger(options);
@@ -139,6 +140,16 @@ namespace Sentry.Unity
             scriptableOptions.OptionsConfiguration?.Configure(options);
 
             return options;
+        }
+
+        internal static bool ShouldDebug(ScriptableSentryUnityOptions scriptableOptions, bool isEditorPlayer)
+        {
+            if (!isEditorPlayer)
+            {
+                return !scriptableOptions.DebugOnlyInEditor && scriptableOptions.Debug;
+            }
+
+            return scriptableOptions.Debug;
         }
     }
 }

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using Sentry.Unity.Integrations;
+using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -53,9 +54,7 @@ namespace Sentry.Unity
         {
             application ??= ApplicationAdapter.Instance;
 
-            if (options.DiagnosticLogger is null
-                && options.Debug
-                && (!options.DebugOnlyInEditor || application.IsEditor))
+            if (options.Debug && options.DiagnosticLogger is null)
             {
                 options.DiagnosticLogger = new UnityLogger(options);
             }

--- a/src/Sentry.Unity/SentryOptionsUtility.cs
+++ b/src/Sentry.Unity/SentryOptionsUtility.cs
@@ -1,7 +1,4 @@
-using System.Linq;
-using System.Text.RegularExpressions;
 using Sentry.Unity.Integrations;
-using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -50,10 +47,8 @@ namespace Sentry.Unity
             scriptableOptions.DiagnosticLevel = SentryLevel.Warning;
         }
 
-        public static void TryAttachLogger(SentryUnityOptions options, IApplication? application = null)
+        public static void TryAttachLogger(SentryUnityOptions options)
         {
-            application ??= ApplicationAdapter.Instance;
-
             if (options.Debug && options.DiagnosticLogger is null)
             {
                 options.DiagnosticLogger = new UnityLogger(options);

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -39,11 +39,6 @@ namespace Sentry.Unity
         /// </summary>
         public bool EnableLogDebouncing { get; set; } = false;
 
-        /// <summary>
-        /// Whether the SDK should be in <see cref="Debug"/> mode only while in the Unity Editor.
-        /// </summary>
-        public bool DebugOnlyInEditor { get; set; }
-
         private CompressionLevelWithAuto _requestBodyCompressionLevel = CompressionLevelWithAuto.Auto;
 
         /// <summary>

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -143,23 +143,6 @@ namespace Sentry.Unity.Editor.Tests.Android
                 $"Expected 'DSN' in Manifest:\n{manifest}");
         }
 
-        // [Test]
-        // [TestCase(false)]
-        // [TestCase(true)]
-        // public void ModifyManifest_DebugOnlyInEditor_ControlsDebugMode(bool debugOnlyInEditor)
-        // {
-        //     _fixture.SentryUnityOptions!.DebugOnlyInEditor = debugOnlyInEditor;
-        //     // Debug Only In Editor means: Don't set debug=true in any player build
-        //     var expectDebugFlag = !debugOnlyInEditor;
-        //
-        //     var sut = _fixture.GetSut();
-        //     var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
-        //
-        //     Assert.AreEqual(expectDebugFlag, manifest.Contains(
-        //             "<meta-data android:name=\"io.sentry.debug\""),
-        //         $"'debug' in Manifest:\n{manifest}");
-        // }
-
         [Test]
         public void ModifyManifest_ReleaseIsNull_ReleaseNotSet()
         {

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -143,22 +143,22 @@ namespace Sentry.Unity.Editor.Tests.Android
                 $"Expected 'DSN' in Manifest:\n{manifest}");
         }
 
-        [Test]
-        [TestCase(false)]
-        [TestCase(true)]
-        public void ModifyManifest_DebugOnlyInEditor_ControlsDebugMode(bool debugOnlyInEditor)
-        {
-            _fixture.SentryUnityOptions!.DebugOnlyInEditor = debugOnlyInEditor;
-            // Debug Only In Editor means: Don't set debug=true in any player build
-            var expectDebugFlag = !debugOnlyInEditor;
-
-            var sut = _fixture.GetSut();
-            var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
-
-            Assert.AreEqual(expectDebugFlag, manifest.Contains(
-                    "<meta-data android:name=\"io.sentry.debug\""),
-                $"'debug' in Manifest:\n{manifest}");
-        }
+        // [Test]
+        // [TestCase(false)]
+        // [TestCase(true)]
+        // public void ModifyManifest_DebugOnlyInEditor_ControlsDebugMode(bool debugOnlyInEditor)
+        // {
+        //     _fixture.SentryUnityOptions!.DebugOnlyInEditor = debugOnlyInEditor;
+        //     // Debug Only In Editor means: Don't set debug=true in any player build
+        //     var expectDebugFlag = !debugOnlyInEditor;
+        //
+        //     var sut = _fixture.GetSut();
+        //     var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
+        //
+        //     Assert.AreEqual(expectDebugFlag, manifest.Contains(
+        //             "<meta-data android:name=\"io.sentry.debug\""),
+        //         $"'debug' in Manifest:\n{manifest}");
+        // }
 
         [Test]
         public void ModifyManifest_ReleaseIsNull_ReleaseNotSet()

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptions.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptions.cs
@@ -95,7 +95,6 @@ namespace Sentry.Unity.Tests
                 Release = "testRelease",
                 Environment = "testEnvironment",
                 Debug = true,
-                DebugOnlyInEditor = true,
                 DiagnosticLevel = SentryLevel.Info,
             };
 
@@ -125,12 +124,25 @@ namespace Sentry.Unity.Tests
             scriptableOptions.ReleaseOverride = expectedOptions.Release;
             scriptableOptions.EnvironmentOverride = expectedOptions.Environment;
             scriptableOptions.Debug = expectedOptions.Debug;
-            scriptableOptions.DebugOnlyInEditor = expectedOptions.DebugOnlyInEditor;
             scriptableOptions.DiagnosticLevel = expectedOptions.DiagnosticLevel;
 
             var optionsActual = ScriptableSentryUnityOptions.ToSentryUnityOptions(scriptableOptions, isBuilding, _fixture.Application);
 
             AssertOptions(expectedOptions, optionsActual);
+        }
+
+        [Test]
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void ShouldDebug_DebugOnlyInEditor_ReturnsExpectedDebug(bool isEditorPlayer, bool expectedDebug)
+        {
+            var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+            scriptableOptions.Debug = true;
+            scriptableOptions.DebugOnlyInEditor = true;
+
+            var actualDebug = ScriptableSentryUnityOptions.ShouldDebug(scriptableOptions, isEditorPlayer);
+
+            Assert.AreEqual(expectedDebug, actualDebug);
         }
 
         [Test]
@@ -145,23 +157,6 @@ namespace Sentry.Unity.Tests
             ScriptableSentryUnityOptions.ToSentryUnityOptions(scriptableOptions, isBuilding);
 
             Assert.IsTrue(optionsConfiguration.GotCalled);
-        }
-
-        [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void ToScriptableOptions_ConvertJsonOptions_AreEqual(bool isBuilding)
-        {
-            var jsonTextAsset = new TextAsset(File.ReadAllText(GetTestOptionsFilePath()));
-            var expectedOptions = JsonSentryUnityOptions.LoadFromJson(jsonTextAsset);
-
-            var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
-            SentryOptionsUtility.SetDefaults(scriptableOptions);
-            JsonSentryUnityOptions.ToScriptableOptions(jsonTextAsset, scriptableOptions);
-
-            var actualOptions = ScriptableSentryUnityOptions.ToSentryUnityOptions(scriptableOptions, isBuilding);
-
-            AssertOptions(expectedOptions, actualOptions);
         }
 
         public static void AssertOptions(SentryUnityOptions expected, SentryUnityOptions actual)
@@ -191,7 +186,6 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(expected.Environment, actual.Environment);
             Assert.AreEqual(expected.CacheDirectoryPath, actual.CacheDirectoryPath);
             Assert.AreEqual(expected.Debug, actual.Debug);
-            Assert.AreEqual(expected.DebugOnlyInEditor, actual.DebugOnlyInEditor);
             Assert.AreEqual(expected.DiagnosticLevel, actual.DiagnosticLevel);
         }
 

--- a/test/Sentry.Unity.Tests/Stubs/TestApplication.cs
+++ b/test/Sentry.Unity.Tests/Stubs/TestApplication.cs
@@ -23,7 +23,7 @@ namespace Sentry.Unity.Tests.Stubs
         public event Application.LogCallback? LogMessageReceived;
         public event Action? Quitting;
         public string ActiveSceneName => "TestSceneName";
-        public bool IsEditor { set; get; }
+        public bool IsEditor { get; }
         public string ProductName { get; }
         public string Version { get; }
         public string PersistentDataPath { get; }

--- a/test/Sentry.Unity.Tests/Stubs/TestApplication.cs
+++ b/test/Sentry.Unity.Tests/Stubs/TestApplication.cs
@@ -23,7 +23,7 @@ namespace Sentry.Unity.Tests.Stubs
         public event Application.LogCallback? LogMessageReceived;
         public event Action? Quitting;
         public string ActiveSceneName => "TestSceneName";
-        public bool IsEditor { get; }
+        public bool IsEditor { set; get; }
         public string ProductName { get; }
         public string Version { get; }
         public string PersistentDataPath { get; }


### PR DESCRIPTION
This would be a breaking change and removes `DebugOnlyInEditor` from SentryOptions.

Until now `DebugOnlyInEditor` applied to the Unity SDK only, leading to logs showing up on the console regardless.
[SetupLogging](https://github.com/getsentry/sentry-dotnet/blob/35b72f296ea000bfc5ee31a7264701cffff39437/src/Sentry/SentryOptionsExtensions.cs#L236) checks for `Debug` and attaches a Console Logger regardless of `DebugOnlyInEditor`.

So the idea is to have `DebugOnlyInEditor` exist exclusively on the ScriptableObject and apply to `Debug` when the SentryOptions get created.

