### PR TITLE
test: async stacktrace

### DIFF
--- a/test/Sentry.Unity.Tests/SentryUnityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityTests.cs
@@ -99,6 +99,12 @@ namespace Sentry.Unity.Tests
                 writer.Flush();
                 Debug.Log($"  {(Encoding.UTF8.GetString(stream.ToArray()))}");
             }
+
+            // Sentry captured frame must be cleaned up - the return type removed from the module (method name)
+            Assert.AreEqual("System.Threading.Tasks.Task`1", framesSentry[0].Module);
+
+            // Sanity check - the manually captured stack frame must contain the wrong format method
+            Assert.IsTrue(framesManual[1].GetMethod()?.DeclaringType?.FullName?.StartsWith("System.Threading.Tasks.Task`1[[System.Int32"));
         }
 
         [Test]

--- a/test/Sentry.Unity.Tests/SentryUnityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityTests.cs
@@ -3,6 +3,14 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Debug = UnityEngine.Debug;
+using Sentry.Extensibility;
 
 namespace Sentry.Unity.Tests
 {
@@ -41,6 +49,55 @@ namespace Sentry.Unity.Tests
             if (SentrySdk.IsEnabled)
             {
                 SentrySdk.Close();
+            }
+        }
+
+        [Test]
+        public void AsyncStackTrace()
+        {
+            var options = new SentryUnityOptions();
+            options.AttachStacktrace = true;
+            options.StackTraceMode = StackTraceMode.Original;
+            var sut = new SentryStackTraceFactory(options);
+
+            IList<SentryStackFrame> framesSentry = null!;
+            StackFrame[] framesManual = null!;
+            Task.Run(() =>
+            {
+                var stackTrace = new StackTrace(true);
+                framesManual = stackTrace.GetFrames();
+
+                var sentryStackTrace = sut.Create()!;
+                var framesReversed = new System.Collections.Generic.List<SentryStackFrame>(sentryStackTrace.Frames);
+                framesReversed.Reverse();
+                framesSentry = framesReversed;
+                return 42; // returning a value here messes up a stack trace
+            }).Wait();
+
+            Debug.Log("Manually captured stack trace:");
+            foreach (var frame in framesManual)
+            {
+                Debug.Log($"  {frame.GetMethod()?.DeclaringType?.FullName} in {frame}");
+            }
+
+            Debug.Log("");
+
+            Debug.Log("Sentry captured stack trace:");
+            foreach (var frame in framesSentry)
+            {
+                Debug.Log($"  {frame.Module} in {frame.Function}");
+            }
+
+            Debug.Log("");
+
+            Debug.Log("Sentry captured stack trace (JSON):");
+            foreach (var frame in framesSentry)
+            {
+                using var stream = new MemoryStream();
+                using var writer = new Utf8JsonWriter(stream);
+                frame.WriteTo(writer, null);
+                writer.Flush();
+                Debug.Log($"  {(Encoding.UTF8.GetString(stream.ToArray()))}");
             }
         }
 

--- a/test/Sentry.Unity.Tests/SentryUnityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityTests.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using System.IO;
 using System.Text;
-using System.Text.Json;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -77,7 +76,7 @@ namespace Sentry.Unity.Tests
             Debug.Log("Manually captured stack trace:");
             foreach (var frame in framesManual)
             {
-                Debug.Log($"  {frame.GetMethod()?.DeclaringType?.FullName} in {frame}");
+                Debug.Log($"  {frame} in {frame.GetMethod()?.DeclaringType?.FullName}");
             }
 
             Debug.Log("");
