### PR TITLE
ref: SetupLogging as extension 

### DIFF
--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -132,7 +132,7 @@ namespace Sentry.Unity
             options.Debug = ShouldDebug(application.IsEditor && !isBuilding);
             options.DiagnosticLevel = DiagnosticLevel;
 
-            options.TryAttachLogger();
+            options.SetupLogging();
 
             OptionsConfiguration?.Configure(options);
 

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -32,7 +32,7 @@ namespace Sentry.Unity
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Init(SentryUnityOptions options)
         {
-            options.TryAttachLogger();
+            options.SetupLogging();
             if (options.ShouldInitializeSdk())
             {
                 // On Standalone, we disable cache dir in case multiple app instances run over the same path.

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -157,14 +157,6 @@ Environment: {Environment}
 Offline Caching: {(CacheDirectoryPath is null ? "disabled" : "enabled")}
 ";
         }
-
-        internal void TryAttachLogger()
-        {
-            if (Debug && DiagnosticLogger is null)
-            {
-                DiagnosticLogger = new UnityLogger(this);
-            }
-        }
     }
 
     /// <summary>

--- a/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
+++ b/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
@@ -48,5 +48,21 @@ namespace Sentry.Unity
 
             return true;
         }
+
+        internal static void SetupLogging(this SentryUnityOptions options)
+        {
+            if (options.Debug)
+            {
+                if (options.DiagnosticLogger is null)
+                {
+                    options.DiagnosticLogger = new UnityLogger(options);
+                    options.DiagnosticLogger.LogDebug("Logging enabled with 'UnityLogger' min level: {0}", options.DiagnosticLevel);
+                }
+            }
+            else
+            {
+                options.DiagnosticLogger = null;
+            }
+        }
     }
 }

--- a/test/Sentry.Unity.Tests/SentryUnityOptionsExtensionsTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityOptionsExtensionsTests.cs
@@ -92,9 +92,11 @@ namespace Sentry.Unity.Tests
         }
 
         [Test]
-        public void SetupLogging_DebugTrue_SetsUnityLogger()
+        public void SetupLogging_DebugAndNoDiagnosticLogger_SetsUnityLogger()
         {
             var options = _fixture.GetSut();
+
+            Assert.IsNull(options.DiagnosticLogger); // Sanity check
 
             options.SetupLogging();
 
@@ -102,7 +104,7 @@ namespace Sentry.Unity.Tests
         }
 
         [Test]
-        public void SetupLogging_DebugFalse_RemovesUnityLogger()
+        public void SetupLogging_DebugFalse_DiagnosticLoggerIsNull()
         {
             _fixture.Debug = false;
             var options = _fixture.GetSut();
@@ -111,6 +113,20 @@ namespace Sentry.Unity.Tests
             options.SetupLogging();
 
             Assert.IsNull(options.DiagnosticLogger);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetupLogging_DiagnosticLoggerSet_LeavesOrRemovesDiagnosticLogger(bool debug)
+        {
+            _fixture.Debug = debug;
+            var options = _fixture.GetSut();
+            options.DiagnosticLogger = new UnityLogger(options);
+
+            options.SetupLogging();
+
+            Assert.AreEqual(debug, options.DiagnosticLogger is not null);
         }
     }
 }

--- a/test/Sentry.Unity.Tests/SentryUnityOptionsExtensionsTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityOptionsExtensionsTests.cs
@@ -11,12 +11,14 @@ namespace Sentry.Unity.Tests
             public bool Enabled { get; set; } = true;
             public string Dsn { get; set; } = "http://test.com";
             public bool CaptureInEditor { get; set; } = true;
+            public bool Debug { get; set; } = true;
 
             public SentryUnityOptions GetSut() => new()
             {
                 Enabled = Enabled,
                 Dsn = Dsn,
-                CaptureInEditor = CaptureInEditor
+                CaptureInEditor = CaptureInEditor,
+                Debug = Debug,
             };
         }
 
@@ -87,6 +89,28 @@ namespace Sentry.Unity.Tests
             var shouldInitialize = options.ShouldInitializeSdk(_fixture.TestApplication);
 
             Assert.IsFalse(shouldInitialize);
+        }
+
+        [Test]
+        public void SetupLogging_DebugTrue_SetsUnityLogger()
+        {
+            var options = _fixture.GetSut();
+
+            options.SetupLogging();
+
+            Assert.IsInstanceOf<UnityLogger>(options.DiagnosticLogger);
+        }
+
+        [Test]
+        public void SetupLogging_DebugFalse_RemovesUnityLogger()
+        {
+            _fixture.Debug = false;
+            var options = _fixture.GetSut();
+            options.DiagnosticLogger = new UnityLogger(options);
+
+            options.SetupLogging();
+
+            Assert.IsNull(options.DiagnosticLogger);
         }
     }
 }


### PR DESCRIPTION
Mirroring the .NET SDK by moving `TryAttachLogger` to options extension `SetupLogging`.

#skip-changelog