### PR TITLE
feat: build macOS SDK as a dylib from sentry-cocoa

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,5 @@ BasedOnStyle: WebKit
 IndentWidth: 4
 IndentPPDirectives: AfterHash
 ColumnLimit: 100
-AlwaysBreakAfterDefinitionReturnType: All
 PointerAlignment: Right
 ForEachMacros: ['SENTRY_WITH_SCOPE', 'SENTRY_WITH_SCOPE_MUT']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       target: iOS
       runsOn: macos-latest
 
+  macos-sdk:
+    uses: ./.github/workflows/sdk.yml
+    with:
+      target: macOS
+      runsOn: macos-latest
+
   windows-sdk:
     uses: ./.github/workflows/sdk.yml
     with:
@@ -88,6 +94,12 @@ jobs:
         with:
           name: iOS-sdk
           path: package-dev/Plugins/iOS
+          wait-timeout: 3600
+
+      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+        with:
+          name: macOS-sdk
+          path: package-dev/Plugins/macOS
           wait-timeout: 3600
 
       - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,11 +311,6 @@ jobs:
           New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
           Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
 
-      # Step used to reduce the Unity path to avoid long path errors on Windows.
-      - name: Make symbolic link for Unity (Windows)
-        if: matrix.os == 'windows'
-        run: New-Item -ItemType SymbolicLink -Path "C:\${{ steps.env.outputs.unityVersion }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ steps.env.outputs.unityVersion }}"
-
       - name: Create new Project
         run: ./test/Scripts.Integration.Test/integration-create-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
         run: ./test/Scripts.Tests/test-pack-contents.ps1
 
   desktop-smoke-test:
-    name: Run  ${{ matrix.os }} Unity ${{ matrix.unity-version }} Smoke Test
+    name: Run  ${{ matrix.os }} Smoke Test - ${{ matrix.unity-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -317,10 +317,10 @@ jobs:
         run: New-Item -ItemType SymbolicLink -Path "C:\${{ steps.env.outputs.unityVersion }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ steps.env.outputs.unityVersion }}"
 
       - name: Create new Project
-        run: ./test/Scripts.Integration.Test/integration-create-project.ps1 "${{ env.UNITY_PATH }}"
+        run: ./test/Scripts.Integration.Test/integration-create-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Build Standalone Player without Sentry SDK
-        run: ./test/Scripts.Integration.Test/integration-build-project.ps1 "${{ env.UNITY_PATH }}"
+        run: ./test/Scripts.Integration.Test/integration-build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Download UPM package
         uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
@@ -333,10 +333,10 @@ jobs:
         run: ./test/Scripts.Integration.Test/integration-extract-package.ps1
 
       - name: Add Sentry to test project
-        run: ./test/Scripts.Integration.Test/integration-update-sentry.ps1 "${{ env.UNITY_PATH }}"
+        run: ./test/Scripts.Integration.Test/integration-update-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Build Standalone Player Sentry SDK
-        run: ./test/Scripts.Integration.Test/integration-build-project.ps1 "${{ env.UNITY_PATH }}"
+        run: ./test/Scripts.Integration.Test/integration-build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Run Player - Smoke Test
         run: ./test/Scripts.Integration.Test/integration-run-smoke-test.ps1 -Smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,16 +272,21 @@ jobs:
         # pwsh ./test/Scripts.Tests/test-pack-contents.ps1 accept
         run: ./test/Scripts.Tests/test-pack-contents.ps1
 
-  windows-smoke-test:
-    name: Run Windows Unity ${{ matrix.unity-version }} Smoke Test
-    runs-on: windows-latest
+  desktop-smoke-test:
+    name: Run  ${{ matrix.os }} Unity ${{ matrix.unity-version }} Smoke Test
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         unity-version: ['2019', '2020', '2021']
+        os: ['windows', 'macos']
         include:
-          - os: windows-latest
+          - os: windows
+            unity-modules: windows-il2cpp
             unity-config-path: C:/ProgramData/Unity/config/
+          - os: macos
+            unity-modules: mac-il2cpp
+            unity-config-path: /Library/Application Support/Unity/config/
     defaults:
       run:
         shell: pwsh
@@ -293,20 +298,11 @@ jobs:
         id: env
         run: echo "::set-output name=unityVersion::$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")"
 
-      # Caching the whole Unity installation would overflow the 10 GiB limit repositories have but we can cache the Hub
-      # to achieve some speedup here at a low size cost.
-      # See https://github.com/kuler90/setup-unity/blob/797ebd0cc9d0e0ca5bcd6cc280ec1a6e685fbf83/src/setup.js#L36
-      - name: Cache Unity Hub
-        uses: actions/cache@v2
-        with:
-          path: 'C:/Program Files/Unity Hub'
-          key: unity-hub|windows
-
       - name: Setup Unity
         uses: getsentry/setup-unity@46c2e082d98cc3a825a5b59038cb31705fe9ff56
         with:
           unity-version: ${{ steps.env.outputs.unityVersion }}
-          unity-modules: windows-il2cpp
+          unity-modules: ${{ matrix.unity-modules }}
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -317,6 +313,7 @@ jobs:
 
       # Step used to reduce the Unity path to avoid long path errors on Windows.
       - name: Make symbolic link for Unity (Windows)
+        if: matrix.os == 'windows'
         run: New-Item -ItemType SymbolicLink -Path "C:\${{ steps.env.outputs.unityVersion }}" -Target "C:\Program Files\Unity\Hub\Editor\${{ steps.env.outputs.unityVersion }}"
 
       - name: Create new Project

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           if [[ "${{ inputs.target }}" == "Android" ]]; then
             submodules="modules/sentry-java"
-          elif [[ "${{ inputs.target }}" == "iOS" ]]; then
+          elif [[ "${{ inputs.target }}" == "iOS" || "${{ inputs.target }}" == "macOS"  ]]; then
             submodules="modules/sentry-cocoa"
           else
             submodules="modules/sentry-native"

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -32,7 +32,7 @@ jobs:
           path: |
             package-dev/Plugins
             modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
-          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets') }}
+          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'package-dev/Plugins/${{ inputs.target }}/**') }}
 
       - name: Checkout submodules
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Get submodules status
         run: git submodule status | tee submodules-status
 
+      - run: cp -r package-dev/Plugins/${{ inputs.target }} sdk-static || echo "never mind, no files checked in..."
+        shell: bash
+
       - name: Restore from cache
         uses: actions/cache@v2
         id: cache
@@ -32,7 +35,7 @@ jobs:
           path: |
             package-dev/Plugins
             modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
-          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'package-dev/Plugins/${{ inputs.target }}/**') }}
+          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
 
       - name: Checkout submodules
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ package-dev/**/*.meta
 package-dev/**/*.framework
 package-dev/**/*.pdb
 package-dev/**/*.xml
