### PR TITLE
Feat: Automatic user IDs on native crashes & .NET events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - macOS native crash support ([#710](https://github.com/getsentry/sentry-unity/pull/710))
 - The SentryUnityOptions now provide a method to disable the UnityLoggingIntegration ([#724](https://github.com/getsentry/sentry-unity/pull/724))
+- Automatic user IDs on native crashes & .NET events ([#728](https://github.com/getsentry/sentry-unity/pull/728))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Linux native crash support ([#734](https://github.com/getsentry/sentry-unity/pull/734))
 - Collect context information synchronously during init to capture it for very early events ([#744](https://github.com/getsentry/sentry-unity/pull/744))
+- Automatic user IDs on native crashes & .NET events ([#728](https://github.com/getsentry/sentry-unity/pull/728))
 
 ## 0.16.0
 
@@ -13,7 +14,6 @@
 
 - macOS native crash support ([#710](https://github.com/getsentry/sentry-unity/pull/710))
 - The SentryUnityOptions now provide a method to disable the UnityLoggingIntegration ([#724](https://github.com/getsentry/sentry-unity/pull/724))
-- Automatic user IDs on native crashes & .NET events ([#728](https://github.com/getsentry/sentry-unity/pull/728))
 
 ### Fixes
 

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -1,3 +1,4 @@
+#import <Sentry/PrivateSentrySDKOnly.h>
 #import <Sentry/Sentry.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -119,6 +120,17 @@ void SentryNativeBridgeSetUser(
 void SentryNativeBridgeUnsetUser()
 {
     [SentrySDK configureScope:^(SentryScope *scope) { [scope setUser:nil]; }];
+}
+
+char *SentryNativeBridgeGetInstallationId()
+{
+    // Create a null terminated C string on the heap as expected by marshalling.
+    // See Tips for iOS in https://docs.unity3d.com/Manual/PluginsForIOS.html
+    const char *nsStringUtf8 = [[PrivateSentrySDKOnly installationID] UTF8String];
+    size_t len = strlen(nsStringUtf8) + 1;
+    char *cString = (char *)malloc(len);
+    memcpy(cString, nsStringUtf8, len);
+    return cString;
 }
 
 NS_ASSUME_NONNULL_END

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -43,7 +43,7 @@ namespace Sentry.Unity
                 try
                 {
 #if SENTRY_NATIVE_COCOA
-                    SentryNativeCocoa.Configure(options);
+                    SentryNativeCocoa.Configure(options, sentryUnityInfo);
 #elif SENTRY_NATIVE_ANDROID
                     SentryNativeAndroid.Configure(options, sentryUnityInfo);
 #elif SENTRY_NATIVE

--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -125,6 +125,7 @@ public class SmokeTester : MonoBehaviour
 
             t.ExpectMessage(currentMessage, "'type':'event'");
             t.ExpectMessage(currentMessage, $"LogError(GUID)={guid}");
+            t.ExpectMessage(currentMessage, "'user':{'id':'"); // non-null automatic ID
             t.ExpectMessage(currentMessage, "'filename':'screenshot.jpg','attachment_type':'event.attachment'");
             t.ExpectMessageNot(currentMessage, "'length':0");
 

--- a/scripts/smoke-test-webgl.py
+++ b/scripts/smoke-test-webgl.py
@@ -183,6 +183,7 @@ t.ExpectMessage(currentMessage, "'type':'session'")
 currentMessage += 1
 t.ExpectMessage(currentMessage, "'type':'event'")
 t.ExpectMessage(currentMessage, "LogError(GUID)")
+t.ExpectMessage(currentMessage, "'user':{'id':'")
 # t.ExpectMessage(
 #     currentMessage, "'filename':'screenshot.jpg','attachment_type':'event.attachment'")
 # t.ExpectMessageNot(currentMessage, "'length':0")

--- a/scripts/smoke-test-webgl.py
+++ b/scripts/smoke-test-webgl.py
@@ -63,6 +63,9 @@ class RequestVerifier:
             raise Exception(info)
 
     def CheckMessage(self, index, substring, negate):
+        if len(self.__requests) <= index:
+            raise Exception('HTTP Request #{} not captured.'.format(index))
+
         message = self.__requests[index]["body"]
         contains = substring in message or substring.replace(
             "'", "\"") in message

--- a/scripts/unity-utils.ps1
+++ b/scripts/unity-utils.ps1
@@ -66,11 +66,13 @@ function RunUnity([string] $unityPath, [string[]] $arguments, [switch] $ReturnLo
             break
         }
     } while ($stopwatch.Elapsed.TotalSeconds -lt $RunUnityLicenseRetryTimeoutSeconds)
-    
+
     if ($process.ExitCode -ne 0)
     {
         Throw "Unity exited with code $($process.ExitCode)"
     }
+
+    Write-Host -ForegroundColor Green "Unity finished successfully. Time taken: $($stopwatch.Elapsed.ToString('hh\:mm\:ss\.fff'))"
     return $ReturnLogOutput ? $stdout : $null
 }
 

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -3,15 +3,28 @@ using UnityEngine;
 namespace Sentry.Unity.Android
 {
     /// <summary>
-    /// P/Invoke to `sentry-java` methods.
+    /// JNI access to `sentry-java` methods.
     /// </summary>
     /// <remarks>
     /// The `sentry-java` SDK on Android is brought in through the `sentry-android-core`
     /// and `sentry-java` maven packages.
     /// </remarks>
     /// <see href="https://github.com/getsentry/sentry-java"/>
-    public static class SentryJava
+    internal static class SentryJava
     {
+        internal static string? GetInstallationId()
+        {
+            if (!Attach())
+            {
+                return null;
+            }
+
+            using var sentry = GetSentryJava();
+            using var hub = sentry.CallStatic<AndroidJavaObject>("getCurrentHub");
+            using var options = hub?.Call<AndroidJavaObject>("getOptions");
+            return options?.Call<string>("getDistinctId");
+        }
+
         /// <summary>
         /// Returns whether or not the last run resulted in a crash.
         /// </summary>
@@ -24,15 +37,25 @@ namespace Sentry.Unity.Android
         /// </returns>
         public static bool? CrashedLastRun()
         {
-            using var jo = new AndroidJavaObject("io.sentry.Sentry");
-            return jo.CallStatic<AndroidJavaObject>("isCrashedLastRun")
-                ?.Call<bool>("booleanValue");
+            if (!Attach())
+            {
+                return null;
+            }
+            using var sentry = GetSentryJava();
+            using var jo = sentry.CallStatic<AndroidJavaObject>("isCrashedLastRun");
+            return jo?.Call<bool>("booleanValue");
         }
 
         public static void Close()
         {
-            using var jo = new AndroidJavaObject("io.sentry.Sentry");
-            jo.CallStatic("close");
+            if (Attach())
+            {
+                using var sentry = GetSentryJava();
+                sentry.CallStatic("close");
+            }
         }
+
+        private static bool Attach() => AndroidJNI.AttachCurrentThread() == 0;
+        private static AndroidJavaObject GetSentryJava() => new AndroidJavaClass("io.sentry.Sentry");
     }
 }

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -51,6 +51,17 @@ namespace Sentry.Unity.Android
                     options.DiagnosticLogger?.LogDebug("Closing the sentry-java SDK");
                     SentryJava.Close();
                 };
+
+                options.DefaultUserId = SentryJava.GetInstallationId();
+                if (options.DefaultUserId is not null)
+                {
+                    options.DiagnosticLogger?
+                                .LogDebug("Setting Android 'installationId' '{0}' as the default user ID.", options.DefaultUserId);
+                }
+                else
+                {
+                    options.DiagnosticLogger?.LogWarning("Failed to set the default user ID based on Android 'installationId'.");
+                }
             }
         }
     }

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -53,15 +53,6 @@ namespace Sentry.Unity.Android
                 };
 
                 options.DefaultUserId = SentryJava.GetInstallationId();
-                if (options.DefaultUserId is not null)
-                {
-                    options.DiagnosticLogger?
-                                .LogDebug("Setting Android installationId ('{0}') as the default user ID.", options.DefaultUserId);
-                }
-                else
-                {
-                    options.DiagnosticLogger?.LogWarning("Failed to set the default user ID based on Android 'installationId'.");
-                }
             }
         }
     }

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -56,7 +56,7 @@ namespace Sentry.Unity.Android
                 if (options.DefaultUserId is not null)
                 {
                     options.DiagnosticLogger?
-                                .LogDebug("Setting Android 'installationId' '{0}' as the default user ID.", options.DefaultUserId);
+                                .LogDebug("Setting Android installationId ('{0}') as the default user ID.", options.DefaultUserId);
                 }
                 else
                 {

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -45,8 +45,6 @@ namespace Sentry.Unity.Native
                 options.DefaultUserId = AnalyticsSessionInfo.userId;
                 if (options.DefaultUserId is not null)
                 {
-                    options.DiagnosticLogger?.LogDebug(
-                        "Setting Unity AnalyticsSessionInfo.userId ('{0}') as the default user ID.", options.DefaultUserId);
                     options.ScopeObserver.SetUser(new User { Id = options.DefaultUserId });
                 }
 

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -2,6 +2,7 @@ using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Analytics;
 
 namespace Sentry.Unity.Native
 {
@@ -39,6 +40,15 @@ namespace Sentry.Unity.Native
                 };
                 options.ScopeObserver = new NativeScopeObserver(options);
                 options.EnableScopeSync = true;
+
+                // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
+                options.DefaultUserId = AnalyticsSessionInfo.userId;
+                if (options.DefaultUserId is not null)
+                {
+                    options.DiagnosticLogger?.LogDebug(
+                        "Setting Unity AnalyticsSessionInfo.userId ('{0}') as the default user ID.", options.DefaultUserId);
+                    options.ScopeObserver.SetUser(new User { Id = options.DefaultUserId });
+                }
 
                 // Note: we must actually call the function now and on every other call use the value we get here.
                 // Additionally, we cannot call this multiple times for the same directory, because the result changes

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -100,5 +100,8 @@ namespace Sentry.Unity.iOS
 
         [DllImport("__Internal")]
         public static extern void SentryNativeBridgeUnsetUser();
+
+        [DllImport("__Internal", EntryPoint = "SentryNativeBridgeGetInstallationId")]
+        public static extern string GetInstallationId();
     }
 }

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -13,9 +13,10 @@ namespace Sentry.Unity.iOS
         /// Configures the native support.
         /// </summary>
         /// <param name="options">The Sentry Unity options to use.</param>
-        public static void Configure(SentryUnityOptions options) => Configure(options, ApplicationAdapter.Instance.Platform);
+        public static void Configure(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo) =>
+            Configure(options, sentryUnityInfo, ApplicationAdapter.Instance.Platform);
 
-        internal static void Configure(SentryUnityOptions options, RuntimePlatform platform)
+        internal static void Configure(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo, RuntimePlatform platform)
         {
             switch (platform)
             {
@@ -58,7 +59,10 @@ namespace Sentry.Unity.iOS
                 options.DiagnosticLogger?.LogDebug("Closing the sentry-cocoa SDK");
                 SentryCocoaBridgeProxy.Close();
             };
-            options.DefaultUserId = SentryCocoaBridgeProxy.GetInstallationId();
+            if (sentryUnityInfo.IL2CPP)
+            {
+                options.DefaultUserId = SentryCocoaBridgeProxy.GetInstallationId();
+            }
         }
     }
 }

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -59,15 +59,6 @@ namespace Sentry.Unity.iOS
                 SentryCocoaBridgeProxy.Close();
             };
             options.DefaultUserId = SentryCocoaBridgeProxy.GetInstallationId();
-            if (options.DefaultUserId is not null)
-            {
-                options.DiagnosticLogger?
-                            .LogDebug("Setting installationId ('{0}') as the default user ID.", options.DefaultUserId);
-            }
-            else
-            {
-                options.DiagnosticLogger?.LogWarning("Failed to set the default user ID based on installationId (empty).");
-            }
         }
     }
 }

