### PR TITLE
Refactor droid steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,19 +384,48 @@ jobs:
           name: testapp-Android-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build
 
-      - name: Android emulator setup + Smoke test
+      # outputs variables: version-label, api-level, target, arch
+      - name: Configure Android Settings
+        id: droid-settings
+        shell: pwsh
+        run : |
+          # Setup API Level
+          $apiLevel = '${{ matrix.api-level }}'
+          if ( $apiLevel -eq 'latest') 
+          {
+            # Gets the latest API level that isn't in Beta/Alpha
+            $response = (Invoke-WebRequest -UseBasicParsing -Uri "https://developer.android.com/studio/releases/platforms").Content
+            $result = [regex]::Match($response, " \(API level (?<model>\d+)\)")
+            $apiLevel = $result.Groups["model"].Value
+            Write-Output "Latest API is $apiLevel"
+            echo "::set-output name=api-level::$apiLevel"
+            echo "::set-output name=version-label::$apiLevel (latest)"
+          }
+          else 
+          {
+            Write-Output "Current API is $apiLevel"
+            echo "::set-output name=api-level::$apiLevel"
+            echo "::set-output name=version-label::$arch"
+          }          
+          # Setup Arch and Target
+          $target = $apiLevel -ge 30 ? 'google_apis' : 'default'
+          Write-Output "Current Target is $target"
+          echo "::set-output name=target::$target"
+          
+      - name: Android API ${{ steps.droid-settings.outputs.version-label }} emulator  setup  + Smoke test
         id: smoke-test
         continue-on-error: true
         timeout-minutes: 30
-        uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
+        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
-          api-level: ${{ matrix.api-level }}
+          api-level: ${{ steps.droid-settings.outputs.api-level }}
           #api-level 30 image is only available with google services.
-          target: ${{ matrix.api-level == 30 && 'google_apis' || 'default' }}
+          target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86
           cores: 2
+          disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: sudo pwsh ./scripts/smoke-test-droid.ps1 -IsCI -IsIntegrationTest
@@ -408,20 +437,21 @@ jobs:
           adb emu kill
           sleep 7
 
-      - name: Android emulator setup + Smoke test (Retry)
+      - name: Android API ${{ steps.droid-settings.outputs.version-label }} emulator setup + Smoke test (Retry)
         id: smoke-test-retry
         continue-on-error: true
         timeout-minutes: 30
         # Retry the tests if the previous fail happened on the emulator startup.
         if: ${{ steps.smoke-test.outputs.smoke-status == 'Flaky' }}
-        uses: reactivecircus/android-emulator-runner@2b2ebf2e518e38a17180117fc2b677006db27330
+        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level == 30 && 'google_apis' || 'default' }}
+          api-level: ${{ steps.droid-settings.outputs.api-level }}
+          target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86
           cores: 2
