### PR TITLE
feat: setup wizard

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -551,7 +551,7 @@ void PrintFailedTests(XElement element)
     <RemoveDir Directories="$(SentryArtifactsDestination)%(SDK.Identity)" />
     <Exec Command="gh run download $(LastSuccessfulRunId) -n &quot;%(SDK.Identity)-sdk&quot; -D &quot;$(SentryArtifactsDestination)%(SDK.Identity)&quot;" />
 
-    <!-- Download overwrites some files that then show up as chagned in the IDE, even though there are no changes, e.g. only whitespace -->
+    <!-- Download overwrites some files that then show up as changed in the IDE, even though there are no changes, e.g. only whitespace -->
     <Message Importance="High" Text="Restoring package-dev/Plugins to the latest git commit" />
     <Exec WorkingDirectory="$(RepoRoot)" Command="git restore package-dev/Plugins" />
   </Target>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -550,5 +550,9 @@ void PrintFailedTests(XElement element)
     <Message Importance="High" Text="Replacing $(SentryArtifactsDestination)%(SDK.Identity)" />
     <RemoveDir Directories="$(SentryArtifactsDestination)%(SDK.Identity)" />
     <Exec Command="gh run download $(LastSuccessfulRunId) -n &quot;%(SDK.Identity)-sdk&quot; -D &quot;$(SentryArtifactsDestination)%(SDK.Identity)&quot;" />
+
+    <!-- Download overwrites some files that then show up as chagned in the IDE, even though there are no changes, e.g. only whitespace -->
+    <Message Importance="High" Text="Restoring package-dev/Plugins to the latest git commit" />
+    <Exec WorkingDirectory="$(RepoRoot)" Command="git restore package-dev/Plugins" />
   </Target>
 </Project>

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -118,7 +118,7 @@ public class {scriptName} : ScriptableOptionsConfiguration
             AssetDatabase.Refresh();
 
             // Don't overwrite already set OptionsConfiguration