--- a/src/Sentry.Unity.iOS/SentryNative.cs
+++ b/src/Sentry.Unity.iOS/SentryNative.cs
@@ -58,6 +58,16 @@ namespace Sentry.Unity.iOS
                 options.DiagnosticLogger?.LogDebug("Closing the sentry-cocoa SDK");
                 SentryCocoaBridgeProxy.Close();
             };
+            options.DefaultUserId = SentryCocoaBridgeProxy.GetInstallationId();
+            if (options.DefaultUserId is not null)
+            {
+                options.DiagnosticLogger?
+                            .LogDebug("Setting installationId ('{0}') as the default user ID.", options.DefaultUserId);
+            }
+            else
+            {
+                options.DiagnosticLogger?.LogWarning("Failed to set the default user ID based on installationId (empty).");
+            }
         }
     }
 }

--- a/src/Sentry.Unity/Sentry.Unity.csproj
+++ b/src/Sentry.Unity/Sentry.Unity.csproj
@@ -27,4 +27,9 @@
       Overwrite="true"/>
   </Target>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sentry.Unity.Native</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -110,8 +110,9 @@ namespace Sentry.Unity
         /// Whether the SDK should add native support for Linux
         /// </summary>
         public bool LinuxNativeSupportEnabled { get; set; } = true;