+          disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: sudo pwsh ./scripts/smoke-test-droid.ps1 -IsCI -IsIntegrationTest

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -79,17 +79,17 @@ function CloseSystemAlert([string] $deviceId, [string] $deviceApi, [string] $ale
 {
     if ("$alert" -ne "")
     {
-        $splittedXml = $alert -split "<node"
+        $splitXml = $alert -split "<node"
         $alertTitle = ""
         $alertOption1Label = $null
         $alertOption1Coord = $null
         $alertOption2Label = $null
         $alertOption2Coord = $null
 
-        if ($splittedXml.Count -ne 1) {
+        if ($splitXml.Count -ne 1) {
             # We have a "valid" XML
             # Use Regex to get the message and the options labels + coordinates.
-            foreach ($iterator in $splittedXml) {
+            foreach ($iterator in $splitXml) {
                 if ($iterator.Contains("alertTitle")) {
                     $titleRegex = [regex]::Match($iterator, "text=\`"(?<text>.+)\`" resource-id")
                     $alertTitle = $titleRegex.Groups["text"].Value
@@ -128,7 +128,7 @@ function CloseSystemAlert([string] $deviceId, [string] $deviceApi, [string] $ale
         }
         else
         {
-            # Fallback to the old method of closing Alerts.
+            # Fallback to the old method of closing Alerts. (Android API 21 to 27)
             Write-Warning "Active system alert found on $deviceId (API $deviceApi). Closing it. The alert was: '$alert'."
             if ($deviceApi -eq "21")
             {

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -79,19 +79,70 @@ function CloseSystemAlert([string] $deviceId, [string] $deviceApi, [string] $ale
 {
     if ("$alert" -ne "")
     {
-        Write-Warning "Active system alert found on $deviceId (API $deviceApi). Closing it. The alert was: '$alert'."
-        if ($deviceApi -eq "21")
-        {
-            Write-Warning "Issuing ENTER command twice to close the current window."
-            # sends "enter" - the first one focues the OK button, the second one taps it
-            adb -s $deviceId shell input keyevent 66
-            adb -s $deviceId shell input keyevent 66
+        $splittedXml = $alert -split "<node"
+        $alertTitle = ""
+        $alertOption1Label = $null
+        $alertOption1Coord = $null
+        $alertOption2Label = $null
+        $alertOption2Coord = $null
+
+        if ($splittedXml.Count -ne 1) {
+            # We have a "valid" XML
+            # Use Regex to get the message and the options labels + coordinates.
+            foreach ($iterator in $splittedXml) {
+                if ($iterator.Contains("alertTitle")) {
+                    $titleRegex = [regex]::Match($iterator, "text=\`"(?<text>.+)\`" resource-id")
+                    $alertTitle = $titleRegex.Groups["text"].Value
+                }
+                elseif ($iterator.Contains("Button")) {
+                    $buttonRegex = [regex]::Match($iterator, "text=\`"(?<text>.+)\`" resource-id.* bounds=\`"\[(?<horStart>\d+),(?<verStart>\d+)\]\[(?<horEnd>\d+),(?<verEnd>\d+)\]\`"")
+                    if ($null -eq $alertOption1Label) {
+                        $alertOption1Label = $buttonRegex.Groups["text"].Value
+                        $alertOption1Coord = ($buttonRegex.Groups["horStart"].Value, $buttonRegex.Groups["verStart"].Value, $buttonRegex.Groups["horEnd"].Value, $buttonRegex.Groups["verEnd"].Value)
+                    }
+                    else {
+                        $alertOption2Label = $buttonRegex.Groups["text"].Value
+                        $alertOption2Coord = ($buttonRegex.Groups["horStart"].Value, $buttonRegex.Groups["verStart"].Value, $buttonRegex.Groups["horEnd"].Value, $buttonRegex.Groups["verEnd"].Value)
+                    }
+                }
+            }
+
+            if ($null -ne $alertTitle) {
+                Write-Warning "Found Alert on Screen, TITLE: $alertTitle `n Options: `n $alertOption1Label at $alertOption1Coord `n $alertOption2Label at $alertOption2Coord "
+
+                if ($null -eq $alertOption2Label)
+                {
+                    $tapX = [int]([int]$alertOption1Coord[0] + [int]$alertOption1Coord[2] ) / 2
+                    $tapY = [int]([int]$alertOption1Coord[1] + [int]$alertOption1Coord[3] ) / 2
+                    $tapLabel = $alertOption1Label
+                }
+                else 
+                {
+                    $tapX = [int]([int]$alertOption2Coord[0] + [int]$alertOption2Coord[2] ) / 2
+                    $tapY = [int]([int]$alertOption2Coord[1] + [int]$alertOption2Coord[3] ) / 2
+                    $tapLabel = $alertOption2Label
+                }
+                Write-Host "Tapping on $tapLabel at [$tapX, $tapY]"
+                adb -s $deviceId shell input tap $tapX $tapY
+            }
         }
         else
         {
-            # sends "back" action
-            Write-Warning "Issuing BACK command to close the current window."
-            adb -s $deviceId shell input keyevent 4
+            # Fallback to the old method of closing Alerts.
+            Write-Warning "Active system alert found on $deviceId (API $deviceApi). Closing it. The alert was: '$alert'."
+            if ($deviceApi -eq "21")
+            {
+                Write-Warning "Issuing ENTER command twice to close the current window."
+                # sends "enter" - the first one focues the OK button, the second one taps it
+                adb -s $deviceId shell input keyevent 66
+                adb -s $deviceId shell input keyevent 66
+            }
+            else
+            {
+                # sends "back" action
+                Write-Warning "Issuing BACK command to close the current window."
+                adb -s $deviceId shell input keyevent 4
+            }
         }
     }
 }
@@ -162,8 +213,20 @@ foreach ($device in $DeviceList)
     # Move device to home screen
     $stdout = adb -s $device shell input keyevent KEYCODE_HOME
 
-    Write-Host "Installing test app..."
-    $stdout = (adb -s $device install -r $ApkPath/$ApkFileName)
+    $adbInstallRetry = 5
+    do
+    {
+        Write-Host "Installing test app..."
+        $stdout = (adb -s $device install -r $ApkPath/$ApkFileName)
+
+        if ($stdout.Contains("Broken pipe"))
+        {
+            Write-Warning "Failed to comunicate with the Device, retrying..."
+            Start-Sleep 3
+            $adbInstallRetry--
+        }
+    } while ($adbInstallRetry -gt 1 -and $stdout.Contains("Broken pipe"))
+
     If ($stdout -notcontains "Success")
     {
         SignalActionSmokeStatus("Failed")


### PR DESCRIPTION
The goal is to move the additional changes from the latest android test into a separate PR and then move back to the latest version of Android.

Changes:

- Updated action to setup the Simulators (Actions Logs are more organized by groups)
- Fix issue where some simulators may fail due to out of storage errors.
- Retry to install the APK if ADB  failed to communicate with the Device.
- Add new logic to close Alerts (the old one does not work with the latest devices plus when an alert happens it's more readable than having to visualize an xml with the UI information)
- Added additional step to concatenate the variables used by the Simulator steps (removing the if conditions from the smoke test + smoke test retry)
- Added logic to retrieve the latest Android version.

#skip-changelog