### PR TITLE
draft: Compilation hooks of IL Weaving

### DIFF
--- a/samples/unity-of-bugs/Assets/Editor/CompileInterceptor.cs
+++ b/samples/unity-of-bugs/Assets/Editor/CompileInterceptor.cs
@@ -1,0 +1,39 @@
+﻿using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+[InitializeOnLoad]
+public class CompileInterceptor
+{
+    static CompileInterceptor()
+    {
+        CompilationPipeline.compilationStarted -= OnCompilationStarted;
+        CompilationPipeline.compilationStarted += OnCompilationStarted;
+
+        CompilationPipeline.assemblyCompilationStarted -= OnAssemblyCompilationStarted;
+        CompilationPipeline.assemblyCompilationStarted += OnAssemblyCompilationStarted;
+
+        CompilationPipeline.assemblyCompilationFinished -= OnAssemblyCompilationFinished;
+        CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompilationFinished;
+
+        CompilationPipeline.compilationFinished -= OnCompilationFinished;
+        CompilationPipeline.compilationFinished += OnCompilationFinished;
+    }
+
+    private static void OnCompilationStarted(object o) => Debug.Log("Compilation started.");
+    private static void OnAssemblyCompilationStarted(string assemblyPath) =>
+        Debug.Log($"Starting to compile: {assemblyPath}");
+
+    private static void OnAssemblyCompilationFinished(string assemblyPath, CompilerMessage[] compilerMessages)
+    {
+        if (assemblyPath.Contains("Assembly-CSharp.dll"))
+        {
+            Debug.Log($"Finished compiling: {assemblyPath}");
+
+            // This is running on the main thread
+            Debug.Log("This is where IL Weaving will happen.");
+        }
+    }
+
+    private static void OnCompilationFinished(object o) => Debug.Log("Compilation finished.");
+}

--- a/samples/unity-of-bugs/Assets/Editor/CompileInterceptor.cs
+++ b/samples/unity-of-bugs/Assets/Editor/CompileInterceptor.cs
@@ -2,38 +2,27 @@
 using UnityEditor.Compilation;
 using UnityEngine;
 
-[InitializeOnLoad]
 public class CompileInterceptor
 {
-    static CompileInterceptor()
+    [InitializeOnLoadMethod]
+    public static void Setup()
     {
-        CompilationPipeline.compilationStarted -= OnCompilationStarted;
-        CompilationPipeline.compilationStarted += OnCompilationStarted;
+        CompilationPipeline.compilationStarted += o => Debug.Log("Compilation started.");
 
-        CompilationPipeline.assemblyCompilationStarted -= OnAssemblyCompilationStarted;
-        CompilationPipeline.assemblyCompilationStarted += OnAssemblyCompilationStarted;
+        CompilationPipeline.assemblyCompilationStarted += assemblyPath =>
+            Debug.Log($"Starting to compile: {assemblyPath}");;
 
-        CompilationPipeline.assemblyCompilationFinished -= OnAssemblyCompilationFinished;
-        CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompilationFinished;
-
-        CompilationPipeline.compilationFinished -= OnCompilationFinished;
-        CompilationPipeline.compilationFinished += OnCompilationFinished;
-    }
-
-    private static void OnCompilationStarted(object o) => Debug.Log("Compilation started.");
-    private static void OnAssemblyCompilationStarted(string assemblyPath) =>
-        Debug.Log($"Starting to compile: {assemblyPath}");
-
-    private static void OnAssemblyCompilationFinished(string assemblyPath, CompilerMessage[] compilerMessages)
-    {
-        if (assemblyPath.Contains("Assembly-CSharp.dll"))
+        CompilationPipeline.assemblyCompilationFinished += (assemblyPath, compilerMessages) =>
         {
-            Debug.Log($"Finished compiling: {assemblyPath}");
+            if (assemblyPath.Contains("Assembly-CSharp.dll"))
+            {
+                Debug.Log($"Finished compiling: {assemblyPath}");
 
-            // This is running on the main thread
-            Debug.Log("This is where IL Weaving will happen.");
-        }
+                // This is running on the main thread
+                Debug.Log("This is where IL Weaving will happen.");
+            }
+        };
+
+        CompilationPipeline.compilationFinished += o => Debug.Log("Compilation finished.");
     }
-
-    private static void OnCompilationFinished(object o) => Debug.Log("Compilation finished.");
 }

--- a/samples/unity-of-bugs/Assets/Editor/CompileInterceptor.cs.meta
+++ b/samples/unity-of-bugs/Assets/Editor/CompileInterceptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a86bf2c5ccff749e1a9e2b27c62026a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Goal: Explore how to hook up into the build pipeline before the assemblies are passed on to the IL2CPP compiler.

There seems to be a difference between `ScriptAssemblies` and `PlayerScriptAssemblies` which leads to the events being invoked twice for `Assembly-CSharp.dll` with different sizes.

![image](https://user-images.githubusercontent.com/25725783/168095608-8f774760-3f6b-46cd-bf2d-4ee0e035bb53.png)

The one in the `PlayerScriptAssemblies` then seems to be cached in `PlayerDataCache` and the `BackupThisFolder_DontShip`:

```
➜  Unity git:(poc/il-weaving-hook) ✗ find . -name "Assembly-CSharp.dll" -exec ls -lh {} \;
-rw-r--r--  1 bitfox  staff    23K May 12 16:11 ./samples/unity-of-bugs/Library/PlayerDataCache/OSXUniversal/Data/Managed/Assembly-CSharp.dll
-rw-r--r--  1 bitfox  staff    24K May 12 16:11 ./samples/unity-of-bugs/Library/ScriptAssemblies/Assembly-CSharp.dll
-rw-r--r--  1 bitfox  staff    23K May 12 16:11 ./samples/unity-of-bugs/Builds/test_BackUpThisFolder_ButDontShipItWithYourGame/Managed/Assembly-CSharp.dll
```