-        // Initialized by native SDK binding code and to set the User.ID in sentry-dotnet.
 
+
+        // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).
         internal string? DefaultUserId;
 
         public SentryUnityOptions() : this(ApplicationAdapter.Instance, false)

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using Sentry.Unity.Integrations;
+using Sentry.Extensibility;
 using CompressionLevel = System.IO.Compression.CompressionLevel;
 
 namespace Sentry.Unity
@@ -113,7 +114,23 @@ namespace Sentry.Unity
 
 
         // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).
-        internal string? DefaultUserId;
+        internal string? _defaultUserId;
+        internal string? DefaultUserId
+        {
+            get => _defaultUserId;
+            set
+            {
+                _defaultUserId = value;
+                if (_defaultUserId is null)
+                {
+                    DiagnosticLogger?.LogWarning("Couldn't set the default user ID - the value is NULL.");
+                }
+                else
+                {
+                    DiagnosticLogger?.LogDebug("Setting '{0}' as the default user ID.", _defaultUserId);
+                }
+            }
+        }
 
         public SentryUnityOptions() : this(ApplicationAdapter.Instance, false)
         {

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -110,6 +110,9 @@ namespace Sentry.Unity
         /// Whether the SDK should add native support for Linux
         /// </summary>
         public bool LinuxNativeSupportEnabled { get; set; } = true;
+        // Initialized by native SDK binding code and to set the User.ID in sentry-dotnet.
+
+        internal string? DefaultUserId;
 
         public SentryUnityOptions() : this(ApplicationAdapter.Instance, false)
         {

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -19,12 +19,12 @@ namespace Sentry.Unity
 
     internal class UnityEventProcessor : ISentryEventProcessor
     {
-        private readonly SentryOptions _sentryOptions;
+        private readonly SentryUnityOptions _sentryOptions;
         private readonly MainThreadData _mainThreadData;
         private readonly IApplication _application;
 
 
-        public UnityEventProcessor(SentryOptions sentryOptions, SentryMonoBehaviour sentryMonoBehaviour, IApplication? application = null)
+        public UnityEventProcessor(SentryUnityOptions sentryOptions, SentryMonoBehaviour sentryMonoBehaviour, IApplication? application = null)
         {
             _sentryOptions = sentryOptions;
             _mainThreadData = sentryMonoBehaviour.MainThreadData;
@@ -42,6 +42,7 @@ namespace Sentry.Unity
                 PopulateGpu(@event.Contexts.Gpu);
                 PopulateUnity((Protocol.Unity)@event.Contexts.GetOrAdd(Protocol.Unity.Type, _ => new Protocol.Unity()));
                 PopulateTags(@event);
+                PopulateUser(@event);
             }
             catch (Exception ex)
             {
@@ -209,6 +210,17 @@ namespace Sentry.Unity
             }
 
             @event.SetTag("unity.is_main_thread", _mainThreadData.IsMainThread().ToTagValue());
+        }
+
+        private void PopulateUser(SentryEvent @event)
+        {
+            if (_sentryOptions.DefaultUserId is not null)
+            {
+                if (@event.User.Id is null)
+                {
+                    @event.User.Id = _sentryOptions.DefaultUserId;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Sentry.Unity/WebGL/SentryWebGL.cs
+++ b/src/Sentry.Unity/WebGL/SentryWebGL.cs
@@ -40,11 +40,6 @@ namespace Sentry.Unity.WebGL
 
             // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
             options.DefaultUserId = AnalyticsSessionInfo.userId;
-            if (options.DefaultUserId is not null)
-            {
-                options.DiagnosticLogger?.LogDebug(
-                    "Setting Unity AnalyticsSessionInfo.userId ('{0}') as the default user ID.", options.DefaultUserId);
-            }
         }
     }
 }

--- a/src/Sentry.Unity/WebGL/SentryWebGL.cs
+++ b/src/Sentry.Unity/WebGL/SentryWebGL.cs
@@ -1,4 +1,5 @@
 using Sentry.Extensibility;
+using UnityEngine.Analytics;
 
 namespace Sentry.Unity.WebGL
 {
@@ -35,6 +36,14 @@ namespace Sentry.Unity.WebGL
                 options.AttachScreenshot = false;
                 options.DiagnosticLogger?.LogWarning("Attaching screenshots on WebGL is disabled - " +
                     "it currently produces blank screenshots mid-frame.");
+            }
+
+            // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
+            options.DefaultUserId = AnalyticsSessionInfo.userId;
+            if (options.DefaultUserId is not null)
+            {
+                options.DiagnosticLogger?.LogDebug(
+                    "Setting Unity AnalyticsSessionInfo.userId ('{0}') as the default user ID.", options.DefaultUserId);
             }
         }
     }

