### PR TITLE
fix: collect main thread data synchronously during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Linux native crash support ([#734](https://github.com/getsentry/sentry-unity/pull/734))
+- Collect context information synchronously during init to capture it for very early events ([#744](https://github.com/getsentry/sentry-unity/pull/744))
 
 ## 0.16.0
 

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -138,13 +138,15 @@ namespace Sentry.Unity
             set => _sentrySystemInfo = value;
         }
 
-        private void Start()
-            => StartCoroutine(CollectData());
+        // Note: Awake is called only once and synchronously while the object is built.
+        // We want to do it this way instead of a StartCoroutine() so that we have the context info ASAP.
+        private void Awake() => CollectData();
 
-        internal IEnumerator CollectData()
+        internal void CollectData()
         {
+            // Note: Awake() runs on the main thread. The following code just reads a couple of variables so there's no
+            // delay on the UI and we're safe to do it on the main thread.
             MainThreadData.MainThreadId = SentrySystemInfo.MainThreadId;
-            yield return null;
             MainThreadData.ProcessorCount = SentrySystemInfo.ProcessorCount;
             MainThreadData.DeviceType = SentrySystemInfo.DeviceType;
             MainThreadData.OperatingSystem = SentrySystemInfo.OperatingSystem;
@@ -154,7 +156,6 @@ namespace Sentry.Unity
             MainThreadData.DeviceUniqueIdentifier = SentrySystemInfo.DeviceUniqueIdentifier;
             MainThreadData.DeviceModel = SentrySystemInfo.DeviceModel;
             MainThreadData.SystemMemorySize = SentrySystemInfo.SystemMemorySize;
-            yield return null;
             MainThreadData.GraphicsDeviceId = SentrySystemInfo.GraphicsDeviceId;
             MainThreadData.GraphicsDeviceName = SentrySystemInfo.GraphicsDeviceName;
             MainThreadData.GraphicsDeviceVendorId = SentrySystemInfo.GraphicsDeviceVendorId;

--- a/test/Sentry.Unity.Tests/UnityEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventProcessorTests.cs
@@ -85,8 +85,8 @@ namespace Sentry.Unity.Tests
             Assert.NotZero(_testLogger.Logs.Count(log => log.logLevel <= SentryLevel.Info));
         }
 
-        [UnityTest]
-        public IEnumerator SentrySdkCaptureEvent_OnNotUIThreadThenUIThreadThenNotUIThread_Cached()
+        [Test]
+        public void SentrySdkCaptureEvent_OnNotUIThreadThenUIThreadThenNotUIThread_Cached()
         {
             // arrange
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
@@ -113,7 +113,7 @@ namespace Sentry.Unity.Tests
             options.AddEventProcessor(new UnityEventProcessor(options, _sentryMonoBehaviour, _testApplication));
             SentryUnity.Init(options);
 
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
 
             // act & assert
             var nonUiThreadEventDataNotCached = NonUiThread();
@@ -275,8 +275,8 @@ namespace Sentry.Unity.Tests
             Assert.IsNull(sentryEvent.ServerName);
         }
 
-        [UnityTest]
-        public IEnumerator Process_DeviceUniqueIdentifierWithSendDefaultPii_IsNotNull()
+        [Test]
+        public void Process_DeviceUniqueIdentifierWithSendDefaultPii_IsNotNull()
         {
             // arrange
             var sentryOptions = new SentryOptions { SendDefaultPii = true };
@@ -284,15 +284,15 @@ namespace Sentry.Unity.Tests
             var sentryEvent = new SentryEvent();
 
             // act
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             // assert
             Assert.IsNotNull(sentryEvent.Contexts.Device.DeviceUniqueIdentifier);
         }
 
-        [UnityTest]
-        public IEnumerator Process_AppProtocol_Assigned()
+        [Test]
+        public void Process_AppProtocol_Assigned()
         {
             // arrange
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
@@ -303,15 +303,15 @@ namespace Sentry.Unity.Tests
             var sentryEvent = new SentryEvent();
 
             // act
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             unityEventProcessor.Process(sentryEvent);
 
             // assert
             Assert.IsNotNull(sentryEvent.Contexts.App.StartTime);
         }
 
-        [UnityTest]
-        public IEnumerator Process_Tags_Set()
+        [Test]
+        public void Process_Tags_Set()
         {
             // arrange
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
@@ -327,7 +327,7 @@ namespace Sentry.Unity.Tests
             var sentryEvent = new SentryEvent();
 
             // act
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             unityEventProcessor.Process(sentryEvent);
 
             // assert
@@ -357,8 +357,8 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(bool.TrueString, isMainThread.Value);
         }
 
-        [UnityTest]
-        public IEnumerator Process_OperatingSystemProtocol_Assigned()
+        [Test]
+        public void Process_OperatingSystemProtocol_Assigned()
         {
             // arrange
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo { OperatingSystem = "Windows" };
@@ -367,15 +367,15 @@ namespace Sentry.Unity.Tests
 
             // act
             // SentryInitialization always called
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             // assert
             Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.OperatingSystem, sentryEvent.Contexts.OperatingSystem.RawDescription);
         }
 
-        [UnityTest]
-        public IEnumerator Process_DeviceProtocol_Assigned()
+        [Test]
+        public void Process_DeviceProtocol_Assigned()
         {
             const long toByte = 1048576L; // in `UnityEventProcessor.PopulateDevice`
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
@@ -391,7 +391,7 @@ namespace Sentry.Unity.Tests
             var sut = new UnityEventProcessor(_sentryOptions, _sentryMonoBehaviour, _testApplication);
             var sentryEvent = new SentryEvent();
 
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.ProcessorCount, sentryEvent.Contexts.Device.ProcessorCount);
@@ -403,8 +403,8 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SystemMemorySize * toByte, sentryEvent.Contexts.Device.MemorySize);
         }
 