@@ -85,19 +84,7 @@ namespace Sentry.Unity.Tests
             Debug.Log("Sentry captured stack trace:");
             foreach (var frame in framesSentry)
             {
-                Debug.Log($"  {frame.Module} in {frame.Function}");
-            }
-
-            Debug.Log("");
-
-            Debug.Log("Sentry captured stack trace (JSON):");
-            foreach (var frame in framesSentry)
-            {
-                using var stream = new MemoryStream();
-                using var writer = new Utf8JsonWriter(stream);
-                frame.WriteTo(writer, null);
-                writer.Flush();
-                Debug.Log($"  {(Encoding.UTF8.GetString(stream.ToArray()))}");
+                Debug.Log($"  {frame.Function} in {frame.Module} from ({frame.Package})");
             }
 
             // Sentry captured frame must be cleaned up - the return type removed from the module (method name)

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -68,13 +68,12 @@ namespace Sentry.Unity.Tests
             {
                 Message = new SentryMessage
                 {
-                    Message = "Test message"
+                    Message = NUnit.Framework.TestContext.CurrentContext.Test.Name
                 }
             };
 
             // act
-            Task.Run(() => SentrySdk.CaptureEvent(sentryEvent))
-                .Wait();
+            Task.Run(() => SentrySdk.CaptureEvent(sentryEvent)).Wait();
 
             SentrySdk.FlushAsync(TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
 
@@ -136,7 +135,7 @@ namespace Sentry.Unity.Tests
             {
                 var @event = new SentryEvent()
                 {
-                    Message = "Test message"
+                    Message = NUnit.Framework.TestContext.CurrentContext.Test.Name
                 };
 
                 // Events should have the same context, regardless of the thread they were issued on.

--- a/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
@@ -51,7 +51,7 @@ namespace Sentry.Unity.Tests
         public void CaptureLogFormat_LogTypeError_CaptureEvent()
         {
             var sut = _fixture.GetSut();
-            var message = "Test Message";
+            var message = NUnit.Framework.TestContext.CurrentContext.Test.Name;
 
             sut.CaptureLogFormat(LogType.Error, null, "{0}", message);
 
@@ -68,7 +68,7 @@ namespace Sentry.Unity.Tests
         {
             _fixture.SentryOptions.EnableLogDebouncing = true;
             var sut = _fixture.GetSut();
-            var message = "message";
+            var message = NUnit.Framework.TestContext.CurrentContext.Test.Name;
 
             sut.CaptureLogFormat(unityLogType, null, "{0}", message);
             sut.CaptureLogFormat(unityLogType, null, "{0}", message);
@@ -86,7 +86,7 @@ namespace Sentry.Unity.Tests
         public void CaptureLogFormat_UnityErrorLogTypes_CapturedAndCorrespondToSentryLevel(LogType unityLogType, SentryLevel sentryLevel, BreadcrumbLevel breadcrumbLevel)
         {
             var sut = _fixture.GetSut();
-            var message = "Test Message";
+            var message = NUnit.Framework.TestContext.CurrentContext.Test.Name;
 
             sut.CaptureLogFormat(unityLogType, null, "{0}", message);
 
@@ -110,7 +110,7 @@ namespace Sentry.Unity.Tests
         public void CaptureLogFormat_UnityNotErrorLogTypes_NotCaptured(LogType unityLogType, BreadcrumbLevel breadcrumbLevel)
         {
             var sut = _fixture.GetSut();
-            var message = "Test Message";
+            var message = NUnit.Framework.TestContext.CurrentContext.Test.Name;
 
             sut.CaptureLogFormat(unityLogType, null, "{0}", message);
 
@@ -128,7 +128,7 @@ namespace Sentry.Unity.Tests
         public void CaptureException_ExceptionCapturedAndMechanismSet()
         {
             var sut = _fixture.GetSut();
-            var message = "Test Exception";
+            var message = NUnit.Framework.TestContext.CurrentContext.Test.Name;
 
             sut.CaptureException(new Exception(message), null);
 
@@ -151,7 +151,7 @@ namespace Sentry.Unity.Tests
         public void CaptureException_CapturedExceptionAddedAsBreadcrumb()
         {
             var sut = _fixture.GetSut();
-            var message = "Test Message";
+            var message = NUnit.Framework.TestContext.CurrentContext.Test.Name;
             var exception = new Exception(message);
 
             sut.CaptureException(exception, null);


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-unity/issues/845

depends on https://github.com/getsentry/sentry-dotnet/pull/1743

#skip-changelog