### PR TITLE
chore: remove version from the android .jar

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -183,14 +183,12 @@ Expected to exist:
     <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="./gradlew -PsentryAndroidSdkName=sentry.native.android.unity :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none"></Exec>
 
     <ItemGroup>
-      <!-- building snapshot based on version, i.e: sentry-5.0.0-beta.3-SNAPSHOT.jar -->
-      <AndroidSdkArtifacts Include="$(SentryAndroidRoot)sentry/build/libs/sentry*.jar" />
       <AndroidSdkArtifacts Include="$(SentryAndroidRoot)sentry-android-ndk/build/outputs/aar/sentry-android-ndk-release.aar" />
       <AndroidSdkArtifacts Include="$(SentryAndroidRoot)sentry-android-core/build/outputs/aar/sentry-android-core-release.aar" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(AndroidSdkArtifacts)" DestinationFiles="@(AndroidSdkArtifacts->'$(SentryAndroidArtifactsDestination)%(RecursiveDir)%(Filename)%(Extension)')">
-    </Copy>
+    <Copy SourceFiles="@(AndroidSdkArtifacts)" DestinationFiles="@(AndroidSdkArtifacts->'$(SentryAndroidArtifactsDestination)%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="cp sentry/build/libs/sentry*.jar $(SentryAndroidArtifactsDestination)sentry.jar" />
 
     <Error Condition="!Exists('$(SentryAndroidArtifactsDestination)')" Text="Failed to build the Android SDK."></Error>
   </Target>

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -267,8 +267,8 @@ Plugins/iOS/Device/Sentry.framework/Headers/SentryUserFeedback.h.meta
 Plugins/iOS/Device/Sentry.framework/Modules/module.modulemap
 Plugins/iOS/Device/Sentry.framework/Modules/module.modulemap.meta
 Plugins/Android/Sentry.meta
-Plugins/Android/Sentry/sentry-6.1.0.jar
-Plugins/Android/Sentry/sentry-6.1.0.jar.meta
+Plugins/Android/Sentry/sentry.jar
+Plugins/Android/Sentry/sentry.jar.meta
 Plugins/Android/Sentry/sentry-android-core-release.aar
 Plugins/Android/Sentry/sentry-android-core-release.aar.meta
 Plugins/Android/Sentry/sentry-android-ndk-release.aar


### PR DESCRIPTION
to avoid having to do this: https://github.com/getsentry/sentry-unity/pull/811/commits/afd1681ba2c64e820b58a26241e8153b7ee416e8

#skip-changelog