-        [UnityTest]
-        public IEnumerator Process_UnityProtocol_Assigned()
+        [Test]
+        public void Process_UnityProtocol_Assigned()
         {
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
             {
@@ -418,7 +418,7 @@ namespace Sentry.Unity.Tests
             var sentryEvent = new SentryEvent();
 
             // act
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             var unityProtocol = (Unity.Protocol.Unity)sentryEvent.Contexts.GetOrAdd(Unity.Protocol.Unity.Type, _ => new Unity.Protocol.Unity());
@@ -428,8 +428,8 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.RenderingThreadingMode!.Value, unityProtocol.RenderingThreadingMode);
         }
 
-        [UnityTest]
-        public IEnumerator Process_GpuProtocol_Assigned()
+        [Test]
+        public void Process_GpuProtocol_Assigned()
         {
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
             {
@@ -453,7 +453,7 @@ namespace Sentry.Unity.Tests
 
             // act
             // SentryInitialization always called
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceId, sentryEvent.Contexts.Gpu.Id);
@@ -472,8 +472,8 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsGeometryShaders, sentryEvent.Contexts.Gpu.SupportsGeometryShaders);
         }
 
-        [UnityTest]
-        public IEnumerator Process_GpuProtocolGraphicsShaderLevel_Assigned(
+        [Test]
+        public void Process_GpuProtocolGraphicsShaderLevel_Assigned(
             [ValueSource(nameof(ShaderLevels))] (int, string) shaderValue)
         {
             var (shaderLevel, shaderDescription) = shaderValue;
@@ -488,7 +488,7 @@ namespace Sentry.Unity.Tests
 
             // act
             // SentryInitialization always called
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             Assert.AreEqual(shaderDescription, sentryEvent.Contexts.Gpu.GraphicsShaderLevel);
@@ -507,8 +507,8 @@ namespace Sentry.Unity.Tests
            (21, "21")
         };
 
-        [UnityTest]
-        public IEnumerator Process_GpuProtocolGraphicsShaderLevelMinusOne_Ignored()
+        [Test]
+        public void Process_GpuProtocolGraphicsShaderLevelMinusOne_Ignored()
         {
             _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
             {
@@ -520,7 +520,7 @@ namespace Sentry.Unity.Tests
 
             // act
             // SentryInitialization always called
-            yield return _sentryMonoBehaviour.CollectData();
+            _sentryMonoBehaviour.CollectData();
             sut.Process(sentryEvent);
 
             Assert.IsNull(sentryEvent.Contexts.Gpu.GraphicsShaderLevel);


### PR DESCRIPTION
After adding the exception handling to SentryInitialization.cs, I've noticed it doesn't collect any of the usual context. This fixes that (and maybe a few other very early user-space error captures). The original behaviour was to run the main thread info collection asynchronously in a coroutine. Now, we collect it right away during init.

## Before 
https://sentry.io/organizations/sentry-sdks/issues/3267829133/events/2651b13a859b4859860b3f44859ffacd/?project=5439417
 
<img width="929" alt="image" src="https://user-images.githubusercontent.com/6349682/168063717-5ddc4d31-d79f-4ced-886e-8fef255652d8.png">
 
## After 
https://sentry.io/organizations/sentry-sdks/issues/3267829133/events/e12e6634035b4eb0bdc3c4349a5d03e1/?project=5439417

<img width="937" alt="image" src="https://user-images.githubusercontent.com/6349682/168063804-8a84a2bb-9681-4177-a4a1-277ed2a2006d.png">