+package-dev/**/*.dylib
+package-dev/**/*.dSYM
 package-dev/**/TestSentryOptions.json
 package-dev/Tests/Editor/TestFiles/
 package-dev/Plugins/*/Sentry/crashpad_handler*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- macOS native crash support ([#710](https://github.com/getsentry/sentry-unity/pull/710))
 - The SentryUnityOptions now provide a method to disable the UnityLoggingIntegration ([#724](https://github.com/getsentry/sentry-unity/pull/724))
 
 ### Fixes

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,10 +15,11 @@
     <UnityTestPlayModeResultFilePath>../../artifacts/test/playmode/results.xml</UnityTestPlayModeResultFilePath>
     <UnityTestEditModeResultFilePath>../../artifacts/test/editmode/results.xml</UnityTestEditModeResultFilePath>
     <SentryArtifactsDestination>$(RepoRoot)package-dev/Plugins/</SentryArtifactsDestination>
-    <!-- Cocoa -->
+    <!-- iOS -->
     <SentryCocoaRoot>$(RepoRoot)modules/sentry-cocoa/</SentryCocoaRoot>
     <SentryiOSDeviceArtifactsDestination>$(SentryArtifactsDestination)/iOS/Device/Sentry.framework/</SentryiOSDeviceArtifactsDestination>
     <SentryiOSSimulatorArtifactsDestination>$(SentryArtifactsDestination)/iOS/Simulator/Sentry.framework/</SentryiOSSimulatorArtifactsDestination>
+    <SentrymacOSArtifactsDestination>$(SentryArtifactsDestination)/macOS/Sentry/</SentrymacOSArtifactsDestination>
     <!-- Android -->
     <SentryAndroidRoot>$(RepoRoot)modules/sentry-java/</SentryAndroidRoot>
     <SentryAndroidArtifactsDestination>$(SentryArtifactsDestination)/Android/Sentry/</SentryAndroidArtifactsDestination>
@@ -107,6 +108,7 @@ Expected to exist:
   </Target>
 
   <Target Name="CleaniOSSDK" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
+    <RemoveDir Directories="$(SentryCocoaRoot)Carthage" ContinueOnError="true" />
     <RemoveDir Directories="$(SentryiOSDeviceArtifactsDestination)" ContinueOnError="true" />
     <RemoveDir Directories="$(SentryiOSSimulatorArtifactsDestination)" ContinueOnError="true" />
   </Target>
@@ -115,6 +117,12 @@ Expected to exist:
     <!-- The jar file is version appended and we copy by glob so to avoid duplicates: -->
     <RemoveDir Directories="$(SentryAndroidRoot)sentry/build/libs/" ContinueOnError="true" />
     <RemoveDir Directories="$(SentryAndroidArtifactsDestination)" ContinueOnError="true" />
+  </Target>
+
+  <Target Name="CleanmacOSSDK" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
+    <RemoveDir Directories="$(SentryCocoaRoot)Carthage/Build/Mac" ContinueOnError="true" />
+    <Delete Files="$(SentrymacOSArtifactsDestination)/Sentry.dylib" ContinueOnError="true" />
+    <Delete Files="$(SentrymacOSArtifactsDestination)/Sentry.dylib.dSYM" ContinueOnError="true" />
   </Target>
 
   <Target Name="CleanWindowsSDK" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
@@ -143,8 +151,20 @@ Expected to exist:
     <Copy SourceFiles="@(iOSSimulatorBuildPath)" DestinationFiles="@(iOSSimulatorBuildPath->'$(SentryiOSSimulatorArtifactsDestination)%(RecursiveDir)%(Filename)%(Extension)')">
     </Copy>
 
-    <Error Condition="(!Exists('$(SentryiOSDeviceArtifactsDestination)') OR !Exists('$(SentryiOSSimulatorArtifactsDestination)'))" Text="Failed to build the Cocoa SDK.">
-    </Error>
+    <Error Condition="(!Exists('$(SentryiOSDeviceArtifactsDestination)') OR !Exists('$(SentryiOSSimulatorArtifactsDestination)'))" Text="Failed to build the iOS SDK." />
+  </Target>
+
+  <!-- Build the macOS SDK: dotnet msbuild /t:BuildmacOSSDK src/Sentry.Unity -->
+  <Target Name="BuildmacOSSDK" BeforeTargets="BeforeBuild" Condition="$([MSBuild]::IsOSPlatform('OSX'))
+          And '$(MSBuildProjectName)' == 'Sentry.Unity'
+          And (!Exists('$(SentrymacOSArtifactsDestination)/Sentry.dylib') Or !Exists('$(SentrymacOSArtifactsDestination)/Sentry.dylib.dSYM'))">
+    <Error Condition="!Exists('$(SentryCocoaRoot)')" Text="Couldn't find the Cocoa root at $(SentryCocoaRoot)."></Error>
+    <Message Importance="High" Text="Building Sentry macOS SDK."></Message>
+
+    <Exec WorkingDirectory="$(SentryCocoaRoot)" Command="carthage build --no-skip-current --platform macOS"></Exec>
+
+    <Copy SourceFiles="$(SentryCocoaRoot)Carthage/Build/Mac/Sentry.framework/Sentry" DestinationFiles="$(SentrymacOSArtifactsDestination)/Sentry.dylib" />
+    <Copy SourceFiles="$(SentryCocoaRoot)Carthage/Build/Mac/Sentry.framework.dSYM/Contents/Resources/DWARF/Sentry" DestinationFiles="$(SentrymacOSArtifactsDestination)/Sentry.dylib.dSYM" />
   </Target>
 
   <!-- Build the Android SDK: dotnet msbuild /t:BuildAndroidSDK src/Sentry.Unity -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,7 +15,7 @@
     <UnityTestPlayModeResultFilePath>../../artifacts/test/playmode/results.xml</UnityTestPlayModeResultFilePath>
     <UnityTestEditModeResultFilePath>../../artifacts/test/editmode/results.xml</UnityTestEditModeResultFilePath>
     <SentryArtifactsDestination>$(RepoRoot)package-dev/Plugins/</SentryArtifactsDestination>
-    <!-- iOS -->
+    <!-- Cocoa -->
     <SentryCocoaRoot>$(RepoRoot)modules/sentry-cocoa/</SentryCocoaRoot>
     <SentryiOSDeviceArtifactsDestination>$(SentryArtifactsDestination)/iOS/Device/Sentry.framework/</SentryiOSDeviceArtifactsDestination>
     <SentryiOSSimulatorArtifactsDestination>$(SentryArtifactsDestination)/iOS/Simulator/Sentry.framework/</SentryiOSSimulatorArtifactsDestination>
@@ -521,6 +521,7 @@ void PrintFailedTests(XElement element)
     <ItemGroup>
       <SDK Include="Windows"/>
       <SDK Include="iOS"/>
+      <SDK Include="macOS"/>
       <SDK Include="Android"/>
     </ItemGroup>
     <Message Importance="High" Text="Replacing $(SentryArtifactsDestination)%(SDK.Identity)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,8 +40,6 @@
       <UnityRoot Condition="Exists('C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Hub\Editor\$(UnityVersion)\Editor</UnityRoot>
       <!--If not using Unity Hub, tries to pick whatever Unity version is installed on the machine-->
       <UnityRoot Condition="$(UnityRoot) == '' AND Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor</UnityRoot>
-      <!--Short version for GitHub Actions to avoid long path names errors on Windows-->
-      <UnityRoot Condition="Exists('C:\$(UnityVersion)\Editor\Data\Managed\UnityEngine.dll')">C:\$(UnityVersion)\Editor</UnityRoot>
       <UnityManagedPath>$(UnityRoot)\Data\Managed</UnityManagedPath>
       <UnityExec>&quot;$(UnityRoot)\Unity.exe&quot;</UnityExec>
       <StandaloneBuildMethod>Builder.BuildWindowsIl2CPPPlayer</StandaloneBuildMethod>

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -2,31 +2,51 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// must be here to match the native bridge API for macOS
-int SentryNativeBridgeInit() {
-    return 0; // this shouldn't be used so return "false"
+int SentryNativeBridgeLoadLibrary()
+{
+    // macOS only
 }
 
-int SentryNativeBridgeCrashedLastRun() {
-    return [SentrySDK crashedLastRun] ? 1 : 0;
+void *SentryNativeBridgeOptionsNew()
+{
+    // macOS only
 }
 
-void SentryNativeBridgeClose() {
-    [SentrySDK close];
+void SentryNativeBridgeOptionsSetString(void *options, const char *name, const char *value)
+{
+    // macOS only
 }
 
-void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message, const char* type, const char* category, int level) {
+void SentryNativeBridgeOptionsSetInt(void *options, const char *name, int32_t value)
+{
+    // macOS only
+}
+
+void SentryNativeBridgeStartWithOptions(void *options)
+{
+    // macOS only
+}
+
+int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 : 0; }
+
+void SentryNativeBridgeClose() { [SentrySDK close]; }
+
+void SentryNativeBridgeAddBreadcrumb(
+    const char *timestamp, const char *message, const char *type, const char *category, int level)
+{
     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
         return;
     }
 
-    [SentrySDK configureScope:^(SentryScope * scope) {
+    [SentrySDK configureScope:^(SentryScope *scope) {
         SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] init];
 
         if (timestamp != NULL) {
             NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
             [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
-            breadcrumb.timestamp = [dateFormatter dateFromString:[NSString stringWithCString:timestamp encoding:NSUTF8StringEncoding]];
+            breadcrumb.timestamp =
+                [dateFormatter dateFromString:[NSString stringWithCString:timestamp
+                                                                 encoding:NSUTF8StringEncoding]];
         }
 
         if (message != NULL) {
@@ -38,7 +58,8 @@ void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message,
         }
 
         if (category != NULL) {
-            breadcrumb.category = [NSString stringWithCString:category encoding:NSUTF8StringEncoding];
+            breadcrumb.category = [NSString stringWithCString:category
+                                                     encoding:NSUTF8StringEncoding];
         }
 
         breadcrumb.level = level;
@@ -47,50 +68,56 @@ void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message,
     }];
 }
 
-void SentryNativeBridgeSetExtra(const char* key, const char* value) {
+void SentryNativeBridgeSetExtra(const char *key, const char *value)
+{
     if (key == NULL) {
         return;
     }
 
-    [SentrySDK configureScope:^(SentryScope * scope) {
+    [SentrySDK configureScope:^(SentryScope *scope) {
         if (value != NULL) {
-            [scope setExtraValue:[NSString stringWithUTF8String:value] forKey:[NSString stringWithUTF8String:key]];
+            [scope setExtraValue:[NSString stringWithUTF8String:value]
+                          forKey:[NSString stringWithUTF8String:key]];
         } else {
             [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
         }
     }];
 }
 
-void SentryNativeBridgeSetTag(const char* key, const char* value) {
+void SentryNativeBridgeSetTag(const char *key, const char *value)
+{
     if (key == NULL) {
         return;
     }
 
-    [SentrySDK configureScope:^(SentryScope * scope) {
+    [SentrySDK configureScope:^(SentryScope *scope) {
         if (value != NULL) {
-            [scope setTagValue:[NSString stringWithUTF8String:value] forKey:[NSString stringWithUTF8String:key]];
+            [scope setTagValue:[NSString stringWithUTF8String:value]
+                        forKey:[NSString stringWithUTF8String:key]];
         } else {
             [scope removeTagForKey:[NSString stringWithUTF8String:key]];
         }
     }];
 }
 
-void SentryNativeBridgeUnsetTag(const char* key) {
+void SentryNativeBridgeUnsetTag(const char *key)
+{
     if (key == NULL) {
         return;
     }
 
-    [SentrySDK configureScope:^(SentryScope * scope) {
-        [scope removeTagForKey:[NSString stringWithUTF8String:key]];
-    }];
+    [SentrySDK configureScope:^(
+        SentryScope *scope) { [scope removeTagForKey:[NSString stringWithUTF8String:key]]; }];
 }
 
-void SentryNativeBridgeSetUser(const char* email, const char* userId, const char* ipAddress, const char* username) {
+void SentryNativeBridgeSetUser(
+    const char *email, const char *userId, const char *ipAddress, const char *username)
+{
     if (email == NULL && userId == NULL && ipAddress == NULL && username == NULL) {
         return;
     }
 
-    [SentrySDK configureScope:^(SentryScope * scope) {
+    [SentrySDK configureScope:^(SentryScope *scope) {
         SentryUser *user = [[SentryUser alloc] init];
 
         if (email != NULL) {
@@ -113,10 +140,9 @@ void SentryNativeBridgeSetUser(const char* email, const char* userId, const char
     }];
 }
 
-void SentryNativeBridgeUnsetUser() {
-    [SentrySDK configureScope:^(SentryScope * scope) {
-        [scope setUser:nil];
-    }];
+void SentryNativeBridgeUnsetUser()
+{
+    [SentrySDK configureScope:^(SentryScope *scope) { [scope setUser:nil]; }];
 }
 
 NS_ASSUME_NONNULL_END

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -2,49 +2,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-int SentryNativeBridgeLoadLibrary()
-{
-    // macOS only
-}
+// macOS only
+int SentryNativeBridgeLoadLibrary() { return 0; }
+void *SentryNativeBridgeOptionsNew() { return nil; }
+void SentryNativeBridgeOptionsSetString(void *options, const char *name, const char *value) { }
+void SentryNativeBridgeOptionsSetInt(void *options, const char *name, int32_t value) { }
+void SentryNativeBridgeStartWithOptions(void *options) { }
 
-void *SentryNativeBridgeOptionsNew()
-{
-    // macOS only
-}
+int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 : 0; }
 
-void SentryNativeBridgeOptionsSetString(void *options, const char *name, const char *value)
-{
-    // macOS only
-}
-
-void SentryNativeBridgeOptionsSetInt(void *options, const char *name, int32_t value)
-{
-    // macOS only
-}
-
-void SentryNativeBridgeStartWithOptions(void *options)
-{
-    // macOS only
-}
-
-int SentryNativeBridgeCrashedLastRun()
-{
-    @try {
-        return [SentrySDK crashedLastRun] ? 1 : 0;
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to get crashedLastRun: %@", exception.reason);
-    }
-    return -1;
-}
-
-void SentryNativeBridgeClose()
-{
-    @try {
-        [SentrySDK close];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to close: %@", exception.reason);
-    }
-}
+void SentryNativeBridgeClose() { [SentrySDK close]; }
 
 void SentryNativeBridgeAddBreadcrumb(
     const char *timestamp, const char *message, const char *type, const char *category, int level)
@@ -53,33 +20,28 @@ void SentryNativeBridgeAddBreadcrumb(
         return;
     }
 
-    @try {
-        [SentrySDK configureScope:^(SentryScope *scope) {
-            SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc]
-                initWithLevel:level
-                     category:(category ? [NSString stringWithUTF8String:category] : nil)];
+    [SentrySDK configureScope:^(SentryScope *scope) {
+        SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc]
+            initWithLevel:level
+                 category:(category ? [NSString stringWithUTF8String:category] : nil)];
 
-            if (timestamp != NULL) {
-                NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-                [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
-                breadcrumb.timestamp =
-                    [dateFormatter dateFromString:[NSString stringWithUTF8String:timestamp]];
-                [dateFormatter release];
-            }
+        if (timestamp != NULL) {
+            NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+            [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
+            breadcrumb.timestamp =
+                [dateFormatter dateFromString:[NSString stringWithUTF8String:timestamp]];
+        }
 
-            if (message != NULL) {
-                breadcrumb.message = [NSString stringWithUTF8String:message];
-            }
+        if (message != NULL) {
+            breadcrumb.message = [NSString stringWithUTF8String:message];
+        }
 
-            if (type != NULL) {
-                breadcrumb.type = [NSString stringWithUTF8String:type];
-            }
+        if (type != NULL) {
+            breadcrumb.type = [NSString stringWithUTF8String:type];
+        }
 
-            [scope addBreadcrumb:breadcrumb];
-        }];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to add breadcrumb: %@", exception.reason);
-    }
+        [scope addBreadcrumb:breadcrumb];
+    }];
 }
 
 void SentryNativeBridgeSetExtra(const char *key, const char *value)
@@ -88,18 +50,14 @@ void SentryNativeBridgeSetExtra(const char *key, const char *value)
         return;
     }
 
-    @try {
-        [SentrySDK configureScope:^(SentryScope *scope) {
-            if (value != NULL) {
-                [scope setExtraValue:[NSString stringWithUTF8String:value]
-                              forKey:[NSString stringWithUTF8String:key]];
-            } else {
-                [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
-            }
-        }];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to set extra: %@", exception.reason);
-    }
+    [SentrySDK configureScope:^(SentryScope *scope) {
+        if (value != NULL) {
+            [scope setExtraValue:[NSString stringWithUTF8String:value]
+                          forKey:[NSString stringWithUTF8String:key]];
+        } else {
+            [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
+        }
+    }];
 }
 
 void SentryNativeBridgeSetTag(const char *key, const char *value)
@@ -108,18 +66,14 @@ void SentryNativeBridgeSetTag(const char *key, const char *value)
         return;
     }
 
-    @try {
-        [SentrySDK configureScope:^(SentryScope *scope) {
-            if (value != NULL) {
-                [scope setTagValue:[NSString stringWithUTF8String:value]
-                            forKey:[NSString stringWithUTF8String:key]];
-            } else {
-                [scope removeTagForKey:[NSString stringWithUTF8String:key]];
-            }
-        }];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to set tag: %@", exception.reason);
-    }
+    [SentrySDK configureScope:^(SentryScope *scope) {
+        if (value != NULL) {
+            [scope setTagValue:[NSString stringWithUTF8String:value]
+                        forKey:[NSString stringWithUTF8String:key]];
+        } else {
+            [scope removeTagForKey:[NSString stringWithUTF8String:key]];
+        }
+    }];
 }
 
 void SentryNativeBridgeUnsetTag(const char *key)
@@ -128,12 +82,8 @@ void SentryNativeBridgeUnsetTag(const char *key)
         return;
     }
 
-    @try {
-        [SentrySDK configureScope:^(
-            SentryScope *scope) { [scope removeTagForKey:[NSString stringWithUTF8String:key]]; }];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to unset tag: %@", exception.reason);
-    }
+    [SentrySDK configureScope:^(
+        SentryScope *scope) { [scope removeTagForKey:[NSString stringWithUTF8String:key]]; }];
 }
 
 void SentryNativeBridgeSetUser(
@@ -143,40 +93,32 @@ void SentryNativeBridgeSetUser(
         return;
     }
 
-    @try {
-        [SentrySDK configureScope:^(SentryScope *scope) {
-            SentryUser *user = [[SentryUser alloc] init];
+    [SentrySDK configureScope:^(SentryScope *scope) {
+        SentryUser *user = [[SentryUser alloc] init];
 
-            if (email != NULL) {
-                user.email = [NSString stringWithUTF8String:email];
-            }
+        if (email != NULL) {
+            user.email = [NSString stringWithUTF8String:email];
+        }
 
-            if (userId != NULL) {
-                user.userId = [NSString stringWithUTF8String:userId];
-            }
+        if (userId != NULL) {
+            user.userId = [NSString stringWithUTF8String:userId];
+        }
 
-            if (ipAddress != NULL) {
-                user.ipAddress = [NSString stringWithUTF8String:ipAddress];
-            }
+        if (ipAddress != NULL) {
+            user.ipAddress = [NSString stringWithUTF8String:ipAddress];
+        }
 
-            if (username != NULL) {
-                user.username = [NSString stringWithUTF8String:username];
-            }
+        if (username != NULL) {
+            user.username = [NSString stringWithUTF8String:username];
+        }
 
-            [scope setUser:user];
-        }];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to set user: %@", exception.reason);
-    }
+        [scope setUser:user];
+    }];
 }
 
 void SentryNativeBridgeUnsetUser()
 {
-    @try {
-        [SentrySDK configureScope:^(SentryScope *scope) { [scope setUser:nil]; }];
-    } @catch (NSException *exception) {
-        NSLog(@"Sentry (bridge): failed to unset user: %@", exception.reason);
-    }
+    [SentrySDK configureScope:^(SentryScope *scope) { [scope setUser:nil]; }];
 }
 
 NS_ASSUME_NONNULL_END

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -2,11 +2,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-int CrashedLastRun() {
+// must be here to match the native bridge API for macOS
+int SentryNativeBridgeInit() {
+    return 0; // this shouldn't be used so return "false"
+}
+
+int SentryNativeBridgeCrashedLastRun() {
     return [SentrySDK crashedLastRun] ? 1 : 0;
 }
 
-void Close() {
+void SentryNativeBridgeClose() {
     [SentrySDK close];
 }
 

--- a/package-dev/Plugins/macOS/Sentry/Sentry.dylib.meta
+++ b/package-dev/Plugins/macOS/Sentry/Sentry.dylib.meta
@@ -1,0 +1,81 @@
+fileFormatVersion: 2
+guid: 23251176c1b104465a1b141cf7aabd2b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags:
+        FrameworkDependencies:
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/package-dev/Plugins/macOS/Sentry/Sentry.dylib.meta
+++ b/package-dev/Plugins/macOS/Sentry/Sentry.dylib.meta
@@ -31,7 +31,7 @@ PluginImporter:
       settings:
         CPU: ARMv7
   - first:
-      Any:
+      Any: 
     second:
       enabled: 0
       settings: {}
@@ -48,7 +48,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
@@ -74,8 +74,8 @@ PluginImporter:
       settings:
         AddToEmbeddedBinaries: false
         CPU: AnyCPU
-        CompileFlags:
-        FrameworkDependencies:
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -50,16 +50,16 @@ LoadSentryDylib()
 
 // [sdkClass startWithOptionsObject:options];
 
-// int CrashedLastRun() {
+int CrashedLastRun() {
 //     return [SentrySDK crashedLastRun] ? 1 : 0;
-// }
+}
 
-// void Close() {
+void Close() {
 //     [SentrySDK close];
-// }
+}
 
-// void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message, const char*
-// type, const char* category, int level) {
+void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message, const char*
+type, const char* category, int level) {
 //     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
 //         return;
 //     }
@@ -93,9 +93,9 @@ LoadSentryDylib()
 
 //         [scope addBreadcrumb:breadcrumb];
 //     }];
-// }
+}
 
-// void SentryNativeBridgeSetExtra(const char* key, const char* value) {
+void SentryNativeBridgeSetExtra(const char* key, const char* value) {
 //     if (key == NULL) {
 //         return;
 //     }
@@ -108,9 +108,9 @@ LoadSentryDylib()
 //             [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
 //         }
 //     }];
-// }
+}
 
-// void SentryNativeBridgeSetTag(const char* key, const char* value) {
+void SentryNativeBridgeSetTag(const char* key, const char* value) {
 //     if (key == NULL) {
 //         return;
 //     }
@@ -123,9 +123,9 @@ LoadSentryDylib()
 //             [scope removeTagForKey:[NSString stringWithUTF8String:key]];
 //         }
 //     }];
-// }
+}
 
-// void SentryNativeBridgeUnsetTag(const char* key) {
+void SentryNativeBridgeUnsetTag(const char* key) {
 //     if (key == NULL) {
 //         return;
 //     }
@@ -133,10 +133,10 @@ LoadSentryDylib()
 //     [SentrySDK configureScope:^(SentryScope * scope) {
 //         [scope removeTagForKey:[NSString stringWithUTF8String:key]];
 //     }];
-// }
+}
 
-// void SentryNativeBridgeSetUser(const char* email, const char* userId, const char* ipAddress,
-// const char* username) {
+void SentryNativeBridgeSetUser(const char* email, const char* userId, const char* ipAddress,
+const char* username) {
 //     if (email == NULL && userId == NULL && ipAddress == NULL && username == NULL) {
 //         return;
 //     }
@@ -164,10 +164,10 @@ LoadSentryDylib()
 
 //         [scope setUser:user];
 //     }];
-// }
+}
 
-// void SentryNativeBridgeUnsetUser() {
+void SentryNativeBridgeUnsetUser() {
 //     [SentrySDK configureScope:^(SentryScope * scope) {
 //         [scope setUser:nil];
 //     }];
-// }
+}

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -40,134 +40,160 @@ LoadSentryDylib()
     return loadStatus;
 }
 
-// TODO expose options setup & init
-// SentryOptions *options = [[optionsClass alloc] init];
-// [options
-//     setValue:
-//         @"https://94677106febe46b88b9b9ae5efd18a00@o447951.ingest.sentry.io/5439417"
-//       forKey:@"dsn"];
-// [options setValue:[NSNumber numberWithBool:YES] forKey:@"debug"];
+// Initialize Sentry SDK with the given options
+// returns (bool): 0 on failure, 1 on success, -1 on error
+// WARNING: you may only call other Sentry* functions AFTER calling this AND only if it returned "1"
+int
+SentryNativeBridgeInit()
+{
+    if (LoadSentryDylib() != 1) {
+        return loadStatus;
+    }
 
-// [sdkClass startWithOptionsObject:options];
+    SentryOptions *options = [[optionsClass alloc] init];
+    [options setValue:@"https://94677106febe46b88b9b9ae5efd18a00@o447951.ingest.sentry.io/5439417"
+               forKey:@"dsn"];
+    [options setValue:[NSNumber numberWithBool:YES] forKey:@"debug"];
 
-int CrashedLastRun() {
-//     return [SentrySDK crashedLastRun] ? 1 : 0;
+    [sdkClass startWithOptionsObject:options];
+
+    return 1;
 }
 
-void Close() {
-//     [SentrySDK close];
+int
+SentryNativeBridgeCrashedLastRun()
+{
+    // return [sdkClass crashedLastRun] ? 1 : 0;
 }
 
-void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message, const char*
-type, const char* category, int level) {
-//     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
-//         return;
-//     }
-
-//     [SentrySDK configureScope:^(SentryScope * scope) {
-//         SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] init];
-
-//         if (timestamp != NULL) {
-//             NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-//             [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
-//             breadcrumb.timestamp = [dateFormatter dateFromString:[NSString
-//             stringWithCString:timestamp encoding:NSUTF8StringEncoding]];
-//         }
-
-//         if (message != NULL) {
-//             breadcrumb.message = [NSString stringWithCString:message
-//             encoding:NSUTF8StringEncoding];
-//         }
-
-//         if (type != NULL) {
-//             breadcrumb.type = [NSString stringWithCString:type
-//             encoding:NSUTF8StringEncoding];
-//         }
-
-//         if (category != NULL) {
-//             breadcrumb.category = [NSString stringWithCString:category
-//             encoding:NSUTF8StringEncoding];
-//         }
-
-//         breadcrumb.level = level;
-
-//         [scope addBreadcrumb:breadcrumb];
-//     }];
+void
+SentryNativeBridgeClose()
+{
+    // [sdkClass close];
 }
 
-void SentryNativeBridgeSetExtra(const char* key, const char* value) {
-//     if (key == NULL) {
-//         return;
-//     }
+void
+SentryNativeBridgeAddBreadcrumb(
+    const char *timestamp, const char *message, const char *type, const char *category, int level)
+{
+    //     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
+    //         return;
+    //     }
 
-//     [SentrySDK configureScope:^(SentryScope * scope) {
-//         if (value != NULL) {
-//             [scope setExtraValue:[NSString stringWithUTF8String:value] forKey:[NSString
-//             stringWithUTF8String:key]];
-//         } else {
-//             [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
-//         }
-//     }];
+    //     [SentrySDK configureScope:^(SentryScope * scope) {
+    //         SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] init];
+
+    //         if (timestamp != NULL) {
+    //             NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    //             [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
+    //             breadcrumb.timestamp = [dateFormatter dateFromString:[NSString
+    //             stringWithCString:timestamp encoding:NSUTF8StringEncoding]];
+    //         }
+
+    //         if (message != NULL) {
+    //             breadcrumb.message = [NSString stringWithCString:message
+    //             encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         if (type != NULL) {
+    //             breadcrumb.type = [NSString stringWithCString:type
+    //             encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         if (category != NULL) {
+    //             breadcrumb.category = [NSString stringWithCString:category
+    //             encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         breadcrumb.level = level;
+
+    //         [scope addBreadcrumb:breadcrumb];
+    //     }];
 }
 
-void SentryNativeBridgeSetTag(const char* key, const char* value) {
-//     if (key == NULL) {
-//         return;
-//     }
+void
+SentryNativeBridgeSetExtra(const char *key, const char *value)
+{
+    //     if (key == NULL) {
+    //         return;
+    //     }
 
-//     [SentrySDK configureScope:^(SentryScope * scope) {
-//         if (value != NULL) {
-//             [scope setTagValue:[NSString stringWithUTF8String:value] forKey:[NSString
-//             stringWithUTF8String:key]];
-//         } else {
-//             [scope removeTagForKey:[NSString stringWithUTF8String:key]];
-//         }
-//     }];
+    //     [SentrySDK configureScope:^(SentryScope * scope) {
+    //         if (value != NULL) {
+    //             [scope setExtraValue:[NSString stringWithUTF8String:value] forKey:[NSString
+    //             stringWithUTF8String:key]];
+    //         } else {
+    //             [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
+    //         }
+    //     }];
 }
 
-void SentryNativeBridgeUnsetTag(const char* key) {
-//     if (key == NULL) {
-//         return;
-//     }
+void
+SentryNativeBridgeSetTag(const char *key, const char *value)
+{
+    //     if (key == NULL) {
+    //         return;
+    //     }
 
-//     [SentrySDK configureScope:^(SentryScope * scope) {
-//         [scope removeTagForKey:[NSString stringWithUTF8String:key]];
-//     }];
+    //     [SentrySDK configureScope:^(SentryScope * scope) {
+    //         if (value != NULL) {
+    //             [scope setTagValue:[NSString stringWithUTF8String:value] forKey:[NSString
+    //             stringWithUTF8String:key]];
+    //         } else {
+    //             [scope removeTagForKey:[NSString stringWithUTF8String:key]];
+    //         }
+    //     }];
 }
 
-void SentryNativeBridgeSetUser(const char* email, const char* userId, const char* ipAddress,
-const char* username) {
-//     if (email == NULL && userId == NULL && ipAddress == NULL && username == NULL) {
-//         return;
-//     }
+void
+SentryNativeBridgeUnsetTag(const char *key)
+{
+    //     if (key == NULL) {
+    //         return;
+    //     }
 
-//     [SentrySDK configureScope:^(SentryScope * scope) {
-//         SentryUser *user = [[SentryUser alloc] init];
-
-//         if (email != NULL) {
-//             user.email = [NSString stringWithCString:email encoding:NSUTF8StringEncoding];
-//         }
-
-//         if (userId != NULL) {
-//             user.userId = [NSString stringWithCString:userId encoding:NSUTF8StringEncoding];
-//         }
-
-//         if (ipAddress != NULL) {
-//             user.ipAddress = [NSString stringWithCString:ipAddress
-//             encoding:NSUTF8StringEncoding];
-//         }
-
-//         if (username != NULL) {
-//             user.username = [NSString stringWithCString:username
-//             encoding:NSUTF8StringEncoding];
-//         }
-
-//         [scope setUser:user];
-//     }];
+    //     [SentrySDK configureScope:^(SentryScope * scope) {
+    //         [scope removeTagForKey:[NSString stringWithUTF8String:key]];
+    //     }];
 }
 
-void SentryNativeBridgeUnsetUser() {
-//     [SentrySDK configureScope:^(SentryScope * scope) {
-//         [scope setUser:nil];
-//     }];
+void
+SentryNativeBridgeSetUser(
+    const char *email, const char *userId, const char *ipAddress, const char *username)
+{
+    //     if (email == NULL && userId == NULL && ipAddress == NULL && username == NULL) {
+    //         return;
+    //     }
+
+    //     [SentrySDK configureScope:^(SentryScope * scope) {
+    //         SentryUser *user = [[SentryUser alloc] init];
+
+    //         if (email != NULL) {
+    //             user.email = [NSString stringWithCString:email encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         if (userId != NULL) {
+    //             user.userId = [NSString stringWithCString:userId encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         if (ipAddress != NULL) {
+    //             user.ipAddress = [NSString stringWithCString:ipAddress
+    //             encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         if (username != NULL) {
+    //             user.username = [NSString stringWithCString:username
+    //             encoding:NSUTF8StringEncoding];
+    //         }
+
+    //         [scope setUser:user];
+    //     }];
+}
+
+void
+SentryNativeBridgeUnsetUser()
+{
+    //     [SentrySDK configureScope:^(SentryScope * scope) {
+    //         [scope setUser:nil];
+    //     }];
 }

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -6,11 +6,12 @@ static int loadStatus = -1; // unitialized
 static Class SentrySDK;
 static Class SentryScope;
 static Class SentryBreadcrumb;
+static Class SentryUser;
 
 #define LOAD_CLASS_OR_BREAK(name)                                                                  \
     name = dlsym(dylib, "OBJC_CLASS_$_" #name);                                                    \
     if (!name) {                                                                                   \
-        NSLog(@("Couldn't load " #name " class from the dynamic library"));                        \
+        NSLog(@"Sentry (native bridge): Couldn't load %@ class from the dynamic library", name);   \
         break;                                                                                     \
     }
 
@@ -23,13 +24,14 @@ int SentryNativeBridgeLoadLibrary()
         do {
             void *dylib = dlopen("@executable_path/../PlugIns/Sentry.dylib", RTLD_LAZY);
             if (!dylib) {
-                NSLog(@"Couldn't load Sentry.dylib - dlopen() failed");
+                NSLog(@"Sentry (native bridge): Couldn't load Sentry.dylib - dlopen() failed");
                 break;
             }
 
             LOAD_CLASS_OR_BREAK(SentrySDK)
             LOAD_CLASS_OR_BREAK(SentryScope)
             LOAD_CLASS_OR_BREAK(SentryBreadcrumb)
+            LOAD_CLASS_OR_BREAK(SentryUser)
 
             // everything above passed - mark as successfully loaded
             loadStatus = 1;
@@ -37,6 +39,10 @@ int SentryNativeBridgeLoadLibrary()
     }
     return loadStatus;
 }
+
+// We're doing dynamic access so we're getting warnings about missing class/instance methods...
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-method-access"
 
 void *SentryNativeBridgeOptionsNew() { return (void *)[[NSMutableDictionary alloc] init]; }
 
@@ -58,14 +64,32 @@ void SentryNativeBridgeStartWithOptions(void *options)
     [((NSMutableDictionary *)options) release];
 }
 
-/******************************************************************************************/
-/* THE REMAINING CODE IS A LITERAL COPY OF THE iOS/SentryNativeBridge.m                   */
-/* Note: maybe we could avoid the code copy, e.g. by doing the dlopen(__internal) on iOS? */
-/******************************************************************************************/
+/*****************************************************************************/
+/* The remaining code is a copy of iOS/SentryNativeBridge.m                  */
+/* with minor changes to make it work with dynamically loaded classes.       */
+/* Specifically:                                                             */
+/*   - use `id` as variable types                                            */
+/*   - use [obj setValue:value forKey:@"prop"] instead of `obj.prop = value` */
+/*****************************************************************************/
 
