### PR TITLE
Fix flaky iOS tests

### DIFF
--- a/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/SmokeTester.cs
@@ -241,7 +241,10 @@ public class SmokeTester : MonoBehaviour
             var msgText = message.Content.ReadAsStringAsync().Result;
             lock (_requests)
             {
-                Debug.Log($"{name} TEST: Intercepted HTTP Request #{_requests.Count} = {msgText}");
+                // Adding "Sentry: " prefix to prevent the UnityLogHandlerIntegration from capturing this message and
+                // adding it as a breadcrumb, which in turn multiplies it on following (intercepted) HTTP requests...
+                // Note: remove the prefix once setting breadcrumb log level is possible - https://github.com/getsentry/sentry-unity/issues/60
+                Debug.Log($"Sentry: {name} TEST: Intercepted HTTP Request #{_requests.Count} = {msgText}");
                 _requests.Add(msgText);
                 _requestReceived.Set();
             }


### PR DESCRIPTION
#skip-changelog

The problem was that we're logging the whole HTTP message that's being sent to Sentry - since this is coming through logs, it's added as a breadcrumb. There are two parts to this: 1. the message, being part of breadcrumbs, is then again part of every other captured event, thus growing the size exponentially; 2. the HTTP message also contains a large binary attachment (screenshot). 
The attachment previously wasn't logged due to Unity not stringifying it properly in `application.LogMessageReceived`, but [since we've started using `Debug.unityLogger.logHandler` instead](https://github.com/getsentry/sentry-unity/pull/731/files#diff-ee5e6340639abe48354fb3b1955c5593c52338c45145ef550d253bab26cf8a13), it also started to include the escaped binary data in the log, thus breadcrumbs, etc. This has caused the events to grow significantly and the time it takes for them to be processed too, failing the tests due to timeouts.

I'd argue that what we're doing now with the new LogHandler is the right thing to do - even if you pass a binary content to logs, it's logged and captured as is, instead of being silently skipped as it was before. Therefore, I'd say the issue was always there and it lies in us logging the HTTP message content in the SmokeTest. It just propagated now after the changes in #731.

This PR fixes the issue by making sure we don't add the `SMOKE TEST: Intercepted HTTP Request ...` message to breadcrumbs, so the events don't grow exponentially.