### PR TITLE
chore: Added log to iOS sample

### DIFF
--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/IosButtons.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/IosButtons.cs
@@ -10,6 +10,7 @@ public class IosButtons : MonoBehaviour
     public void ThrowObjectiveC()
     {
 #if PLATFORM_IOS
+        Debug.Log("The iOS SDK supports capturing Objective-C exceptions. Consider enabling 'GCC_ENABLE_OBJC_EXCEPTIONS' in the Xcode build settings.");
         throwObjectiveC();
 #else
         Debug.Log("Requires IL2CPP. Try this on a native player that supports Objective-C native plugins.");


### PR DESCRIPTION
The sample does nothing as long as `GCC_ENABLE_OBJC_EXCEPTIONS`is disabled.
Improved the docs regarding this here https://github.com/getsentry/sentry-docs/pull/4992

#skip-changelog