-int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 : 0; }
+int SentryNativeBridgeCrashedLastRun()
+{
+    @try {
+        return [SentrySDK crashedLastRun] ? 1 : 0;
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to get crashedLastRun: %@", exception.reason);
+    }
+    return -1;
+}
 
-void SentryNativeBridgeClose() { [SentrySDK close]; }
+void SentryNativeBridgeClose()
+{
+    @try {
+        [SentrySDK close];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to close: %@", exception.reason);
+    }
+}
 
 void SentryNativeBridgeAddBreadcrumb(
     const char *timestamp, const char *message, const char *type, const char *category, int level)
@@ -74,35 +98,34 @@ void SentryNativeBridgeAddBreadcrumb(
         return;
     }
 
-    // [SentrySDK configureScope:^(SentryScope *scope) {
-    //     SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] init];
+    @try {
+        [SentrySDK configureScope:^(id scope) {
+            id breadcrumb = [[SentryBreadcrumb alloc]
+                initWithLevel:level
+                     category:(category ? [NSString stringWithUTF8String:category] : nil)];
 
-    //     if (timestamp != NULL) {
-    //         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    //         [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
-    //         breadcrumb.timestamp =
-    //             [dateFormatter dateFromString:[NSString stringWithCString:timestamp
-    //                                                              encoding:NSUTF8StringEncoding]];
-    //     }
+            if (timestamp != NULL) {
+                NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+                [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
+                [breadcrumb setValue:[dateFormatter
+                                         dateFromString:[NSString stringWithUTF8String:timestamp]]
+                              forKey:@"timestamp"];
+                [dateFormatter release];
+            }
 
-    //     if (message != NULL) {
-    //         breadcrumb.message = [NSString stringWithCString:message
-    //         encoding:NSUTF8StringEncoding];
-    //     }
+            if (message != NULL) {
+                [breadcrumb setValue:[NSString stringWithUTF8String:message] forKey:@"message"];
+            }
 
-    //     if (type != NULL) {
-    //         breadcrumb.type = [NSString stringWithCString:type encoding:NSUTF8StringEncoding];
-    //     }
+            if (type != NULL) {
+                [breadcrumb setValue:[NSString stringWithUTF8String:type] forKey:@"type"];
+            }
 
-    //     if (category != NULL) {
-    //         breadcrumb.category = [NSString stringWithCString:category
-    //                                                  encoding:NSUTF8StringEncoding];
-    //     }
-
-    //     breadcrumb.level = level;
-
-    //     [scope addBreadcrumb:breadcrumb];
-    // }];
+            [scope addBreadcrumb:breadcrumb];
+        }];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to add breadcrumb: %@", exception.reason);
+    }
 }
 
 void SentryNativeBridgeSetExtra(const char *key, const char *value)
