### PR TITLE
chore: disable cocoa ANR detection

### DIFF
--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -46,6 +46,8 @@ const void *SentryNativeBridgeOptionsNew()
 {
     NSMutableDictionary *dictOptions = [[NSMutableDictionary alloc] init];
     dictOptions[@"sdk"] = @ { @"name" : @"sentry.cocoa.unity" };
+    dictOptions[@"enableAutoSessionTracking"] = @NO;
+    dictOptions[@"enableAppHangTracking"] = @NO;
     return CFBridgingRetain(dictOptions);
 }
 

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -30,6 +30,7 @@ static NSDictionary* getSentryOptions()
         @""maxBreadcrumbs"": @{options.MaxBreadcrumbs},
         @""maxCacheItems"": @{options.MaxCacheItems},
         @""enableAutoSessionTracking"": @NO,
+        @""enableAppHangTracking"": @NO,
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}""

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -45,10 +45,6 @@ namespace Sentry.Unity.iOS
             options.DiagnosticLogger?.LogDebug("Setting DiagnosticLevel: {0}", diagnosticLevel);
             OptionsSetString(cOptions, "diagnosticLevel", diagnosticLevel);
 
-            // Disabling the native in favor of the C# layer for now
-            options.DiagnosticLogger?.LogDebug("Disabling native auto session tracking");
-            OptionsSetInt(cOptions, "enableAutoSessionTracking", 0);
-
             options.DiagnosticLogger?.LogDebug("Setting SendDefaultPii: {0}", options.SendDefaultPii);
             OptionsSetInt(cOptions, "sendDefaultPii", options.SendDefaultPii ? 1 : 0);
 


### PR DESCRIPTION
closes #838 

#skip-changelog (no user visible change because the native cocoa SDK with the ANR enabled hasn't shipped yet)