-            var options = SentryWindow.Instance.Options;
+            var options = SentryWindow.Instance!.Options;
             if (options.OptionsConfiguration == null)
             {
                 options.OptionsConfiguration = (ScriptableOptionsConfiguration)optionsConfigurationObject;

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryTestWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryTestWindow.cs
@@ -6,7 +6,11 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
 {
     public sealed class SentryTestWindow : SentryWindow, IDisposable
     {
-        protected override string SentryOptionsAssetName { get; } = Path.GetRandomFileName();
+        public SentryTestWindow()
+        {
+            // static
+            SentryWindow.SentryOptionsAssetName = Path.GetRandomFileName();
+        }
 
         public static SentryTestWindow Open()
             => (SentryTestWindow)GetWindow(typeof(SentryTestWindow));

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -89,7 +89,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             var options = SentryScriptableObject.CreateOrLoad<ScriptableSentryUnityOptions>(OptionsPath);
             var cliOptions = SentryScriptableObject.CreateOrLoad<SentryCliOptions>(CliOptionsPath);
             options.Dsn = config.Dsn;
-            cliOptions.UploadSymbols = config.UploadSymbols;
+            cliOptions.UploadSymbols = !string.IsNullOrWhiteSpace(config.Token);
             cliOptions.Auth = config.Token;
             cliOptions.Organization = config.OrgSlug;
             cliOptions.Project = config.ProjectSlug;

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -12,17 +12,35 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
         private const string LinkXmlPath = "Assets/Plugins/Sentry/link.xml";
 
         [MenuItem("Tools/Sentry")]
-        public static SentryWindow OpenSentryWindow()
+        public static void OnMenuClick()
         {
-            var window = (SentryWindow)GetWindow(typeof(SentryWindow));
-            window.minSize = new Vector2(600, 420);
-            return window;
+            if (Wizard.InProgress)
+            {
+                Debug.Log("Wizard in progress, ignoring Tools/Sentry menu click");
+                return;
+            }
+            if (Instance is null && IsFirstLoad && EditorUtility.DisplayDialog("Start a setup wizard?",
+                "It looks like you're setting up Sentry for the first time in this project.\n\n" +
+                "Would you like to start a setup wizard to connect to sentry.io?", "Start wizard", "I'll set it up manually"))
+            {
+                Wizard.Start(CreateLogger());
+            }
+            else
+            {
+                OpenSentryWindow();
+            }
         }
 
-        public static SentryWindow Instance => GetWindow<SentryWindow>();
+        public static void OpenSentryWindow()
+        {
+            Instance = GetWindow<SentryWindow>();
+            Instance.minSize = new Vector2(600, 420);
+        }
 
-        protected virtual string SentryOptionsAssetName { get; } = ScriptableSentryUnityOptions.ConfigName;
-        protected virtual string SentryCliAssetName { get; } = SentryCliOptions.ConfigName;
+        public static SentryWindow? Instance;
+
+        protected static string SentryOptionsAssetName { get; set; } = ScriptableSentryUnityOptions.ConfigName;
+        protected static string SentryCliAssetName { get; } = SentryCliOptions.ConfigName;
 
         public ScriptableSentryUnityOptions Options { get; private set; } = null!; // Set by OnEnable()
         public SentryCliOptions CliOptions { get; private set; } = null!; // Set by OnEnable()
@@ -40,62 +58,53 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             "Debug Symbols"
         };
 
-        private IDiagnosticLogger _logger = null!; // Set by OnEnable()
-        private bool _isFirstLoad = false; // Set by OnEnable()
-        private Wizard? _wizard;
+        private IDiagnosticLogger _logger;
 
-        // Using OnEnable() instead of Awake() so that this is called also when the .dll is reloaded during development.
-        // Otherwise, Awake() wouldn't be called at all again and the fields would be null.
+        private static string OptionsPath => ScriptableSentryUnityOptions.GetConfigPath(SentryOptionsAssetName);
+        private static string CliOptionsPath => SentryCliOptions.GetConfigPath(SentryCliAssetName);
+
+        public SentryWindow()
+        {
+            _logger = CreateLogger();
+        }
+
+        private static IDiagnosticLogger CreateLogger() =>
+            new UnityLogger(new SentryOptions() { Debug = SentryPackageInfo.IsDevPackage });
+
+        void OnDestroy()
+        {
+            Instance = null;
+        }
+
         private void OnEnable()
         {
-            _logger = new UnityLogger(new SentryOptions() { Debug = SentryPackageInfo.IsDevPackage });
-            _logger.LogDebug("SentryWindow.OnEnable() called.");
-
-            SetTitle();
-            var optionsPath = ScriptableSentryUnityOptions.GetConfigPath(SentryOptionsAssetName);
-            var optionsCliPath = SentryCliOptions.GetConfigPath(SentryCliAssetName);
-
-            Options = SentryScriptableObject.CreateOrLoad<ScriptableSentryUnityOptions>(optionsPath);
-            CliOptions = SentryScriptableObject.CreateOrLoad<SentryCliOptions>(optionsCliPath);
-
-            _isFirstLoad = !File.Exists(optionsPath) && !File.Exists(optionsCliPath);
-            _isFirstLoad = true; // xxx temporary
-
-            if (_isFirstLoad)
-            {
-                _logger.LogDebug("Configuration window opened for the first time - starting a setup wizard.");
-            }
+            // Note: these are not allowed to be called in constructors
+            SetTitle(this);
+            Options = SentryScriptableObject.CreateOrLoad<ScriptableSentryUnityOptions>(OptionsPath);
+            CliOptions = SentryScriptableObject.CreateOrLoad<SentryCliOptions>(CliOptionsPath);
         }
+
+        internal static void SaveWizardResult(WizardConfiguration config)
+        {
+            var options = SentryScriptableObject.CreateOrLoad<ScriptableSentryUnityOptions>(OptionsPath);
+            var cliOptions = SentryScriptableObject.CreateOrLoad<SentryCliOptions>(CliOptionsPath);
+            options.Dsn = config.Dsn;
+            cliOptions.UploadSymbols = config.UploadSymbols;
+            cliOptions.Auth = config.Token;
+            cliOptions.Organization = config.OrgSlug;
+            cliOptions.Project = config.ProjectSlug;
+
+            EditorUtility.SetDirty(options);
+            EditorUtility.SetDirty(cliOptions);
+            AssetDatabase.SaveAssets();
+        }
+
+        private static bool IsFirstLoad =>
+          !File.Exists(ScriptableSentryUnityOptions.GetConfigPath(SentryOptionsAssetName)) &&
+          !File.Exists(SentryCliOptions.GetConfigPath(SentryCliAssetName));
 
         // ReSharper disable once UnusedMember.Local
         private void OnGUI()
-        {
-            if (_isFirstLoad)
-            {
-                _wizard ??= new Wizard(_logger);
-                var config = _wizard.Show();
-
-                if (config is not null)
-                {
-                    Options.Dsn = config.Dsn;
-                    CliOptions.Auth = config.Token;
-                    CliOptions.Organization = config.OrgSlug;
-                    CliOptions.Project = config.ProjectSlug;
-                    _isFirstLoad = false;
-                    ShowOptions();
-                }
-                // Repaint();
-            }
-            else
-            {
-                ShowOptions();
-            }
-        }
-
-        // called multiple times per second to update status on the UI thread.
-        private void Update() => _wizard?.Update();
-
-        private void ShowOptions()
         {
             EditorGUILayout.Space();
             GUILayout.Label("SDK Options", EditorStyles.boldLabel);
@@ -191,12 +200,12 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             _logger.LogWarning(validationError.ToString());
         }
 
-        private void SetTitle()
+        internal static void SetTitle(EditorWindow window, string title = "Sentry", string description = "Sentry SDK options")
         {
             var isDarkMode = EditorGUIUtility.isProSkin;
             var texture = new Texture2D(16, 16);
             using var memStream = new MemoryStream();
-            using var stream = GetType().Assembly
+            using var stream = window.GetType().Assembly
                 .GetManifestResourceStream(
                     $"Sentry.Unity.Editor.Resources.SentryLogo{(isDarkMode ? "Light" : "Dark")}.png");
             stream.CopyTo(memStream);
@@ -204,7 +213,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             memStream.Position = 0;
             texture.LoadImage(memStream.ToArray());
 
-            titleContent = new GUIContent("Sentry", texture, "Sentry SDK Options");
+            window.titleContent = new GUIContent(title, texture, description);
         }
     }
 

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
@@ -35,11 +35,11 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
 
                 Instance.ShowUtility();
                 Instance.minSize = new Vector2(600, 200);
-                Instance.StartLoder();
+                Instance.StartLoader();
             }
         }
 