@@ -111,14 +134,18 @@ void SentryNativeBridgeSetExtra(const char *key, const char *value)
         return;
     }
 
-    // [SentrySDK configureScope:^(SentryScope *scope) {
-    //     if (value != NULL) {
-    //         [scope setExtraValue:[NSString stringWithUTF8String:value]
-    //                       forKey:[NSString stringWithUTF8String:key]];
-    //     } else {
-    //         [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
-    //     }
-    // }];
+    @try {
+        [SentrySDK configureScope:^(id scope) {
+            if (value != NULL) {
+                [scope setExtraValue:[NSString stringWithUTF8String:value]
+                              forKey:[NSString stringWithUTF8String:key]];
+            } else {
+                [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
+            }
+        }];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to set extra: %@", exception.reason);
+    }
 }
 
 void SentryNativeBridgeSetTag(const char *key, const char *value)
@@ -127,14 +154,18 @@ void SentryNativeBridgeSetTag(const char *key, const char *value)
         return;
     }
 
-    // [SentrySDK configureScope:^(SentryScope *scope) {
-    //     if (value != NULL) {
-    //         [scope setTagValue:[NSString stringWithUTF8String:value]
-    //                     forKey:[NSString stringWithUTF8String:key]];
-    //     } else {
-    //         [scope removeTagForKey:[NSString stringWithUTF8String:key]];
-    //     }
-    // }];
+    @try {
+        [SentrySDK configureScope:^(id scope) {
+            if (value != NULL) {
+                [scope setTagValue:[NSString stringWithUTF8String:value]
+                            forKey:[NSString stringWithUTF8String:key]];
+            } else {
+                [scope removeTagForKey:[NSString stringWithUTF8String:key]];
+            }
+        }];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to set tag: %@", exception.reason);
+    }
 }
 
 void SentryNativeBridgeUnsetTag(const char *key)
