### PR TITLE
fix: trim CacheDirectoryPath

### DIFF
--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -180,7 +180,7 @@ namespace Sentry.Unity
                 ? "editor"
                 : "production";
 
-            CacheDirectoryPath = application.PersistentDataPath;
+            CacheDirectoryPath = application.PersistentDataPath.Trim();
         }
 
         public override string ToString()


### PR DESCRIPTION
sometimes in developemnt the `application.PersistentDataPath` had a trailing space on Windows... causing test failures

#skip-changelog