-        private void StartLoder()
+        private void StartLoader()
         {
             _task = new WizardLoader(_logger);
             Task.Run(async () => Response = await _task.Load()).ContinueWith(t =>
@@ -194,7 +194,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                     $"Couldn't launch the wizard. Would you like to try again? The error was:\n\n{_task._exception.Message}",
                     "Retry wizard", "I'll set it up manually"))
                 {
-                    StartLoder();
+                    StartLoader();
                 }
                 return;
             }

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor.ConfigurationWindow
+{
+    internal class Wizard
+    {
+        // can't be static
+        private int ProjectSelected = 0;
+        private int OrgSelected = 0;
+        public WizardStep2Response? Response { get; set; }
+        public WizardConfiguration? WizardConfiguration { get; set; }
+
+        public async Task<WizardConfiguration?> Show()
+        {
+            if (WizardConfiguration is not null)
+            {
+                // We're done with the wizard flow
+                return WizardConfiguration;
+            }
+
+            if (Response is not null)
+            {
+                var firstEntry = new string('-', 60);
+                var orgsAndProjects = Response.Projects.GroupBy(k => k.Organization!.Name, v => v).ToArray();
+                if (orgsAndProjects.Length == 1)
+                {
+                    OrgSelected = 1;
+                    ProjectSelected = EditorGUILayout.Popup("Select the Sentry project", ProjectSelected, Response.Projects.Select(p => p.Slug)
+                        .Prepend(firstEntry).ToArray());
+                }
+                else
+                {
+                    if (OrgSelected == 0)
+                    {
+                        OrgSelected = EditorGUILayout.Popup("Select Sentry Organization", OrgSelected, orgsAndProjects.Select(k => k.Key)
+                            .Prepend(firstEntry).ToArray());
+                    }
+                    else
+                    {
+                        ProjectSelected = EditorGUILayout.Popup("Select Sentry Project", ProjectSelected, orgsAndProjects[OrgSelected - 1].Select(v => $"{v.Name} - ({v.Slug})").ToArray()
+                            .Prepend(firstEntry).ToArray());
+                    }
+                }
+
+                if (ProjectSelected != 0)
+                {
+                    var proj = orgsAndProjects[OrgSelected - 1].ToArray()[ProjectSelected - 1];
+                    WizardConfiguration = new WizardConfiguration
+                    {
+                        Token = Response.ApiKeys!.Token,
+                        Dsn = proj.Keys.First().Dsn!.Public,
+                        OrgSlug = proj.Organization!.Slug,
+                        ProjectSlug = proj.Slug
+                    };
+                }
+            }
+            else if (GUILayout.Button("Start Wizard Process"))
+            {
+                var serializeOptions = new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true
+                };
+                var http = new HttpClient();
+                var resp = await http.GetAsync("https://sentry.io/api/0/wizard/").ConfigureAwait(false);
+                resp.EnsureSuccessStatusCode();
+                var wizardHashResponse = await JsonSerializer.DeserializeAsync<WizardStep1Response>(
+                    await resp.Content.ReadAsStreamAsync(), serializeOptions).ConfigureAwait(false);
+
+                var urlToOpenOnBrowser = $"https://sentry.io/account/settings/wizard/{wizardHashResponse!.Hash}/";
+                // TODO: On Windows it's 'start' instead of 'open':
+                try
+                {
+                    var proc = Process.Start(
+                        new ProcessStartInfo("open", urlToOpenOnBrowser) { UseShellExecute = true });
+                }
+                catch
+                {
+                    // TODO: Log here but continue, user can browse manually the URL (see below):
+                }
+
+                // TODO: Print URL we just tried to load (can we show a clickable link?) and tell the user to open manually if somehow the
+                // browser didn't open
+
+                // Poll https://sentry.io/api/0/wizard/hash/
+                var pollingUrl = $"https://sentry.io/api/0/wizard/{wizardHashResponse.Hash}/";
+                var i = 0;
+                do
+                {
+                    try
+                    {
+                        resp = await http.GetAsync(pollingUrl).ConfigureAwait(false);
+                        resp.EnsureSuccessStatusCode();
+                        var completedWizardResponse = await JsonSerializer.DeserializeAsync<WizardStep2Response>(
+                            await resp.Content.ReadAsStreamAsync().ConfigureAwait(false), serializeOptions).ConfigureAwait(false);
+
+                        Response = completedWizardResponse;
+
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        await Task.Delay(1000).ConfigureAwait(false);
+                    }
+                } while (i++ < 10);
+
+                // We're done, so fire and forget delete the wizard token and dispose the client at the end
+                var deleteTask = http.DeleteAsync(pollingUrl);
+                _ = deleteTask.ContinueWith(_ => http.Dispose());
+            }
+
+            return null;
+        }
+
+        internal class WizardStep1Response
+        {
+            public string? Hash { get; set; }
+        }
+        internal class WizardStep2Response
+        {
+            public ApiKeys? ApiKeys { get; set; }
+            public IList<Project> Projects { get; set; } = new List<Project>(0);
+        }
+
+        internal class ApiKeys
+        {
+            public string? Token { get; set; }
+        }
+
+        internal class Project
+        {
+            public Organization? Organization { get; set; }
+            public string? Slug { get; set; }
+            public string? Name { get; set; }
+            public IEnumerable<Key> Keys { get; set; } = Enumerable.Empty<Key>();
+        }
+
+        internal class Key
+        {
+            public Dsn? Dsn { get; set; }
+        }
+
+        internal class Dsn
+        {
+            public string? Public { get; set; }
+        }
+
+        internal class Organization
+        {
+            public string? Name { get; set; }
+            public string? Slug { get; set; }
+        }
+    }
+
+    internal class WizardConfiguration
+    {
+        public string? Token { get; set; }
+        public string? Dsn { get; set; }
+        public string? OrgSlug { get; set; }
+        public string? ProjectSlug { get; set; }
+    }
+}

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
@@ -66,7 +66,8 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             {
                 var serializeOptions = new JsonSerializerOptions
                 {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = true
                 };
                 var http = new HttpClient();
                 var resp = await http.GetAsync("https://sentry.io/api/0/wizard/").ConfigureAwait(false);

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/WizardApi.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/WizardApi.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Sentry.Extensibility;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor.WizardApi
+{
+    [Serializable]
+    internal class WizardStep1Response
+    {
+        public string? hash;
+    }
+
+    [Serializable]
+    internal class WizardStep2Response
+    {
+        public ApiKeys? apiKeys;
+        public List<Project> projects = new List<Project>(0);
+    }
+
+    [Serializable]
+    internal class ApiKeys
+    {
+        public string? token;
+    }
+
+    [Serializable]
+    internal class Project
+    {
+        public Organization? organization;
+        public string? slug;
+        public string? name;
+        public string? platform;
+        public List<Key>? keys;
+
+        public bool IsUnity => string.Equals(platform, "unity", StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Serializable]
+    internal class Key
+    {
+        public Dsn? dsn;
+    }
+
+    [Serializable]
+    internal class Dsn
+    {
+        public string? @public;
+    }
+
+    [Serializable]
+    internal class Organization
+    {
+        public string? name;
+        public string? slug;
+    }
+
+    interface WizardApi {
+        
+    }
+}

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/WizardApi.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/WizardApi.cs
@@ -62,7 +62,8 @@ namespace Sentry.Unity.Editor.WizardApi
         public string? slug;
     }
 
-    interface WizardApi {
-        
+    interface WizardApi
+    {
+
     }
 }

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/WizardApi.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/WizardApi.cs
@@ -61,9 +61,4 @@ namespace Sentry.Unity.Editor.WizardApi
         public string? name;
         public string? slug;
     }