@@ -143,8 +174,12 @@ void SentryNativeBridgeUnsetTag(const char *key)
         return;
     }
 
-    // [SentrySDK configureScope:^(
-    //     SentryScope *scope) { [scope removeTagForKey:[NSString stringWithUTF8String:key]]; }];
+    @try {
+        [SentrySDK configureScope:^(
+            id scope) { [scope removeTagForKey:[NSString stringWithUTF8String:key]]; }];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to unset tag: %@", exception.reason);
+    }
 }
 
 void SentryNativeBridgeSetUser(
@@ -154,31 +189,40 @@ void SentryNativeBridgeSetUser(
         return;
     }
 
-    // [SentrySDK configureScope:^(SentryScope *scope) {
-    //     SentryUser *user = [[SentryUser alloc] init];
+    @try {
+        [SentrySDK configureScope:^(id scope) {
+            id user = [[SentryUser alloc] init];
 
-    //     if (email != NULL) {
-    //         user.email = [NSString stringWithCString:email encoding:NSUTF8StringEncoding];
-    //     }
+            if (email != NULL) {
+                [user setValue:[NSString stringWithUTF8String:email] forKey:@"email"];
+            }
 
-    //     if (userId != NULL) {
-    //         user.userId = [NSString stringWithCString:userId encoding:NSUTF8StringEncoding];
-    //     }
+            if (userId != NULL) {
+                [user setValue:[NSString stringWithUTF8String:userId] forKey:@"userId"];
+            }
 
-    //     if (ipAddress != NULL) {
-    //         user.ipAddress = [NSString stringWithCString:ipAddress
-    //         encoding:NSUTF8StringEncoding];
-    //     }
+            if (ipAddress != NULL) {
+                [user setValue:[NSString stringWithUTF8String:ipAddress] forKey:@"ipAddress"];
+            }
 
-    //     if (username != NULL) {
-    //         user.username = [NSString stringWithCString:username encoding:NSUTF8StringEncoding];
-    //     }
+            if (username != NULL) {
+                [user setValue:[NSString stringWithUTF8String:username] forKey:@"username"];
+            }
 
-    //     [scope setUser:user];
-    // }];
+            [scope setUser:user];
+        }];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to set user: %@", exception.reason);
+    }
 }
 
 void SentryNativeBridgeUnsetUser()
 {
-    // [SentrySDK configureScope:^(SentryScope *scope) { [scope setUser:nil]; }];
+    @try {
+        [SentrySDK configureScope:^(id scope) { [scope setUser:nil]; }];
+    } @catch (NSException *exception) {
+        NSLog(@"Sentry (bridge): failed to unset user: %@", exception.reason);
+    }
 }
+
+#pragma clang diagnostic pop

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -1,0 +1,173 @@
+#import <Foundation/Foundation.h>
+#include <dlfcn.h>
+
+@class SentryOptions;
+@class SentrySDK;
+
+static int loadStatus = 0; // 0 = unitialized; 1 = dylib loaded successfully; -1 = dylib load error
+static void *dylib;
+static Class sdkClass;
+static Class optionsClass;
+
+int
+LoadSentryDylib()
+{
+    if (!loadStatus) {
+        loadStatus = -1; // init to "error"
+        do {
+            dylib = dlopen("@executable_path/../PlugIns/Sentry.dylib", RTLD_LAZY);
+            if (!dylib) {
+                NSLog(@"Couldn't load Sentry.dylib - dlopen() failed");
+                break;
+            }
+
+            sdkClass = dlsym(dylib, "OBJC_CLASS_$_SentrySDK");
+            if (!sdkClass) {
+                NSLog(@"Couldn't load SentrySDK class from the dynamic library");
+                break;
+            }
+
+            optionsClass = dlsym(dylib, "OBJC_CLASS_$_SentryOptions");
+            if (!optionsClass) {
+                NSLog(@"Couldn't load SentryOptions class from the dynamic library");
+                break;
+            }
+
+            // everything above passed succesfully - mark as loaded
+            loadStatus = 1;
+        } while (false);
+    }
+    return loadStatus;
+}
+
+// TODO expose options setup & init
+// SentryOptions *options = [[optionsClass alloc] init];
+// [options
+//     setValue:
+//         @"https://94677106febe46b88b9b9ae5efd18a00@o447951.ingest.sentry.io/5439417"
+//       forKey:@"dsn"];
+// [options setValue:[NSNumber numberWithBool:YES] forKey:@"debug"];
+
+// [sdkClass startWithOptionsObject:options];
+
+// int CrashedLastRun() {
+//     return [SentrySDK crashedLastRun] ? 1 : 0;
+// }
+
+// void Close() {
+//     [SentrySDK close];
+// }
+
+// void SentryNativeBridgeAddBreadcrumb(const char* timestamp, const char* message, const char*
+// type, const char* category, int level) {
+//     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
+//         return;
+//     }
+
+//     [SentrySDK configureScope:^(SentryScope * scope) {
+//         SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] init];
+
+//         if (timestamp != NULL) {
+//             NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+//             [dateFormatter setDateFormat:NSCalendarIdentifierISO8601];
+//             breadcrumb.timestamp = [dateFormatter dateFromString:[NSString
+//             stringWithCString:timestamp encoding:NSUTF8StringEncoding]];
+//         }
+
+//         if (message != NULL) {
+//             breadcrumb.message = [NSString stringWithCString:message
+//             encoding:NSUTF8StringEncoding];
+//         }
+
+//         if (type != NULL) {
+//             breadcrumb.type = [NSString stringWithCString:type
+//             encoding:NSUTF8StringEncoding];
+//         }
+
+//         if (category != NULL) {
+//             breadcrumb.category = [NSString stringWithCString:category
+//             encoding:NSUTF8StringEncoding];
+//         }
+
+//         breadcrumb.level = level;
+
+//         [scope addBreadcrumb:breadcrumb];
+//     }];
+// }
+
+// void SentryNativeBridgeSetExtra(const char* key, const char* value) {
+//     if (key == NULL) {
+//         return;
+//     }
+
+//     [SentrySDK configureScope:^(SentryScope * scope) {
+//         if (value != NULL) {
+//             [scope setExtraValue:[NSString stringWithUTF8String:value] forKey:[NSString
+//             stringWithUTF8String:key]];
+//         } else {
+//             [scope removeExtraForKey:[NSString stringWithUTF8String:key]];
+//         }
+//     }];
+// }
+
+// void SentryNativeBridgeSetTag(const char* key, const char* value) {
+//     if (key == NULL) {
+//         return;
+//     }
+
+//     [SentrySDK configureScope:^(SentryScope * scope) {
+//         if (value != NULL) {
+//             [scope setTagValue:[NSString stringWithUTF8String:value] forKey:[NSString
+//             stringWithUTF8String:key]];
+//         } else {
+//             [scope removeTagForKey:[NSString stringWithUTF8String:key]];
+//         }
+//     }];
+// }
+
+// void SentryNativeBridgeUnsetTag(const char* key) {
+//     if (key == NULL) {
+//         return;
+//     }
+
+//     [SentrySDK configureScope:^(SentryScope * scope) {
+//         [scope removeTagForKey:[NSString stringWithUTF8String:key]];
+//     }];
+// }
+
+// void SentryNativeBridgeSetUser(const char* email, const char* userId, const char* ipAddress,
+// const char* username) {
+//     if (email == NULL && userId == NULL && ipAddress == NULL && username == NULL) {
+//         return;
+//     }
+
+//     [SentrySDK configureScope:^(SentryScope * scope) {
+//         SentryUser *user = [[SentryUser alloc] init];
+
+//         if (email != NULL) {
+//             user.email = [NSString stringWithCString:email encoding:NSUTF8StringEncoding];
+//         }
+
+//         if (userId != NULL) {
+//             user.userId = [NSString stringWithCString:userId encoding:NSUTF8StringEncoding];
+//         }
+
+//         if (ipAddress != NULL) {
+//             user.ipAddress = [NSString stringWithCString:ipAddress
+//             encoding:NSUTF8StringEncoding];
+//         }
+
+//         if (username != NULL) {
+//             user.username = [NSString stringWithCString:username
+//             encoding:NSUTF8StringEncoding];
+//         }
+
+//         [scope setUser:user];
+//     }];
+// }
+
+// void SentryNativeBridgeUnsetUser() {
+//     [SentrySDK configureScope:^(SentryScope * scope) {
+//         [scope setUser:nil];
+//     }];
+// }

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m.meta
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m.meta
@@ -1,0 +1,86 @@
+fileFormatVersion: 2
+guid: 17913db96b84047a990f83b3c11b3117
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package-dev/Runtime/Sentry.Unity.iOS.dll.meta
+++ b/package-dev/Runtime/Sentry.Unity.iOS.dll.meta
@@ -18,10 +18,11 @@ PluginImporter:
       settings:
         Exclude Android: 1
         Exclude Editor: 0
