### PR TITLE
chore: Logging cleanup

### DIFF
--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -85,7 +85,7 @@ namespace Sentry.Unity
 #if ENABLE_IL2CPP
                true;
 #else
-                false;
+               false;
 #endif
         }
 
@@ -111,7 +111,7 @@ namespace Sentry.Unity
 #if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER
             ;
 #else
-#nullable enable
+// #nullable enable
             = new Il2CppMethods(
                 il2cpp_gchandle_get_target,
 #if UNITY_2021_3_OR_NEWER
@@ -152,7 +152,7 @@ namespace Sentry.Unity
         // void il2cpp_native_stack_trace(const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID)
         [DllImport("__Internal")]
         private static extern void il2cpp_native_stack_trace(IntPtr exc, out IntPtr addresses, out int numFrames, [Out] char[] imageUUID);
-#nullable disable
+// #nullable disable
 #endif
 
 #endif

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -111,7 +111,6 @@ namespace Sentry.Unity
 #if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER
             ;
 #else
-#nullable enable
             = new Il2CppMethods(
                 il2cpp_gchandle_get_target,
 #if UNITY_2021_3_OR_NEWER
@@ -132,11 +131,14 @@ namespace Sentry.Unity
         private static extern void il2cpp_free(IntPtr ptr);
 
 #if UNITY_2021_3_OR_NEWER
+#pragma warning disable 8632
         // Definition from Unity `2021.3` (and later):
         // void il2cpp_native_stack_trace(const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char** imageUUID, char** imageName)
         [DllImport("__Internal")]
         private static extern void il2cpp_native_stack_trace(IntPtr exc, out IntPtr addresses, out int numFrames, out string? imageUUID, out string? imageName);
+#pragma warning restore 8632
 #else
+#pragma warning disable 8632
         private static void Il2CppNativeStackTraceShim(IntPtr exc, out IntPtr addresses, out int numFrames, out string? imageUUID, out string? imageName)
         {
             imageName = null;
@@ -147,12 +149,12 @@ namespace Sentry.Unity
             // C-strings are nul-terminated, but the conversion here would normally keep that terminating nul-byte in the string, which we don't want.
             imageUUID = new string(uuidBuffer).TrimEnd('\0');
         }
+#pragma warning restore 8632
 
         // Definition from Unity `2020.3`:
         // void il2cpp_native_stack_trace(const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID)
         [DllImport("__Internal")]
         private static extern void il2cpp_native_stack_trace(IntPtr exc, out IntPtr addresses, out int numFrames, [Out] char[] imageUUID);
-#nullable disable
 #endif
 
 #endif

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -14,7 +14,6 @@ using System;
 #if !UNITY_2021_3_OR_NEWER
 using System.Buffers;
 #endif
-using System.Runtime.InteropServices;
 using UnityEngine;
 using UnityEngine.Scripting;
 
@@ -26,8 +25,6 @@ using Sentry.Unity.Android;
 using Sentry.Unity.Native;
 #elif SENTRY_WEBGL
 using Sentry.Unity.WebGL;
-#elif SENTRY_DEFAULT
-using Sentry.Unity.Default;
 #endif
 
 [assembly: AlwaysLinkAssembly]
@@ -139,15 +136,12 @@ namespace Sentry.Unity
         private static void Il2CppNativeStackTraceShim(IntPtr exc, out IntPtr addresses, out int numFrames, out string? imageUUID, out string? imageName)
         {
             imageName = null;
-            // Unity 2020 does not *return* a newly allocated string as out-parameter,
-            // but rather expects a pre-allocated buffer it writes into.
-            // That buffer needs to have space for the hex-encoded uuid (32) plus
-            // terminating nul-byte.
+            // Unity 2020 does not *return* a newly allocated string as out-parameter, but rather expects a pre-allocated
+            // buffer it writes into. That buffer needs to have space for the hex-encoded uuid (32) plus terminating nul-byte.
             char[] uuidBuffer = new char[32 + 1];
             il2cpp_native_stack_trace(exc, out addresses, out numFrames, uuidBuffer);
-            // C-strings are nul-terminated, but the conversion here would
-            // normally keep that terminating nul-byte in the string, which
-            // we don't want.
+            // C-strings are nul-terminated, but the conversion here would normally keep that terminating nul-byte in
+            // the string, which we don't want.
             imageUUID = new string(uuidBuffer).TrimEnd('\0');
         }
 

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -107,11 +107,11 @@ namespace Sentry.Unity
         public Il2CppMethods Il2CppMethods => _il2CppMethods;
 
         private Il2CppMethods _il2CppMethods
-            // Lowest supported version to have all required methods below
+// Lowest supported version to have all required methods below
 #if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER
             ;
 #else
-// #nullable enable
+#nullable enable
             = new Il2CppMethods(
                 il2cpp_gchandle_get_target,
 #if UNITY_2021_3_OR_NEWER
@@ -152,7 +152,7 @@ namespace Sentry.Unity
         // void il2cpp_native_stack_trace(const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char* imageUUID)
         [DllImport("__Internal")]
         private static extern void il2cpp_native_stack_trace(IntPtr exc, out IntPtr addresses, out int numFrames, [Out] char[] imageUUID);
-// #nullable disable
+#nullable disable
 #endif
 
 #endif

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -186,22 +186,25 @@ namespace Sentry.Unity.Editor.Native
 
             DataReceivedEventHandler logForwarder = (object sender, DataReceivedEventArgs e) =>
             {
-                var msg = e.Data.ToString().Trim();
-                var msgLower = msg.ToLowerInvariant();
-                var level = SentryLevel.Info;
-                if (msgLower.StartsWith("error"))
+                if (!string.IsNullOrEmpty(e.Data))
                 {
-                    level = SentryLevel.Error;
-                }
-                else if (msgLower.StartsWith("warn"))
-                {
-                    level = SentryLevel.Warning;
-                }
+                    var msg = e.Data.Trim();
+                    var msgLower = msg.ToLowerInvariant();
+                    var level = SentryLevel.Info;
+                    if (msgLower.StartsWith("error"))
+                    {
+                        level = SentryLevel.Error;
+                    }
+                    else if (msgLower.StartsWith("warn"))
+                    {
+                        level = SentryLevel.Warning;
+                    }
 
-                // Remove the level and timestamp from the beginning of the message.
-                // INFO    2022-06-20 15:10:03.613794800 +02:00
-                msg = Regex.Replace(msg, "^[a-zA-Z]+ +[0-9\\-]{10} [0-9:]{8}\\.[0-9]+ \\+[0-9:]{5} +", "");
-                logger.Log(level, "sentry-cli: {0}", null, msg);
+                    // Remove the level and timestamp from the beginning of the message.
+                    // INFO    2022-06-20 15:10:03.613794800 +02:00
+                    msg = Regex.Replace(msg, "^[a-zA-Z]+ +[0-9\\-]{10} [0-9:]{8}\\.[0-9]+ \\+[0-9:]{5} +", "");
+                    logger.Log(level, "sentry-cli: {0}", null, msg);
+                }
             };
 
             process.OutputDataReceived += logForwarder;

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -167,7 +167,7 @@ namespace Sentry.Unity
             OptionsConfiguration?.Configure(options);
 
             // Doing this after the configure callback to allow users to programmatically opt out
-            if (Il2CppLineNumberSupportEnabled)
+            if (!isBuilding && Il2CppLineNumberSupportEnabled)
             {
                 options.AddIl2CppExceptionProcessor(unityInfo);
             }


### PR DESCRIPTION
The `Sentry.Unity.Default` namespace no longer exists.
Added `#nullable` to get rid of build-time warnings: `The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.`

#skip-changelog