### PR TITLE
fix: Adding the IL2CPP processor outside the constructor

### DIFF
--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -92,10 +92,7 @@ namespace Sentry.Unity
         internal SentryUnityOptions ToSentryUnityOptions(bool isBuilding, ISentryUnityInfo? unityInfo = null, IApplication? application = null)
         {
             application ??= ApplicationAdapter.Instance;
-
-            UnityEngine.Debug.Log("creating new sentry unity options");
-            UnityEngine.Debug.Log("il2cpp enabled: " + Il2CppLineNumberSupportEnabled);
-
+            
             var options = new SentryUnityOptions(isBuilding, unityInfo, application)
             {
                 Enabled = Enabled,
@@ -149,7 +146,7 @@ namespace Sentry.Unity
 
             OptionsConfiguration?.Configure(options);
 
-            // Doing this after the configure callback
+            // Doing this after the configure callback to allow users to programmatically opt out
             if (Il2CppLineNumberSupportEnabled)
             {
                 options.AddIl2CppExceptionProcessor(unityInfo);

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -92,7 +92,7 @@ namespace Sentry.Unity
         internal SentryUnityOptions ToSentryUnityOptions(bool isBuilding, ISentryUnityInfo? unityInfo = null, IApplication? application = null)
         {
             application ??= ApplicationAdapter.Instance;
-            
+
             var options = new SentryUnityOptions(isBuilding, unityInfo, application)
             {
                 Enabled = Enabled,

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -113,11 +113,6 @@ namespace Sentry.Unity
         /// </summary>
         public bool LinuxNativeSupportEnabled { get; set; } = true;
 
-        /// <summary>
-        /// Whether the SDK should add an exception processor to provide line number support for IL2CPP
-        /// </summary>
-        public bool Il2CppLineNumberSupportEnabled { get; set; } = false;
-
         // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).
         internal string? _defaultUserId;
         internal string? DefaultUserId
@@ -159,11 +154,6 @@ namespace Sentry.Unity
             this.AddInAppExclude("UnityEngine");
             this.AddInAppExclude("UnityEditor");
             this.AddEventProcessor(new UnityEventProcessor(this, SentryMonoBehaviour.Instance));
-
-            if (Il2CppLineNumberSupportEnabled && unityInfo?.Il2CppMethods is not null)
-            {
-                this.AddExceptionProcessor(new UnityIl2CppEventExceptionProcessor(this, unityInfo, unityInfo.Il2CppMethods));
-            }
 
             this.AddIntegration(new UnityLogHandlerIntegration());
             this.AddIntegration(new AnrIntegration(behaviour));

--- a/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
+++ b/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
@@ -63,6 +63,18 @@ namespace Sentry.Unity
             }
         }
 
+        internal static void AddIl2CppExceptionProcessor(this SentryUnityOptions options, ISentryUnityInfo? unityInfo)
+        {
+            if (unityInfo?.Il2CppMethods is not null)
+            {
+                options.AddExceptionProcessor(new UnityIl2CppEventExceptionProcessor(options, unityInfo, unityInfo.Il2CppMethods));
+            }
+            else
+            {
+                options.DiagnosticLogger?.LogWarning("Failed to find required IL2CPP methods - Skipping line number support");
+            }
+        }
+
         /// <summary>
         /// Disables the capture of errors through <see cref="UnityLogHandlerIntegration"/>.
         /// </summary>


### PR DESCRIPTION
Checking the opt-in flag in the constructor does not work since it would have to be passed as an argument.

#skip-changelog