-        Exclude Linux64: 1
-        Exclude OSXUniversal: 1
-        Exclude Win: 1
-        Exclude Win64: 1
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 0
+        Exclude Win64: 0
         Exclude iOS: 0
   - first:
       Android: Android
@@ -45,25 +46,25 @@ PluginImporter:
   - first:
       Standalone: Linux64
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: Win
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:
       Standalone: Win64
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: None
   - first:

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -1,6 +1,6 @@
 #if !UNITY_EDITOR
-#if UNITY_IOS
-#define SENTRY_NATIVE_IOS
+#if UNITY_IOS || (UNITY_STANDALONE_OSX && ENABLE_IL2CPP)
+#define SENTRY_NATIVE_COCOA
 #elif UNITY_ANDROID
 #define SENTRY_NATIVE_ANDROID
 #elif UNITY_STANDALONE_WIN && ENABLE_IL2CPP
@@ -13,7 +13,7 @@
 using UnityEngine;
 using UnityEngine.Scripting;
 
-#if SENTRY_NATIVE_IOS
+#if SENTRY_NATIVE_COCOA
 using Sentry.Unity.iOS;
 #elif UNITY_ANDROID
 using Sentry.Unity.Android;
@@ -37,8 +37,8 @@ namespace Sentry.Unity
             {
                 var sentryUnityInfo = new SentryUnityInfo();
 
-#if SENTRY_NATIVE_IOS
-                SentryNativeIos.Configure(options);
+#if SENTRY_NATIVE_COCOA
+                SentryNativeCocoa.Configure(options);
 #elif SENTRY_NATIVE_ANDROID
                 SentryNativeAndroid.Configure(options, sentryUnityInfo);
 #elif SENTRY_NATIVE_WINDOWS

--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -38,6 +38,7 @@ MonoBehaviour:
   <IosNativeSupportEnabled>k__BackingField: 1
   <AndroidNativeSupportEnabled>k__BackingField: 1
   <WindowsNativeSupportEnabled>k__BackingField: 1
+  <MacosNativeSupportEnabled>k__BackingField: 1
   <OptionsConfiguration>k__BackingField: {fileID: 11400000, guid: bda1a724b0875436aade31393b0129c0,
     type: 2}
   <Debug>k__BackingField: 1

--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/CppPlugin.cpp
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/CppPlugin.cpp
@@ -3,8 +3,7 @@
 #include <string>
 
 extern "C" {
-void
-crash_in_cpp()
+void crash_in_cpp()
 {
     char *ptr = 0;
     *ptr += 1;
@@ -12,8 +11,7 @@ crash_in_cpp()
 }
 
 extern "C" {
-void
-throw_cpp()
+void throw_cpp()
 {
     try {
         // throws std::length_error

--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-void
-throwObjectiveC()
+void throwObjectiveC()
 {
 #ifdef __EXCEPTIONS
     NSLog(@"Throwing an Objective-C Exception");
@@ -17,8 +16,7 @@ throwObjectiveC()
 #endif
 }
 
-char *
-getTestArgObjectiveC()
+char *getTestArgObjectiveC()
 {
     NSArray *args = NSProcessInfo.processInfo.arguments;
 

--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -41,7 +41,7 @@ public class SmokeTester : MonoBehaviour
         }
     }
 
-#if UNITY_IOS
+#if UNITY_IOS && !UNITY_EDITOR
     // .NET `Environment.GetCommandLineArgs()` doesn't seem to work on iOS so we get the test arg in Objective-C
     [DllImport("__Internal", EntryPoint="getTestArgObjectiveC")]
     private static extern string GetTestArg();

--- a/scripts/unity-utils.ps1
+++ b/scripts/unity-utils.ps1
@@ -23,7 +23,7 @@ function RunUnity([string] $unityPath, [string[]] $arguments, [switch] $ReturnLo
         $unityPath = "xvfb-run"
     }
 
-    $logFilePath = "$pwd/unity.log"
+    $logFilePath = "unity.log"
 
     foreach ($arg in $arguments)
     {

--- a/scripts/unity-utils.ps1
+++ b/scripts/unity-utils.ps1
@@ -63,13 +63,15 @@ function RunUnity([string] $unityPath, [string[]] $arguments, [switch] $ReturnLo
         }
         else
         {
-            if ($process.ExitCode -ne 0)
-            {
-                Throw "Unity exited with code $($process.ExitCode)"
-            }
-            return $ReturnLogOutput ? $stdout : $null
+            break
         }
     } while ($stopwatch.Elapsed.TotalSeconds -lt $RunUnityLicenseRetryTimeoutSeconds)
+    
+    if ($process.ExitCode -ne 0)
+    {
+        Throw "Unity exited with code $($process.ExitCode)"
+    }
+    return $ReturnLogOutput ? $stdout : $null
 }
 
 function ClearUnityLog([string] $logFilePath)

--- a/scripts/unity.ps1
+++ b/scripts/unity.ps1
@@ -4,4 +4,4 @@ $ErrorActionPreference = "Stop"
 . $PSScriptRoot/unity-utils.ps1
 
 # Redirecting the output to $null because RunUnity prints logs using Write-Host AND Write-Output - we don't need both here.
-RunUnity $args[0] ($args | Select-Object -Skip 1) > $null
+RunUnity $args[0] ($args | Select-Object -Skip 1)

--- a/scripts/unity.ps1
+++ b/scripts/unity.ps1
@@ -3,5 +3,5 @@ $ErrorActionPreference = "Stop"
 
 . $PSScriptRoot/unity-utils.ps1
 
-# Redirecting the output to $null because RunUnity prints logs using Write-Host AND Write-Output - we don't need both here.
+Log output is written to 'unity.log'
 RunUnity $args[0] ($args | Select-Object -Skip 1)

--- a/scripts/unity.ps1
+++ b/scripts/unity.ps1
@@ -3,5 +3,5 @@ $ErrorActionPreference = "Stop"
 
 . $PSScriptRoot/unity-utils.ps1
 
-Log output is written to 'unity.log'
+# Log output is written to 'unity.log'
 RunUnity $args[0] ($args | Select-Object -Skip 1)

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -59,9 +59,12 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                 options.AndroidNativeSupportEnabled);
 
             options.WindowsNativeSupportEnabled = EditorGUILayout.Toggle(
-                new GUIContent("Windows Native Support", "Whether to enable Native Windows support to " +
-                                                         "capture errors written in languages such as C and C++."),
+                new GUIContent("Windows Native Support", "Whether to enable native crashes support on Windows."),
                 options.WindowsNativeSupportEnabled);
+
+            options.MacosNativeSupportEnabled = EditorGUILayout.Toggle(
+                new GUIContent("macOS Native Support", "Whether to enable native crashes support on macOS."),
+                options.MacosNativeSupportEnabled);
         }
 
 

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -65,6 +65,7 @@ namespace Sentry.Unity.Editor
             EditorGUILayout.Toggle("iOS Native Support", options.IosNativeSupportEnabled);
             EditorGUILayout.Toggle("Android Native Support", options.AndroidNativeSupportEnabled);
             EditorGUILayout.Toggle("Windows Native Support", options.WindowsNativeSupportEnabled);
+            EditorGUILayout.Toggle("macOS Native Support", options.MacosNativeSupportEnabled);
 
             EditorGUILayout.Space();
             EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);

