### PR TITLE
feat: use single-threaded web worker on unknown platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Linux native crash support ([#734](https://github.com/getsentry/sentry-unity/pull/734))
 - Collect context information synchronously during init to capture it for very early events ([#744](https://github.com/getsentry/sentry-unity/pull/744))
 - Automatic user IDs on native crashes & .NET events ([#728](https://github.com/getsentry/sentry-unity/pull/728))
+- Use single-threaded HTTP transport on unknown platforms ([#756](https://github.com/getsentry/sentry-unity/pull/756))
 
 ## 0.16.0
 

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -7,12 +7,15 @@
 #define SENTRY_NATIVE
 #elif UNITY_WEBGL
 #define SENTRY_WEBGL
+#else
+#define SENTRY_DEFAULT
 #endif
 #endif
 
 using System;
 using UnityEngine;
 using UnityEngine.Scripting;
+using UnityEngine.Analytics;
 
 #if SENTRY_NATIVE_COCOA
 using Sentry.Unity.iOS;
@@ -22,6 +25,8 @@ using Sentry.Unity.Android;
 using Sentry.Unity.Native;
 #elif SENTRY_WEBGL
 using Sentry.Unity.WebGL;
+#elif SENTRY_DEFAULT
+using Sentry.Unity.Default;
 #endif
 
 [assembly: AlwaysLinkAssembly]
@@ -50,6 +55,8 @@ namespace Sentry.Unity
                     SentryNative.Configure(options);
 #elif SENTRY_WEBGL
                     SentryWebGL.Configure(options);
+#elif SENTRY_DEFAULT
+                    SentryUnknownPlatform.Configure(options);
 #endif
                 }
                 catch (DllNotFoundException e)

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -15,7 +15,6 @@
 using System;
 using UnityEngine;
 using UnityEngine.Scripting;
-using UnityEngine.Analytics;
 
 #if SENTRY_NATIVE_COCOA
 using Sentry.Unity.iOS;

--- a/src/Sentry.Unity/Default/UnknownPlatform.cs
+++ b/src/Sentry.Unity/Default/UnknownPlatform.cs
@@ -1,0 +1,24 @@
+using Sentry.Extensibility;
+using UnityEngine.Analytics;
+
+namespace Sentry.Unity.Default
+{
+    /// <summary>
+    /// Configure Sentry on an officially unsupported platform.
+    /// This works on a best-effort basis, to try to improve compatibility.
+    /// </summary>
+    public static class SentryUnknownPlatform
+    {
+        public static void Configure(SentryUnityOptions options)
+        {
+            // This is only provided on a best-effort basis for other then the explicitly supported platforms.
+            if (options.BackgroundWorker is null)
+            {
+                options.DiagnosticLogger?.Log(SentryLevel.Debug,
+                        "Configuring on an unknown platform. Using WebBackgroundWorker to improve compatibility.");
+                options.BackgroundWorker = new WebBackgroundWorker(options, SentryMonoBehaviour.Instance);
+            }
+            options.DefaultUserId = AnalyticsSessionInfo.userId;
+        }
+    }
+}

--- a/src/Sentry.Unity/Default/UnknownPlatform.cs
+++ b/src/Sentry.Unity/Default/UnknownPlatform.cs
@@ -11,7 +11,7 @@ namespace Sentry.Unity.Default
     {
         public static void Configure(SentryUnityOptions options)
         {
-            // This is only provided on a best-effort basis for other then the explicitly supported platforms.
+            // This is only provided on a best-effort basis for other than the explicitly supported platforms.
             if (options.BackgroundWorker is null)
             {
                 options.DiagnosticLogger?.Log(SentryLevel.Debug,

--- a/src/Sentry.Unity/UnityWebRequestTransport.cs
+++ b/src/Sentry.Unity/UnityWebRequestTransport.cs
@@ -105,7 +105,7 @@ namespace Sentry.Unity
             foreach (var header in www.GetResponseHeaders())
             {
                 // Unity would throw if we tried to set content-type or content-length
-                if (header.Key is not "content-length" && header.Key is not "content-type")
+                if (header.Key.ToLowerInvariant() is not ("content-length" or "content-type"))
                 {
                     response.Headers.Add(header.Key, header.Value);
                 }


### PR DESCRIPTION
Uses UnityWebRequestTransport by default on other than the officially supported platforms.

(hopefully) fixes #290 