-
-    interface WizardApi
-    {
-
-    }
 }

--- a/src/Sentry.Unity.Editor/SentryPackageInfo.cs
+++ b/src/Sentry.Unity.Editor/SentryPackageInfo.cs
@@ -23,5 +23,7 @@ namespace Sentry.Unity.Editor
 
             throw new FileNotFoundException("Failed to locate the Sentry package");
         }
+
+        internal static bool IsDevPackage => GetName() == PackageNameDev;
     }
 }

--- a/test/Sentry.Unity.Editor.Tests/WizardTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/WizardTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Sentry.Unity.Editor.ConfigurationWindow;
+using Sentry.Unity.Editor.WizardApi;
+using UnityEngine.TestTools;
+using Sentry.Unity.Tests.SharedClasses;
+
+namespace Sentry.Unity.Editor.Tests
+{
+    public sealed class WizardJson
+    {
+        [Test]
+        public void Step1Response()
+        {
+            var sut = new WizardLoader(new TestLogger());
+
+            var parsed = sut.DeserializeJson<WizardStep1Response>("{\"hash\":\"foo\"}");
+
+            Assert.AreEqual("foo", parsed.hash);
+        }
+
+        [Test]
+        public void Step2Response()
+        {
+            var sut = new WizardLoader(new TestLogger());
+
+            var json = "{\"apiKeys\":{\"id\":\"key-1\",\"scopes\":[\"org:read\",\"project:read\",\"project:releases\",\"project:write\"],\"application\":null,\"expiresAt\":null,\"dateCreated\":\"2022-03-02T10:37:56.385524Z\",\"state\":null,\"token\":\"api-key-token\",\"refreshToken\":null},\"projects\":[{\"id\":\"project-1\",\"slug\":\"project-slug\",\"name\":\"personal\",\"isPublic\":false,\"isBookmarked\":false,\"color\":\"#3fb7bf\",\"dateCreated\":\"2022-01-15T20:05:53.883628Z\",\"firstEvent\":\"2022-01-15T20:15:10.171648Z\",\"firstTransactionEvent\":false,\"hasSessions\":true,\"features\":[\"alert-filters\",\"issue-alerts-targeting\",\"minidump\",\"performance-suspect-spans-ingestion\",\"race-free-group-creation\",\"similarity-indexing\",\"similarity-view\",\"releases\"],\"status\":\"active\",\"platform\":\"flutter\",\"isInternal\":false,\"isMember\":false,\"hasAccess\":true,\"avatar\":{\"avatarType\":\"letter_avatar\",\"avatarUuid\":null},\"organization\":{\"id\":\"org-1\",\"slug\":\"org-slug\",\"status\":{\"id\":\"active\",\"name\":\"active\"},\"name\":\"organization-1\",\"dateCreated\":\"2022-01-15T20:03:49.620687Z\",\"isEarlyAdopter\":false,\"require2FA\":false,\"requireEmailVerification\":false,\"avatar\":{\"avatarType\":\"letter_avatar\",\"avatarUuid\":null},\"features\":[\"onboarding\",\"ondemand-budgets\",\"slack-overage-notifications\",\"dashboards-template\",\"discover-frontend-use-events-endpoint\",\"integrations-stacktrace-link\",\"crash-rate-alerts\",\"org-subdomains\",\"performance-dry-run-mep\",\"mobile-app\",\"custom-event-title\",\"advanced-search\",\"widget-library\",\"auto-start-free-trial\",\"release-health-return-metrics\",\"minute-resolution-sessions\",\"capture-lead\",\"invite-members-rate-limits\",\"alert-crash-free-metrics\",\"alert-wizard-v3\",\"images-loaded-v2\",\"duplicate-alert-rule\",\"performance-autogroup-sibling-spans\",\"performance-ops-breakdown\",\"new-widget-builder-experience-design\",\"performance-suspect-spans-view\",\"unified-span-view\",\"performance-frontend-use-events-endpoint\",\"widget-viewer-modal\",\"event-attachments\",\"symbol-sources\",\"performance-span-histogram-view\",\"intl-sales-tax\",\"metrics-extraction\",\"performance-view\",\"new-weekly-report\",\"performance-span-tree-autoscroll\",\"metric-alert-snql\",\"shared-issues\",\"dashboard-grid-layout\",\"open-membership\"]},\"keys\":[{\"id\":\"key-1\",\"name\":\"Default\",\"label\":\"Default\",\"public\":\"public-key\",\"secret\":\"secret-key\",\"projectId\":12345,\"isActive\":true,\"rateLimit\":null,\"dsn\":{\"secret\":\"dsn-secret\",\"public\":\"dsn-public\",\"csp\":\"\",\"security\":\"\",\"minidump\":\"\",\"unreal\":\"\",\"cdn\":\"\"},\"browserSdkVersion\":\"6.x\",\"browserSdk\":{\"choices\":[[\"latest\",\"latest\"],[\"7.x\",\"7.x\"],[\"6.x\",\"6.x\"],[\"5.x\",\"5.x\"],[\"4.x\",\"4.x\"]]},\"dateCreated\":\"2022-01-15T20:05:53.895882Z\"}]},{\"id\":\"project-2\",\"slug\":\"trending-movies\",\"name\":\"trending-movies\",\"isPublic\":false,\"isBookmarked\":false,\"color\":\"#bfb93f\",\"dateCreated\":\"2022-06-16T16:34:36.833418Z\",\"firstEvent\":null,\"firstTransactionEvent\":false,\"hasSessions\":false,\"features\":[\"alert-filters\",\"custom-inbound-filters\",\"data-forwarding\",\"discard-groups\",\"issue-alerts-targeting\",\"minidump\",\"performance-suspect-spans-ingestion\",\"race-free-group-creation\",\"rate-limits\",\"servicehooks\",\"similarity-indexing\",\"similarity-indexing-v2\",\"similarity-view\",\"similarity-view-v2\"],\"status\":\"active\",\"platform\":\"apple-ios\",\"isInternal\":false,\"isMember\":false,\"hasAccess\":true,\"avatar\":{\"avatarType\":\"letter_avatar\",\"avatarUuid\":null},\"organization\":{\"id\":\"organization-2\",\"slug\":\"sentry-sdks\",\"status\":{\"id\":\"active\",\"name\":\"active\"},\"name\":\"Sentry SDKs\",\"dateCreated\":\"2020-09-14T17:28:14.933511Z\",\"isEarlyAdopter\":true,\"require2FA\":false,\"requireEmailVerification\":false,\"avatar\":{\"avatarType\":\"upload\",\"avatarUuid\":\"\"},\"features\":[\"mobile-screenshots\",\"integrations-ticket-rules\",\"ondemand-budgets\",\"dashboards-template\",\"metric-alert-chartcuterie\",\"reprocessing-v2\",\"filters-and-sampling\",\"grouping-stacktrace-ui\",\"discover-frontend-use-events-endpoint\",\"grouping-title-ui\",\"app-store-connect-multiple\",\"crash-rate-alerts\",\"org-subdomains\",\"performance-dry-run-mep\",\"mobile-app\",\"grouping-tree-ui\",\"custom-event-title\",\"widget-library\",\"advanced-search\",\"auto-start-free-trial\",\"global-views\",\"integrations-chat-unfurl\",\"release-health-return-metrics\",\"integrations-stacktrace-link\",\"dashboards-basic\",\"minute-resolution-sessions\",\"discover-basic\",\"capture-lead\",\"alert-crash-free-metrics\",\"data-forwarding\",\"custom-symbol-sources\",\"sso-saml2\",\"integrations-alert-rule\",\"alert-wizard-v3\",\"invite-members\",\"team-insights\",\"integrations-issue-sync\",\"images-loaded-v2\",\"duplicate-alert-rule\",\"performance-autogroup-sibling-spans\",\"monitors\",\"new-widget-builder-experience-design\",\"dashboards-edit\",\"integrations-issue-basic\",\"performance-ops-breakdown\",\"performance-suspect-spans-view\",\"unified-span-view\",\"related-events\",\"integrations-event-hooks\",\"performance-frontend-use-events-endpoint\",\"sso-basic\",\"widget-viewer-modal\",\"event-attachments\",\"symbol-sources\",\"performance-span-histogram-view\",\"new-widget-builder-experience\",\"profiling\",\"dashboards-releases\",\"metrics-extraction\",\"integrations-incident-management\",\"new-weekly-report\",\"performance-view\",\"performance-span-tree-autoscroll\",\"open-membership\",\"metric-alert-snql\",\"shared-issues\",\"integrations-codeowners\",\"change-alerts\",\"dashboard-grid-layout\",\"baa\",\"discover-query\",\"alert-filters\",\"incidents\",\"relay\"]},\"keys\":[{\"id\":\"key-2\",\"name\":\"Default\",\"label\":\"Default\",\"public\":\"public\",\"secret\":\"secret\",\"projectId\":6789,\"isActive\":true,\"rateLimit\":null,\"dsn\":{\"secret\":\"dsn-secret\",\"public\":\"dsn-public\",\"csp\":\"\",\"security\":\"\",\"minidump\":\"\",\"unreal\":\"\",\"cdn\":\"\"},\"browserSdkVersion\":\"7.x\",\"browserSdk\":{\"choices\":[[\"latest\",\"latest\"],[\"7.x\",\"7.x\"],[\"6.x\",\"6.x\"],[\"5.x\",\"5.x\"],[\"4.x\",\"4.x\"]]},\"dateCreated\":\"2022-06-16T16:34:36.845197Z\"}]}]}";
+            var parsed = sut.DeserializeJson<WizardStep2Response>(json);
+
+            Assert.NotNull(parsed.apiKeys);
+            Assert.AreEqual("api-key-token", parsed.apiKeys!.token);
+
+            Assert.NotNull(parsed.projects);
+            Assert.AreEqual(2, parsed.projects.Count);
+            var project = parsed.projects[0];
+            Assert.AreEqual("project-slug", project.slug);
+            Assert.AreEqual("personal", project.name);
+            Assert.AreEqual("flutter", project.platform);
+
+            Assert.IsFalse(project.IsUnity);
+            project.platform = "unity";
+            Assert.IsTrue(project.IsUnity);
+
+            Assert.NotNull(project.organization);
+            var org = project.organization!;
+            Assert.AreEqual("organization-1", org.name);
+            Assert.AreEqual("org-slug", org.slug);
+
+            Assert.NotNull(project.keys);
+            Assert.AreEqual(1, project.keys!.Count);
+            var key = project.keys[0];
+            Assert.NotNull(key.dsn);
+            Assert.AreEqual("dsn-public", key.dsn!.@public);
+        }
+    }
+}