--- a/src/Sentry.Unity.iOS/NativeScopeObserver.cs
+++ b/src/Sentry.Unity.iOS/NativeScopeObserver.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace Sentry.Unity.iOS
 {
-    public class IosNativeScopeObserver : ScopeObserver
+    public class NativeScopeObserver : ScopeObserver
     {
-        public IosNativeScopeObserver(SentryOptions options) : base("iOS", options) { }
+        public NativeScopeObserver(string name, SentryOptions options) : base(name, options) { }
 
         public override void AddBreadcrumbImpl(Breadcrumb breadcrumb)
         {

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Runtime.InteropServices;
+using Sentry.Extensibility;
 
 namespace Sentry.Unity.iOS
 {
@@ -11,8 +13,69 @@ namespace Sentry.Unity.iOS
     /// <see href="https://github.com/getsentry/sentry-cocoa"/>
     internal static class SentryCocoaBridgeProxy
     {
-        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeInit")]
-        public static extern int Init();
+        public static bool Init(SentryUnityOptions options)
+        {
+            // Note: used on macOS only
+            if (LoadLibrary() != 1)
+            {
+                return false;
+            }
+
+            var cOptions = OptionsNew();
+
+            // Note: DSN is not null because options.IsValid() must have returned true for this to be called.
+            OptionsSetString(cOptions, "dsn", options.Dsn!);
+
+            if (options.Release is not null)
+            {
+                options.DiagnosticLogger?.LogDebug("Setting Release: {0}", options.Release);
+                OptionsSetString(cOptions, "release", options.Release);
+            }
+
+            if (options.Environment is not null)
+            {
+                options.DiagnosticLogger?.LogDebug("Setting Environment: {0}", options.Environment);
+                OptionsSetString(cOptions, "environment", options.Environment);
+            }
+
+            options.DiagnosticLogger?.LogDebug("Setting Debug: {0}", options.Debug);
+            OptionsSetInt(cOptions, "debug", options.Debug ? 1 : 0);
+
+            var diagnosticLevel = options.DiagnosticLevel.ToString().ToLowerInvariant();
+            options.DiagnosticLogger?.LogDebug("Setting DiagnosticLevel: {0}", diagnosticLevel);
+            OptionsSetString(cOptions, "environment", diagnosticLevel);
+
+            // Disabling the native in favor of the C# layer for now
+            options.DiagnosticLogger?.LogDebug("Disabling native auto session tracking");
+            OptionsSetInt(cOptions, "enableAutoSessionTracking", 0);
+
+            options.DiagnosticLogger?.LogDebug("Setting SendDefaultPii: {0}", options.SendDefaultPii);
+            OptionsSetInt(cOptions, "sendDefaultPii", options.SendDefaultPii ? 1 : 0);
+
+            options.DiagnosticLogger?.LogDebug("Setting MaxBreadcrumbs: {0}", options.MaxBreadcrumbs);
+            OptionsSetInt(cOptions, "maxBreadcrumbs", options.MaxBreadcrumbs);
+
+            options.DiagnosticLogger?.LogDebug("Setting MaxCacheItems: {0}", options.MaxCacheItems);
+            OptionsSetInt(cOptions, "maxCacheItems", options.MaxCacheItems);
+
+            StartWithOptions(cOptions);
+            return true;
+        }
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeLoadLibrary")]
+        private static extern int LoadLibrary();
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeOptionsNew")]
+        private static extern IntPtr OptionsNew();
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeOptionsSetString")]
+        private static extern void OptionsSetString(IntPtr options, string name, string value);
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeOptionsSetInt")]
+        private static extern void OptionsSetInt(IntPtr options, string name, int value);
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeStartWithOptions")]
+        private static extern void StartWithOptions(IntPtr options);
 
         [DllImport("__Internal", EntryPoint = "SentryNativeBridgeCrashedLastRun")]
         public static extern int CrashedLastRun();

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -43,7 +43,7 @@ namespace Sentry.Unity.iOS
 
             var diagnosticLevel = options.DiagnosticLevel.ToString().ToLowerInvariant();
             options.DiagnosticLogger?.LogDebug("Setting DiagnosticLevel: {0}", diagnosticLevel);
-            OptionsSetString(cOptions, "environment", diagnosticLevel);
+            OptionsSetString(cOptions, "diagnosticLevel", diagnosticLevel);
 
             // Disabling the native in favor of the C# layer for now
             options.DiagnosticLogger?.LogDebug("Disabling native auto session tracking");

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -11,10 +11,13 @@ namespace Sentry.Unity.iOS
     /// <see href="https://github.com/getsentry/sentry-cocoa"/>
     internal static class SentryCocoaBridgeProxy
     {
-        [DllImport("__Internal")]
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeInit")]
+        public static extern int Init();
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeCrashedLastRun")]
         public static extern int CrashedLastRun();
 
-        [DllImport("__Internal")]
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeClose")]
         public static extern void Close();
 
         [DllImport("__Internal")]

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -13,9 +13,9 @@ namespace Sentry.Unity.iOS
     /// <see href="https://github.com/getsentry/sentry-cocoa"/>
     internal static class SentryCocoaBridgeProxy
     {
+        // Note: used on macOS only
         public static bool Init(SentryUnityOptions options)
         {
-            // Note: used on macOS only
             if (LoadLibrary() != 1)
             {
                 return false;

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -29,12 +29,12 @@ namespace Sentry.Unity.iOS
                     {
                         return;
                     }
-                    options.ScopeObserver = new NativeScopeObserver("macOS", options);
-                    if (SentryCocoaBridgeProxy.Init() != 1)
+                    if (!SentryCocoaBridgeProxy.Init(options))
                     {
                         options.DiagnosticLogger?.LogWarning("Failed to initialzie the native SDK");
                         return;
                     }
+                    options.ScopeObserver = new NativeScopeObserver("macOS", options);
                     break;
             }
 

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -4,19 +4,19 @@ using Sentry.Unity.Integrations;
 namespace Sentry.Unity.iOS
 {
     /// <summary>
-    /// Access to the Sentry native support on iOS.
+    /// Access to the Sentry native support on iOS/macOS.
     /// </summary>
-    public static class SentryNativeIos
+    public static class SentryNativeCocoa
     {
         /// <summary>
-        /// Configures the native Android support.
+        /// Configures the native support.
         /// </summary>
         /// <param name="options">The Sentry Unity options to use.</param>
         public static void Configure(SentryUnityOptions options)
         {
             if (options.IosNativeSupportEnabled)
             {
-                options.ScopeObserver = new IosNativeScopeObserver(options);
+                options.ScopeObserver = new NativeScopeObserver("iOS", options);
                 options.EnableScopeSync = true;
                 options.CrashedLastRun = () =>
                 {

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -13,9 +13,11 @@ namespace Sentry.Unity.iOS
         /// Configures the native support.
         /// </summary>
         /// <param name="options">The Sentry Unity options to use.</param>
-        public static void Configure(SentryUnityOptions options)
+        public static void Configure(SentryUnityOptions options) => Configure(options, ApplicationAdapter.Instance.Platform);
+
+        internal static void Configure(SentryUnityOptions options, RuntimePlatform platform)
         {
-            switch (ApplicationAdapter.Instance.Platform)
+            switch (platform)
             {
                 case RuntimePlatform.IPhonePlayer:
                     if (!options.IosNativeSupportEnabled)
@@ -36,6 +38,10 @@ namespace Sentry.Unity.iOS
                     }
                     options.ScopeObserver = new NativeScopeObserver("macOS", options);
                     break;
+                default:
+                    options.DiagnosticLogger?
+                        .LogWarning("Cocoa SentryNative.Configure() called for unsupported platform: '{0}'", platform);
+                    return;
             }
 
             options.EnableScopeSync = true;

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -33,7 +33,7 @@ namespace Sentry.Unity.iOS
                     }
                     if (!SentryCocoaBridgeProxy.Init(options))
                     {
-                        options.DiagnosticLogger?.LogWarning("Failed to initialzie the native SDK");
+                        options.DiagnosticLogger?.LogWarning("Failed to initialize the native SDK");
                         return;
                     }
                     options.ScopeObserver = new NativeScopeObserver("macOS", options);

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -61,6 +61,7 @@ namespace Sentry.Unity
         [field: SerializeField] public bool IosNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool AndroidNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool WindowsNativeSupportEnabled { get; set; } = true;
+        [field: SerializeField] public bool MacosNativeSupportEnabled { get; set; } = true;
 
         [field: SerializeField] public ScriptableOptionsConfiguration? OptionsConfiguration { get; set; }
 
@@ -133,6 +134,7 @@ namespace Sentry.Unity
             options.IosNativeSupportEnabled = IosNativeSupportEnabled;
             options.AndroidNativeSupportEnabled = AndroidNativeSupportEnabled;
             options.WindowsNativeSupportEnabled = WindowsNativeSupportEnabled;
+            options.MacosNativeSupportEnabled = MacosNativeSupportEnabled;
 
             // Because SentryOptions.Debug is used inside the .NET SDK to setup the ConsoleLogger we
             // need to set it here directly.

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -101,6 +101,11 @@ namespace Sentry.Unity
         /// </summary>
         public bool WindowsNativeSupportEnabled { get; set; } = true;
 
+        /// <summary>
+        /// Whether the SDK should add native support for MacOS
+        /// </summary>
+        public bool MacosNativeSupportEnabled { get; set; } = true;
+
         public SentryUnityOptions() : this(ApplicationAdapter.Instance, false)
         {
         }

--- a/test/Scripts.Integration.Test/IntegrationGlobals.ps1
+++ b/test/Scripts.Integration.Test/IntegrationGlobals.ps1
@@ -151,7 +151,7 @@ function TestDsnFor([string] $platform)
     return $dsn
 }
 
-function RunUnityCustom([string] $unityPath, [string[]] $arguments)
+function RunUnityCustom([string] $unityPath, [string[]] $arguments, [switch] $ReturnLogOutput)
 {
     If ($unityPath.StartsWith("docker "))
     {
@@ -161,5 +161,5 @@ function RunUnityCustom([string] $unityPath, [string[]] $arguments)
 
     }
 
-    return RunUnity $unityPath $arguments
+    return RunUnity $unityPath $arguments -ReturnLogOutput:$ReturnLogOutput
 }

--- a/test/Scripts.Integration.Test/IntegrationGlobals.ps1
+++ b/test/Scripts.Integration.Test/IntegrationGlobals.ps1
@@ -63,9 +63,9 @@ function FormatUnityPath
     If ($path)
     {
         #Ajust path on MacOS
-        If ($path -match "Unity.app/$")
+        If ($path -match "Unity.app/?$")
         {
-            $path = $path + "Contents/MacOS"
+            $path = $path + "/Contents/MacOS"
         }
         $unityPath = $path
     }

--- a/test/Scripts.Integration.Test/integration-build-project.ps1
+++ b/test/Scripts.Integration.Test/integration-build-project.ps1
@@ -9,10 +9,8 @@ $unityPath = FormatUnityPath $UnityPath
 $buildMethod = BuildMethodFor $Platform
 $outputPath = "$NewProjectBuildPath/$(GetTestAppName $buildMethod)"
 
-ClearUnityLog
-
 Write-Host -NoNewline "Executing ${buildMethod}:"
 RunUnityCustom $unityPath @("-batchmode", "-projectPath ", "$NewProjectPath", `
-        "-executeMethod", $buildMethod , "-buildPath", $outputPath, "-quit") > $null
+        "-executeMethod", $buildMethod , "-buildPath", $outputPath, "-quit")
 Write-Host "Project built successfully" -ForegroundColor Green
 Get-ChildItem $NewProjectBuildPath

--- a/test/Scripts.Integration.Test/integration-create-project.ps1
+++ b/test/Scripts.Integration.Test/integration-create-project.ps1
@@ -14,14 +14,12 @@ If (Test-Path -Path "$NewProjectPath" )
     Write-Host " OK"
 }
 
-ClearUnityLog
-
 Write-Host -NoNewline "Creating directory for integration test:"
 New-Item -Path "$(ProjectRoot)/samples" -Name $NewProjectName -ItemType "directory"
 Write-Host " OK"
 
 Write-Host "Creating integration project:"
-RunUnityCustom $UnityPath @("-batchmode", "-createProject", "$NewProjectPath", "-quit") > $null
+RunUnityCustom $UnityPath @("-batchmode", "-createProject", "$NewProjectPath", "-quit")
 
 Write-Host -NoNewline "Copying Test scene"
 New-Item -Path "$NewProjectAssetsPath/Scenes" -Name $NewProjectName -ItemType "directory"

--- a/test/Scripts.Integration.Test/integration-run-smoke-test.ps1
+++ b/test/Scripts.Integration.Test/integration-run-smoke-test.ps1
@@ -100,6 +100,17 @@ if ($Smoke) {
 
 # Native crash test
 if ($Crash) {
-    CrashTestWithServer -SuccessString = "POST /api/12345/minidump/" -CrashTestCallback { RunTest "crash" }
-    RunTest "has-crashed"
+    if ($IsMacOS)
+    {
+        # Note: macOS apps post the crash on the second app launch, so we must run both as part of the "CrashTestWithServer"
+        CrashTestWithServer -SuccessString "POST /api/12345/envelope/ HTTP/1.1`" 200 -b'1f8b08000000000000" -CrashTestCallback {
+            RunTest "crash" "CRASH TEST: Issuing a native crash"
+            RunTest "has-crashed"
+        }
+    }
+    else
+    {
+        CrashTestWithServer -SuccessString = "POST /api/12345/minidump/" -CrashTestCallback { RunTest "crash" }
+        RunTest "has-crashed"
+    }
 }

--- a/test/Scripts.Integration.Test/integration-update-sentry.ps1
+++ b/test/Scripts.Integration.Test/integration-update-sentry.ps1
@@ -9,7 +9,7 @@ $UnityPath = FormatUnityPath $UnityPath
 
 function RunUnityAndExpect([string] $name, [string] $successMessage, [string] $failMessage, [string[]] $arguments)
 {
-    $stdout = RunUnityCustom $UnityPath $arguments
+    $stdout = RunUnityCustom $UnityPath $arguments -ReturnLogOutput
     If ($null -ne ($stdout | Select-String $successMessage))
     {
         Write-Host "`n$name | SUCCESS" -ForegroundColor Green

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -13,7 +13,15 @@ Editor/sentry-cli/sentry-cli-Windows-x86_64.exe
 Editor/sentry-cli/sentry-cli-Windows-x86_64.exe.meta
 Plugins/Android.meta
 Plugins/iOS.meta
+Plugins/macOS.meta
 Plugins/Windows.meta
+Plugins/macOS/Sentry.meta
+Plugins/macOS/SentryNativeBridge.m
+Plugins/macOS/SentryNativeBridge.m.meta
+Plugins/macOS/Sentry/Sentry.dylib
+Plugins/macOS/Sentry/Sentry.dylib.dSYM
+Plugins/macOS/Sentry/Sentry.dylib.dSYM.meta
+Plugins/macOS/Sentry/Sentry.dylib.meta
 Plugins/iOS/Device.meta
 Plugins/iOS/SentryNativeBridge.m
 Plugins/iOS/SentryNativeBridge.m.meta

--- a/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -44,6 +44,7 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains("IosNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("AndroidNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("WindowsNativeSupportEnabled", optionsAsString);
+            StringAssert.Contains("MacosNativeSupportEnabled", optionsAsString);
             StringAssert.Contains("OptionsConfiguration", optionsAsString);
             StringAssert.Contains("Debug", optionsAsString);
             StringAssert.Contains("DebugOnlyInEditor", optionsAsString);

--- a/test/Sentry.Unity.iOS.Tests/NativeScopeObserverTests.cs
+++ b/test/Sentry.Unity.iOS.Tests/NativeScopeObserverTests.cs
@@ -11,7 +11,7 @@ namespace Sentry.Unity.iOS.Tests
         {
             var timestamp = DateTimeOffset.UtcNow;
 
-            var timestampString = IosNativeScopeObserver.GetTimestamp(timestamp);
+            var timestampString = NativeScopeObserver.GetTimestamp(timestamp);
             var actualTimestamp = DateTimeOffset.ParseExact(timestampString, "o", CultureInfo.InvariantCulture);
 
             Assert.AreEqual(timestamp, actualTimestamp);
@@ -25,7 +25,7 @@ namespace Sentry.Unity.iOS.Tests
         [TestCase(BreadcrumbLevel.Critical, 5)]
         public void GetBreadcrumbLevel_TestCases(BreadcrumbLevel level, int expectedNativeLevel)
         {
-            var actualLevel = IosNativeScopeObserver.GetBreadcrumbLevel(level);
+            var actualLevel = NativeScopeObserver.GetBreadcrumbLevel(level);
 
             Assert.AreEqual(actualLevel, expectedNativeLevel);
         }

--- a/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
+++ b/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
@@ -2,21 +2,21 @@ using NUnit.Framework;
 
 namespace Sentry.Unity.iOS.Tests
 {
-    public class SentryNativeIosTests
+    public class SentryNativeCocoaTests
     {
         [Test]
         public void Configure_DefaultConfiguration_SetsScopeObserver()
         {
             var options = new SentryUnityOptions();
-            SentryNativeIos.Configure(options);
-            Assert.IsAssignableFrom<IosNativeScopeObserver>(options.ScopeObserver);
+            SentryNativeCocoa.Configure(options);
+            Assert.IsAssignableFrom<NativeScopeObserver>(options.ScopeObserver);
         }
 
         [Test]
         public void Configure_DefaultConfiguration_SetsCrashedLastRun()
         {
             var options = new SentryUnityOptions();
-            SentryNativeIos.Configure(options);
+            SentryNativeCocoa.Configure(options);
             Assert.IsNotNull(options.CrashedLastRun);
         }
 
@@ -24,7 +24,7 @@ namespace Sentry.Unity.iOS.Tests
         public void Configure_NativeIosSupportDisabled_ObserverIsNull()
         {
             var options = new SentryUnityOptions { IosNativeSupportEnabled = false };
-            SentryNativeIos.Configure(options);
+            SentryNativeCocoa.Configure(options);
             Assert.Null(options.ScopeObserver);
         }
 
@@ -32,7 +32,7 @@ namespace Sentry.Unity.iOS.Tests
         public void Configure_DefaultConfiguration_EnablesScopeSync()
         {
             var options = new SentryUnityOptions();
-            SentryNativeIos.Configure(options);
+            SentryNativeCocoa.Configure(options);
             Assert.True(options.EnableScopeSync);
         }
 
@@ -40,7 +40,7 @@ namespace Sentry.Unity.iOS.Tests
         public void Configure_NativeIosSupportDisabled_DisabledScopeSync()
         {
             var options = new SentryUnityOptions { IosNativeSupportEnabled = false };
-            SentryNativeIos.Configure(options);
+            SentryNativeCocoa.Configure(options);
             Assert.False(options.EnableScopeSync);
         }
     }

--- a/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
+++ b/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
@@ -1,46 +1,48 @@
+using System;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Sentry.Unity.iOS.Tests
 {
     public class SentryNativeCocoaTests
     {
         [Test]
-        public void Configure_DefaultConfiguration_SetsScopeObserver()
+        public void Configure_DefaultConfiguration_iOS()
         {
             var options = new SentryUnityOptions();
-            SentryNativeCocoa.Configure(options);
+            SentryNativeCocoa.Configure(options, RuntimePlatform.IPhonePlayer);
             Assert.IsAssignableFrom<NativeScopeObserver>(options.ScopeObserver);
-        }
-
-        [Test]
-        public void Configure_DefaultConfiguration_SetsCrashedLastRun()
-        {
-            var options = new SentryUnityOptions();
-            SentryNativeCocoa.Configure(options);
             Assert.IsNotNull(options.CrashedLastRun);
-        }
-
-        [Test]
-        public void Configure_NativeIosSupportDisabled_ObserverIsNull()
-        {
-            var options = new SentryUnityOptions { IosNativeSupportEnabled = false };
-            SentryNativeCocoa.Configure(options);
-            Assert.Null(options.ScopeObserver);
-        }
-
-        [Test]
-        public void Configure_DefaultConfiguration_EnablesScopeSync()
-        {
-            var options = new SentryUnityOptions();
-            SentryNativeCocoa.Configure(options);
             Assert.True(options.EnableScopeSync);
         }
 
         [Test]
-        public void Configure_NativeIosSupportDisabled_DisabledScopeSync()
+        public void Configure_NativeSupportDisabled_iOS()
         {
             var options = new SentryUnityOptions { IosNativeSupportEnabled = false };
-            SentryNativeCocoa.Configure(options);
+            SentryNativeCocoa.Configure(options, RuntimePlatform.IPhonePlayer);
+            Assert.Null(options.ScopeObserver);
+            Assert.Null(options.CrashedLastRun);
+            Assert.False(options.EnableScopeSync);
+        }
+
+        [Test]
+        public void Configure_DefaultConfiguration_macOS()
+        {
+            var options = new SentryUnityOptions();
+            // Note: can't test macOS - throws because it tries to call SentryCocoaBridgeProxy.Init()
+            // but the bridge isn't loaded now...
+            Assert.Throws<EntryPointNotFoundException>(() =>
+                SentryNativeCocoa.Configure(options, RuntimePlatform.OSXPlayer));
+        }
+
+        [Test]
+        public void Configure_NativeSupportDisabled_macOS()
+        {
+            var options = new SentryUnityOptions { MacosNativeSupportEnabled = false };
+            SentryNativeCocoa.Configure(options, RuntimePlatform.OSXPlayer);
+            Assert.Null(options.ScopeObserver);
+            Assert.Null(options.CrashedLastRun);
             Assert.False(options.EnableScopeSync);
         }
     }


### PR DESCRIPTION
closes #693 - finally found a working solution that's reasonably integrable into Unity build - using a `dylib`, letting Unity add it to the project, and accessing the content dynamically,  using `dlopen()/dsym()`.

Replaces #703 which was deemed too complicated as well as limited (required users to export to xcode).

### TODOs:
* [x] PoC - calling an exposed c-api init() from SentryInitialization.cs, hard-coded DSN, got an issue to sentry.io - https://sentry.io/organizations/sentry-sdks/issues/3083605658/?project=5439417&query=is%3Aunresolved
* [x] bridge code (expose as the necessary objective-c code as C-APIs so we can call from C#)
* [x] initialize (at runtime), after Unity is loaded
* [x] Integration test in CI - after #686 is merged
* [x] Symbol upload
* [ ] anyone some ideas how to improve the [App section](https://sentry.io/organizations/sentry-sdks/issues/3235150078/?project=5439417&query=is%3Aunresolved#context-app) - e.g. "App Build", "Build Type" - it's likely set in [SentryCrashIntegration.m in sentry-cocoa](https://github.com/getsentry/sentry-cocoa/blob/aa03532ec9a5cd1e6816e14b3e6d10aebb1358cf/Sources/Sentry/SentryCrashIntegration.m#L243-L251) but not sure how to influence the content...

### Issue samples:
* https://sentry.io/organizations/sentry-sdks/issues/2677827744/?project=5439417&query=is%3Aunresolved
* https://sentry.io/organizations/sentry-sdks/issues/3235146941/?project=5439417&query=is%3Aunresolved
* https://sentry.io/organizations/sentry-sdks/issues/3235150078/?project=5439417&query=is%3Aunresolved