--- a/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
+++ b/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
@@ -4,13 +4,26 @@ using UnityEngine;
 
 namespace Sentry.Unity.iOS.Tests
 {
+    public class TestSentryUnityInfo : ISentryUnityInfo
+    {
+        public bool IL2CPP { get; set; }
+    }
+
     public class SentryNativeCocoaTests
     {
+        private TestSentryUnityInfo _sentryUnityInfo = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sentryUnityInfo = new TestSentryUnityInfo { IL2CPP = false };
+        }
+
         [Test]
         public void Configure_DefaultConfiguration_iOS()
         {
             var options = new SentryUnityOptions();
-            SentryNativeCocoa.Configure(options, RuntimePlatform.IPhonePlayer);
+            SentryNativeCocoa.Configure(options, _sentryUnityInfo, RuntimePlatform.IPhonePlayer);
             Assert.IsAssignableFrom<NativeScopeObserver>(options.ScopeObserver);
             Assert.IsNotNull(options.CrashedLastRun);
             Assert.True(options.EnableScopeSync);
@@ -20,7 +33,7 @@ namespace Sentry.Unity.iOS.Tests
         public void Configure_NativeSupportDisabled_iOS()
         {
             var options = new SentryUnityOptions { IosNativeSupportEnabled = false };
-            SentryNativeCocoa.Configure(options, RuntimePlatform.IPhonePlayer);
+            SentryNativeCocoa.Configure(options, _sentryUnityInfo, RuntimePlatform.IPhonePlayer);
             Assert.Null(options.ScopeObserver);
             Assert.Null(options.CrashedLastRun);
             Assert.False(options.EnableScopeSync);
@@ -33,14 +46,14 @@ namespace Sentry.Unity.iOS.Tests
             // Note: can't test macOS - throws because it tries to call SentryCocoaBridgeProxy.Init()
             // but the bridge isn't loaded now...
             Assert.Throws<EntryPointNotFoundException>(() =>
-                SentryNativeCocoa.Configure(options, RuntimePlatform.OSXPlayer));
+                SentryNativeCocoa.Configure(options, _sentryUnityInfo, RuntimePlatform.OSXPlayer));
         }
 
         [Test]
         public void Configure_NativeSupportDisabled_macOS()
         {
             var options = new SentryUnityOptions { MacosNativeSupportEnabled = false };
-            SentryNativeCocoa.Configure(options, RuntimePlatform.OSXPlayer);
+            SentryNativeCocoa.Configure(options, _sentryUnityInfo, RuntimePlatform.OSXPlayer);
             Assert.Null(options.ScopeObserver);
             Assert.Null(options.CrashedLastRun);
             Assert.False(options.EnableScopeSync);


### PR DESCRIPTION
closes #606 

* [x] android -> [dotnet](https://sentry.io/organizations/sentry-sdks/issues/3013122412/events/24772b6605694aeaa42378755ae9f31b/?project=5439417)
* [x] iOS-> [dotnet](https://sentry.io/organizations/sentry-sdks/issues/2771507099/events/c74dfdc14c5444fda5a37287f59e62cb/?project=5439417)
* [x] macOS -> [dotnet](https://sentry.io/organizations/sentry-sdks/issues/2771507099/events/23e47e291dc34cfeb2b62984693b4085/?project=5439417)
* [x] [Unity](https://docs.unity3d.com/ScriptReference/Analytics.AnalyticsSessionInfo-userId.html) -> [dotnet](https://sentry.io/organizations/sentry-sdks/issues/3013122412/events/2d5c0c8bdf0a46059dc01a69bfcf4799/?project=5439417) -> [Windows](https://sentry.io/organizations/sentry-sdks/issues/3250798745/events/3a5d39fd411f4a1e90ec3963349b8b86/?project=5439417)
* [x]  Unity -> [dotnet](https://sentry.io/organizations/sentry-sdks/issues/2771507099/events/59843f407c1048cbaa8d95efe0be85b1/?project=5439417) -> [Linux](https://sentry.io/organizations/sentry-sdks/issues/3262191687/events/26b52e0cc279401d4f1ee39d28707288/?project=5439417)
* [x]  Unity -> [dotnet](https://sentry.io/organizations/sentry-sdks/issues/3013122412/events/061c6bca5932424288ccdae07ca8bab3/?project=5439417) on WebGL. Notes:
  -  the ID seems to persist across tabs & browser sessions, likely a cookie or local storage based, so pretty useful and in line with other platforms
  - opening in a different browser or a private tab gives a new ID, which is also OK