### PR DESCRIPTION
The goal is to have an onboarding flow that will have the user hit Sentry, select an org and project, and will pre-populate the DSN and the Sentry CLI options for symbol upload.

---------------------

Edit @vaind: cleaned this up [_somewhat_](https://github.com/getsentry/sentry-unity/pull/780/files/69b1be294e3a108c45dc10ab08e74f308cdba9bd..0fb1956caa17c6a532e24e285dcecd7072e53c70), resolved TODOs and usability issues. 

Remaining TODO: tests 😱 

Basic workflow:
![wizard](https://user-images.githubusercontent.com/6349682/172891523-c4f887a5-7622-47d8-9fc3-0e2a9b641e15.gif)

----------------

<details>
<summary>First draft does (outdated):</summary>

![image](https://user-images.githubusercontent.com/1633368/172023199-5dce9fe6-6a9b-4eb0-9010-560e4f641ab9.png)

Opens the browser:
![image](https://user-images.githubusercontent.com/1633368/172023216-cf26235d-0b19-4393-875d-97e9db226e5d.png)

prepopulates orgs:
![image](https://user-images.githubusercontent.com/1633368/172023220-b509587f-6a05-42f6-ab7d-20344285f91f.png)

Then projects:
![image](https://user-images.githubusercontent.com/1633368/172023224-02a5374f-947d-454d-ae9f-a46a7a455588.png)

After selecting, the normal window shows up. With DSN, Org and Proj slug and Auth token.

</details>

