### PR TITLE
fix: Android debug symbols 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- The automated debug symbol upload now works with Unity 2021.2 and newer ([#730](https://github.com/getsentry/sentry-unity/pull/730))
 - Dropped support for Sentry options as Json ([#709](https://github.com/getsentry/sentry-unity/pull/709))
   - If you're migrating from version 0.3.0 or older, make sure to upgrade to 0.15.0 first, as it is the last version supporting the automated conversion of the options as Json file to a Scriptable Object.
 - Bump Sentry .NET SDK 3.17.0 ([#726](https://github.com/getsentry/sentry-unity/pull/726))

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -162,14 +162,14 @@ namespace Sentry.Unity.Editor.Android
             if (sentryCliOptions is null)
             {
                 logger.LogWarning("Failed to load sentry-cli options.");
-                symbolsUpload.RemoveUploadTaskFromGradleFile();
+                symbolsUpload.RemoveUploadFromGradleFile();
 
                 return;
             }
 
             if (!sentryCliOptions.IsValid(logger, _isDevelopmentBuild))
             {
-                symbolsUpload.RemoveUploadTaskFromGradleFile();
+                symbolsUpload.RemoveUploadFromGradleFile();
                 return;
             }
 

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -170,15 +170,28 @@ namespace Sentry.Unity.Editor.Android
 
             try
             {
-                var symbolsPath = DebugSymbolUpload.GetSymbolsPath(
-                    unityProjectPath,
-                    gradleProjectPath,
-                    EditorUserBuildSettings.exportAsGoogleAndroidProject);
+                logger.LogInfo("Adding automated debug symbol upload.");
+
+                var symbolsUpload = new DebugSymbolUpload(logger);
+                var symbolsPath = Array.Empty<string>();
+
+                if (EditorUserBuildSettings.exportAsGoogleAndroidProject)
+                {
+                    // copy symbols?
+
+                    logger.LogDebug("Exporting project: trying to take the symbols with us.");
+                    symbolsPath = new[] { gradleProjectPath };
+                }
+                else
+                {
+                    symbolsPath = symbolsUpload.GetDefaultSymbolPaths(unityProjectPath);
+                }
 
                 var sentryCliPath = SentryCli.SetupSentryCli();
                 SentryCli.CreateSentryProperties(gradleProjectPath, sentryCliOptions);
 
-                DebugSymbolUpload.AppendUploadToGradleFile(sentryCliPath, gradleProjectPath, symbolsPath);
+                // TODO: make this  reentrant!
+                symbolsUpload.AppendUploadToGradleFile(sentryCliPath, gradleProjectPath, symbolsPath);
             }
             catch (Exception e)
             {

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -161,21 +161,21 @@ namespace Sentry.Unity.Editor.Android
             var sentryCliOptions = _getSentryCliOptions();
             if (sentryCliOptions is null)
             {
-                logger.LogWarning("Failed to load sentry-cli options - Skipping symbols upload.");
-                symbolsUpload.RemoveUploadFromGradleFile();
+                logger.LogWarning("Failed to load sentry-cli options.");
+                symbolsUpload.RemoveUploadTaskFromGradleFile();
 
                 return;
             }
 
             if (!sentryCliOptions.IsValid(logger, _isDevelopmentBuild))
             {
-                symbolsUpload.RemoveUploadFromGradleFile();
+                symbolsUpload.RemoveUploadTaskFromGradleFile();
                 return;
             }
 
             try
             {
-                logger.LogInfo("Adding automated debug symbol upload.");
+                logger.LogInfo("Adding automated debug symbol upload to the gradle project.");
 
                 var sentryCliPath = SentryCli.SetupSentryCli();
                 SentryCli.CreateSentryProperties(gradleProjectPath, sentryCliOptions);

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -37,14 +37,15 @@ gradle.taskGraph.whenReady {{
         public DebugSymbolUpload(IDiagnosticLogger logger,
             string unityProjectPath,
             string gradleProjectPath,
-            bool isExporting = false)
+            bool isExporting = false,
+            IApplication? application = null)
         {
             _logger = logger;
 
             _unityProjectPath = unityProjectPath;
             _gradleProjectPath = gradleProjectPath;
 
-            _symbolUploadPaths = GetSymbolUploadPaths(isExporting);
+            _symbolUploadPaths = GetSymbolUploadPaths(isExporting, application);
         }
 
         public void AppendUploadToGradleFile(string sentryCliPath)

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -143,6 +143,7 @@ gradle.taskGraph.whenReady {{
         {
             if (isExporting)
             {
+                _logger.LogInfo("Exporting the project. Root for symbols upload: {0}", _gradleProjectPath);
                 return new[] { _gradleProjectPath };
             }
 

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -14,7 +14,7 @@ namespace Sentry.Unity.Editor.Android
         internal const string RelativeBuildOutputPathOld = "Temp/StagingArea/symbols";
         internal const string RelativeGradlePathOld = "Temp/gradleOut";
         internal const string RelativeBuildOutputPathNew = "Library/Bee/artifacts/Android";
-        internal const string RelativeAndroidPathNew = "Library/Android";
+        internal const string RelativeAndroidPathNew = "Library/Bee/Android";
 
         private readonly string _unityProjectPath;
         private readonly string _gradleProjectPath;

--- a/src/Sentry.Unity/Integrations/IApplication.cs
+++ b/src/Sentry.Unity/Integrations/IApplication.cs
@@ -12,6 +12,7 @@ namespace Sentry.Unity.Integrations
         bool IsEditor { get; }
         string ProductName { get; }
         string Version { get; }
+        string UnityVersion { get; }
         string PersistentDataPath { get; }
         RuntimePlatform Platform { get; }
     }
@@ -40,6 +41,7 @@ namespace Sentry.Unity.Integrations
         public string ProductName => Application.productName;
 
         public string Version => Application.version;
+        public string UnityVersion => Application.unityVersion;
 
         public string PersistentDataPath => Application.persistentDataPath;
 

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -317,6 +317,8 @@ namespace Sentry.Unity.Editor.Tests.Android
             sut.SetupSymbolsUpload("unity_project_path", gradleProjectPath);
 
             _fixture.LoggerInterceptor.AssertLogContains(SentryLevel.Debug, "sentry-cli: Automated symbols upload has been disabled.");
+
+            Directory.Delete(Path.GetFullPath(fakeProjectPath), true);
         }
 
         [Test]

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -183,10 +183,11 @@ namespace Sentry.Unity.Editor.Tests.Android
         [Test]
         public void TryCopySymbolsToGradleProject_IsOldBuildingBackend_CopiesFilesFromBuildOutputToSymbolsDirectory()
         {
+            _fixture.Application = new TestApplication(unityVersion: "2019.4");
             var expectedSymbolsPath = Path.Combine(_fixture.GradleProjectPath, "symbols");
             var sut = _fixture.GetSut();
 
-            sut.TryCopySymbolsToGradleProject();
+            sut.TryCopySymbolsToGradleProject(_fixture.Application);
 
             var files = Directory.GetFiles(expectedSymbolsPath, "*.so", SearchOption.AllDirectories).ToList();
             Assert.IsNotNull(files.Find(f => f.EndsWith("libil2cpp.dbg.so")));

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -3,7 +3,10 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using Sentry.Extensibility;
 using Sentry.Unity.Editor.Android;
+using Sentry.Unity.Tests.SharedClasses;
+using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
 
 namespace Sentry.Unity.Editor.Tests.Android
@@ -12,6 +15,8 @@ namespace Sentry.Unity.Editor.Tests.Android
     {
         private class Fixture
         {
+            public TestApplication Application { get; set; }
+            public TestUnityLoggerInterceptor LoggerInterceptor { get; set; }
             public string FakeProjectPath { get; set; }
             public string UnityProjectPath { get; set; }
             public string GradleProjectPath { get; set; }
@@ -19,12 +24,17 @@ namespace Sentry.Unity.Editor.Tests.Android
 
             public Fixture()
             {
+                Application = new TestApplication(unityVersion: "2019.4");
+                LoggerInterceptor = new();
+
                 FakeProjectPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
                 UnityProjectPath = Path.Combine(FakeProjectPath, "UnityProject");
                 GradleProjectPath = Path.Combine(FakeProjectPath, "GradleProject");
                 SentryCliPath = Path.Combine(FakeProjectPath, "fake-sentry-cli");
             }
+
+            public DebugSymbolUpload GetSut() => new(new UnityLogger(new SentryOptions(), LoggerInterceptor), UnityProjectPath, GradleProjectPath);
         }
 
         [SetUp]
@@ -40,77 +50,144 @@ namespace Sentry.Unity.Editor.Tests.Android
         public void TearDown() => Directory.Delete(Path.GetFullPath(_fixture.FakeProjectPath), true);
 
         [Test]
-        public void GetSymbolsPath_IsExportingFalse_ReturnsUnityDefaultPath()
+        [TestCase("2019.4", false)]
+        [TestCase("2020.3", false)]
+        [TestCase("2021.1", false)]
+        [TestCase("2021.2", true)]
+        [TestCase("2022.1", true)]
+        public void IsNewBuildingBackend(string unityVersion, bool expectedIsNewBuildingBackend)
         {
-            var expectedSymbolsPath = Path.Combine(_fixture.UnityProjectPath, "Temp", "StagingArea", "symbols");
+            _fixture.Application = new TestApplication(unityVersion: unityVersion);
 
-            var actualSymbolsPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, false);
+            var actualIsNewBuildingBackend = DebugSymbolUpload.IsNewBuildingBackend(_fixture.Application);
 
-            Assert.AreEqual(expectedSymbolsPath, actualSymbolsPath);
+            Assert.AreEqual(expectedIsNewBuildingBackend, actualIsNewBuildingBackend);
         }
 
         [Test]
-        public void GetSymbolsPath_IsExportingTrue_CopiesSymbolsAndReturnsPath()
+        [TestCase("2019.4", DebugSymbolUpload.RelativeBuildOutputPathOld, DebugSymbolUpload.RelativeGradlePathOld)]
+        [TestCase("2021.2", DebugSymbolUpload.RelativeBuildOutputPathNew, DebugSymbolUpload.RelativeAndroidPathNew)]
+        public void GetSymbolUploadPaths_IsExportingFalse_ReturnsCorrectPathForVersion(string unityVersion, string relativeBuildPath, string gradlePath)
         {
-            var expectedSymbolsPath = Path.Combine(_fixture.GradleProjectPath, DebugSymbolUpload.GradleExportedSymbolsPath);
+            var sut = _fixture.GetSut();
 
-            var actualSymbolsPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, true);
+            var actualSymbolsPaths = sut.GetSymbolUploadPaths(false);
 
-            Assert.AreEqual(expectedSymbolsPath, actualSymbolsPath);
-            Assert.IsTrue(Directory.Exists(expectedSymbolsPath));
+            Assert.NotNull(actualSymbolsPaths.Any(path => path.Contains(relativeBuildPath)));
+            Assert.NotNull(actualSymbolsPaths.Any(path => path.Contains(gradlePath)));
+        }
 
-            var files = Directory.GetFiles(expectedSymbolsPath, "*.so", SearchOption.AllDirectories).ToList();
-            Assert.IsNotNull(files.Find(f => f.EndsWith("libil2cpp.dbg.so")));
-            Assert.IsNotNull(files.Find(f => f.EndsWith("libil2cpp.sym.so")));
-            Assert.IsNotNull(files.Find(f => f.EndsWith("libunity.sym.so")));
+        [Test]
+        public void GetSymbolUploadPaths_IsExportingTrue_ReturnsPathToExportedProject()
+        {
+            var sut = _fixture.GetSut();
+
+            var actualSymbolPaths = sut.GetSymbolUploadPaths(true);
+
+            Assert.AreEqual(1, actualSymbolPaths.Length);
+            Assert.NotNull(actualSymbolPaths.Any(path => path.Contains(_fixture.GradleProjectPath)));
         }
 
         [Test]
         public void AppendUploadToGradleFile_SentryCliFileDoesNotExist_ThrowsFileNotFoundException()
         {
-            var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, false);
             var invalidSentryCliPath = Path.GetRandomFileName();
+            var sut = _fixture.GetSut();
 
-            var ex = Assert.Throws<FileNotFoundException>(() => DebugSymbolUpload.AppendUploadToGradleFile(invalidSentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath));
+            var ex = Assert.Throws<FileNotFoundException>(() => sut.AppendUploadToGradleFile(invalidSentryCliPath));
             Assert.AreEqual(invalidSentryCliPath, ex.FileName);
         }
 
         [Test]
         public void AppendUploadToGradleFile_BuildGradleFileDoesNotExist_ThrowsFileNotFoundException()
         {
-            var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, false);
-            var invalidGradlePath = Path.GetRandomFileName();
+            _fixture.GradleProjectPath = Path.GetRandomFileName();
+            var sut = _fixture.GetSut();
 
-            var ex = Assert.Throws<FileNotFoundException>(() => DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, invalidGradlePath, symbolsDirectoryPath));
-            Assert.AreEqual(invalidGradlePath, ex.FileName);
+            var ex = Assert.Throws<FileNotFoundException>(() => sut.AppendUploadToGradleFile(_fixture.SentryCliPath));
+            Assert.AreEqual(_fixture.GradleProjectPath, ex.FileName);
         }
 
         [Test]
         public void AppendUploadToGradleFile_SymbolsDirectoryDoesNotExist_ThrowsDirectoryNotFoundException()
         {
-            Assert.Throws<DirectoryNotFoundException>(() => DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, String.Empty));
+            var sut = _fixture.GetSut();
+            sut._symbolUploadPaths = new[] { string.Empty };
+
+            Assert.Throws<DirectoryNotFoundException>(() => sut.AppendUploadToGradleFile(_fixture.SentryCliPath));
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void AppendUploadToGradleFile_AllRequirementsMet_AppendsSentryCliToFile(bool export)
+        public void AppendUploadToGradleFile_AllRequirementsMet_AppendsUploadTask()
         {
-            var symbolsDirectoryPath = DebugSymbolUpload.GetSymbolsPath(_fixture.UnityProjectPath, _fixture.GradleProjectPath, export);
-            var expectedSentryCliPath = _fixture.SentryCliPath;
-            var expectedSymbolsDirectoryPath = symbolsDirectoryPath;
+            var sut = _fixture.GetSut();
 
-            if (Application.platform == RuntimePlatform.WindowsEditor)
-            {
-                expectedSentryCliPath = expectedSentryCliPath.Replace(@"\", "/");
-                expectedSymbolsDirectoryPath = symbolsDirectoryPath.Replace(@"\", "/");
-            }
-
-            DebugSymbolUpload.AppendUploadToGradleFile(_fixture.SentryCliPath, _fixture.GradleProjectPath, symbolsDirectoryPath);
+            sut.AppendUploadToGradleFile(_fixture.SentryCliPath);
             var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
 
-            StringAssert.Contains(expectedSentryCliPath, actualFileContent);
-            StringAssert.Contains(expectedSymbolsDirectoryPath, actualFileContent);
+            StringAssert.Contains("sentry.properties", actualFileContent);
+        }
+
+        [Test]
+        public void RemoveUploadTaskFromGradleFile_GradleFileDoesNotExist_ThrowsFileNotFoundException()
+        {
+            _fixture.GradleProjectPath = Path.GetRandomFileName();
+            var sut = _fixture.GetSut();
+
+            var ex = Assert.Throws<FileNotFoundException>(() => sut.RemoveUploadFromGradleFile());
+            Assert.AreEqual(_fixture.GradleProjectPath, ex.FileName);
+        }
+
+        [Test]
+        public void RemoveUploadTaskFromGradleFile_UploadHasNotBeenAdded_LogsAndReturns()
+        {
+            var sut = _fixture.GetSut();
+
+            sut.RemoveUploadFromGradleFile();
+
+            _fixture.LoggerInterceptor.AssertLogContains(SentryLevel.Debug, "Skipping removing the upload task. The task has not been added to the gradle project.");
+        }
+
+        [Test]
+        public void RemoveUploadTaskFromGradleFile_UploadHasBeenAdded_RemovesUploadTask()
+        {
+            var sut = _fixture.GetSut();
+            sut.AppendUploadToGradleFile(_fixture.SentryCliPath);
+
+            // Sanity check
+            var actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
+            StringAssert.Contains("sentry.properties", actualFileContent);
+
+            sut.RemoveUploadFromGradleFile();
+
+            actualFileContent = File.ReadAllText(Path.Combine(_fixture.GradleProjectPath, "build.gradle"));
+            StringAssert.DoesNotContain("sentry.properties", actualFileContent);
+        }
+
+        [Test]
+        public void TryCopySymbolsToGradleProject_IsNewBuildingBackend_LogsAndReturns()
+        {
+            _fixture.Application = new TestApplication(unityVersion: "2021.2");
+
+            var sut = _fixture.GetSut();
+
+            sut.TryCopySymbolsToGradleProject(_fixture.Application);
+
+            _fixture.LoggerInterceptor.AssertLogContains(SentryLevel.Debug, "New building backend. Skipping copying of debug symbols.");
+        }
+
+        [Test]
+        public void TryCopySymbolsToGradleProject_IsOldBuildingBackend_CopiesFilesFromBuildOutputToSymbolsDirectory()
+        {
+            var expectedSymbolsPath = Path.Combine(_fixture.GradleProjectPath, "symbols");
+            var sut = _fixture.GetSut();
+
+            sut.TryCopySymbolsToGradleProject();
+
+            var files = Directory.GetFiles(expectedSymbolsPath, "*.so", SearchOption.AllDirectories).ToList();
+            Assert.IsNotNull(files.Find(f => f.EndsWith("libil2cpp.dbg.so")));
+            Assert.IsNotNull(files.Find(f => f.EndsWith("libil2cpp.sym.so")));
+            Assert.IsNotNull(files.Find(f => f.EndsWith("libunity.sym.so")));
         }
 
         public static void SetupFakeProject(string fakeProjectPath)
@@ -120,12 +197,12 @@ namespace Sentry.Unity.Editor.Tests.Android
             var assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var projectTemplatePath = Path.Combine(assemblyPath, "TestFiles", "SymbolsUploadProject");
 
-            foreach (string dirPath in Directory.GetDirectories(projectTemplatePath, "*", SearchOption.AllDirectories))
+            foreach (var dirPath in Directory.GetDirectories(projectTemplatePath, "*", SearchOption.AllDirectories))
             {
                 Directory.CreateDirectory(dirPath.Replace(projectTemplatePath, fakeProjectPath));
             }
 
-            foreach (string newPath in Directory.GetFiles(projectTemplatePath, "*", SearchOption.AllDirectories))
+            foreach (var newPath in Directory.GetFiles(projectTemplatePath, "*", SearchOption.AllDirectories))
             {
                 File.Copy(newPath, newPath.Replace(projectTemplatePath, fakeProjectPath), true);
             }

--- a/test/Sentry.Unity.Editor.Tests/TestUnityLoggerInterceptor.cs
+++ b/test/Sentry.Unity.Editor.Tests/TestUnityLoggerInterceptor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using Sentry.Extensibility;
 
 namespace Sentry.Unity.Editor.Tests
@@ -13,5 +14,8 @@ namespace Sentry.Unity.Editor.Tests
 
         public void Log(SentryLevel logLevel, string message, Exception? exception = null, params object?[] args)
             => Messages.Add((logLevel, message));
+
+        public void AssertLogContains(SentryLevel sentryLevel, string message)
+            => CollectionAssert.Contains(Messages, (sentryLevel, $"Sentry: ({sentryLevel.ToString()}) {message} "));
     }
 }

--- a/test/Sentry.Unity.Tests/Stubs/TestApplication.cs
+++ b/test/Sentry.Unity.Tests/Stubs/TestApplication.cs
@@ -10,12 +10,14 @@ namespace Sentry.Unity.Tests.Stubs
             bool isEditor = true,
             string productName = "",
             string version = "",
+            string unityVersion = "",
             string persistentDataPath = "",
             RuntimePlatform platform = RuntimePlatform.WindowsEditor)
         {
             IsEditor = isEditor;
             ProductName = productName;
             Version = version;
+            UnityVersion = unityVersion;
             PersistentDataPath = persistentDataPath;
             Platform = platform;
         }
@@ -26,6 +28,7 @@ namespace Sentry.Unity.Tests.Stubs
         public bool IsEditor { get; }
         public string ProductName { get; }
         public string Version { get; }
+        public string UnityVersion { get; }
         public string PersistentDataPath { get; }
         public RuntimePlatform Platform { get; }
         private void OnQuitting() => Quitting?.Invoke();

--- a/test/SharedClasses/TestLogger.cs
+++ b/test/SharedClasses/TestLogger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using NUnit.Framework;
 using Sentry.Extensibility;
 
 namespace Sentry.Unity.Tests.SharedClasses

--- a/test/SharedClasses/TestLogger.cs
+++ b/test/SharedClasses/TestLogger.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using NUnit.Framework;
 using Sentry.Extensibility;
 
 namespace Sentry.Unity.Tests.SharedClasses


### PR DESCRIPTION
Starting with 2021.2 the caching directory changed from `Temp` to `Library`.

Additionally, the gradle project persists across builds, so the "append symbol upload" functionality must be reentrant and removed in case the user opts out at a later point.