### PR TITLE
test: fix tests flaking with "Unhandled log message"

### DIFF
--- a/test/Sentry.Unity.Tests/IntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/IntegrationTests.cs
@@ -302,14 +302,14 @@ namespace Sentry.Unity.Tests
 
         internal static IEnumerator SetupSceneCoroutine(string sceneName)
         {
+            // don't fail test if exception is thrown via 'SendMessage', we want to continue
+            LogAssert.ignoreFailingMessages = true;
+
             // load scene with initialized Sentry, SceneManager.LoadSceneAsync(sceneName);
             SceneManager.LoadScene(sceneName);
 
             // skip a frame for a Unity to properly load a scene
             yield return null;
-
-            // don't fail test if exception is thrown via 'SendMessage', we want to continue
-            LogAssert.ignoreFailingMessages = true;
         }
 
         internal IDisposable InitSentrySdk(Action<SentryUnityOptions>? configure = null)


### PR DESCRIPTION
#skip-changelog

Should fix [this](
https://github.com/getsentry/sentry-unity/runs/6796442971?check_suite_focus=true) - my assumption is that it's flaky because after yield, we can't be sure the setup function finishes before the test runs:

```
Test 1058: DebugLogException_IsMarkedUnhandled
Unhandled log message: '[Exception] Exception: a6dee71e-6a24-4455-b0a2-010b8624555b Test Event'. Use UnityEngine.TestTools.LogAssert.Expect
Test StackTrace: Sentry.Unity.Integrations.UnityLogHandlerIntegration:LogException(Exception, Object) (at /sentry-unity/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs:47)
Sentry.Unity.Integrations.UnityLogHandlerIntegration:LogException(Exception, Object) (at /sentry-unity/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs:47)
Sentry.Unity.Integrations.UnityLogHandlerIntegration:LogException(Exception, Object) (at /sentry-unity/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs:47)
Sentry.Unity.Integrations.UnityLogHandlerIntegration:LogException(Exception, Object) (at /sentry-unity/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs:47)
Sentry.Unity.Integrations.UnityLogHandlerIntegration:LogException(Exception, Object) (at /sentry-unity/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs:47)
Sentry.Unity.Tests.TestBehaviours.TestMonoBehaviour:DebugLogException(String) (at /sentry-unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs:15)
Sentry.Unity.Tests.TestBehaviours.<>c__DisplayClass4_0:<DebugLogExceptionInTask>b__0() (at /sentry-unity/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs:16)
System.Threading._ThreadPoolWaitCallback:PerformWaitCallback()
```

