### PR TITLE
fix: Added a x64 guard to the IL2CPP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed linker issues for x86 IL2CPP builds on 2020.3 and newer ([#871](https://github.com/getsentry/sentry-unity/pull/871))
+- Explicitly disable Windows x86 native-error tracking and IL2CPP processing integration ([#871](https://github.com/getsentry/sentry-unity/pull/871))
 
 ## 0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed linker issues for x86 IL2CPP builds on 2020.3 and newer ([#871](https://github.com/getsentry/sentry-unity/pull/871))
+
 ## 0.20.0
 
 ### Features

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -11,7 +11,7 @@
 #endif
 
 using System;
-#if UNITY_2020_3_36_OR_NEWER
+#if UNITY_2020_3_OR_NEWER
 using System.Buffers;
 using System.Runtime.InteropServices;
 #endif
@@ -108,12 +108,12 @@ namespace Sentry.Unity
 
         private Il2CppMethods _il2CppMethods
 // Lowest supported version to have all required methods below
-#if !ENABLE_IL2CPP || !UNITY_2020_3_36_OR_NEWER
+#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER || !UNITY_64
             ;
 #else
             = new Il2CppMethods(
                 il2cpp_gchandle_get_target,
-#if UNITY_2021_3_5_OR_NEWER
+#if UNITY_2021_5_OR_NEWER
                 il2cpp_native_stack_trace,
 #else
                 Il2CppNativeStackTraceShim,
@@ -130,7 +130,7 @@ namespace Sentry.Unity
         [DllImport("__Internal")]
         private static extern void il2cpp_free(IntPtr ptr);
 
-#if UNITY_2021_3_5_OR_NEWER
+#if UNITY_2021_3_OR_NEWER
 #pragma warning disable 8632
         // Definition from Unity `2021.3` (and later):
         // void il2cpp_native_stack_trace(const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char** imageUUID, char** imageName)

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -11,7 +11,7 @@
 #endif
 
 using System;
-#if UNITY_2020_3_OR_NEWER
+#if UNITY_2020_3_36_OR_NEWER
 using System.Buffers;
 using System.Runtime.InteropServices;
 #endif
@@ -108,12 +108,12 @@ namespace Sentry.Unity
 
         private Il2CppMethods _il2CppMethods
 // Lowest supported version to have all required methods below
-#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER
+#if !ENABLE_IL2CPP || !UNITY_2020_3_36_OR_NEWER
             ;
 #else
             = new Il2CppMethods(
                 il2cpp_gchandle_get_target,
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2021_3_5_OR_NEWER
                 il2cpp_native_stack_trace,
 #else
                 Il2CppNativeStackTraceShim,
@@ -130,7 +130,7 @@ namespace Sentry.Unity
         [DllImport("__Internal")]
         private static extern void il2cpp_free(IntPtr ptr);
 
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2021_3_5_OR_NEWER
 #pragma warning disable 8632
         // Definition from Unity `2021.3` (and later):
         // void il2cpp_native_stack_trace(const Il2CppException * ex, uintptr_t** addresses, int* numFrames, char** imageUUID, char** imageName)

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -113,7 +113,7 @@ namespace Sentry.Unity
 #else
             = new Il2CppMethods(
                 il2cpp_gchandle_get_target,
-#if UNITY_2021_5_OR_NEWER
+#if UNITY_2021_3_OR_NEWER
                 il2cpp_native_stack_trace,
 #else
                 Il2CppNativeStackTraceShim,

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -108,7 +108,7 @@ namespace Sentry.Unity
 
         private Il2CppMethods _il2CppMethods
 // Lowest supported version to have all required methods below
-#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER
+#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER || !UNITY_64
             ;
 #else
             = new Il2CppMethods(
@@ -125,7 +125,7 @@ namespace Sentry.Unity
         [DllImport("__Internal")]
         private static extern IntPtr il2cpp_gchandle_get_target(int gchandle);
 
-        // Available in Unity `2019.4.34f1` (and later)f
+        // Available in Unity `2019.4.34f1` (and later)
         // void il2cpp_free(void* ptr)
         [DllImport("__Internal")]
         private static extern void il2cpp_free(IntPtr ptr);

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -3,7 +3,7 @@
 #define SENTRY_NATIVE_COCOA
 #elif UNITY_ANDROID
 #define SENTRY_NATIVE_ANDROID
-#elif UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX
+#elif UNITY_64 && (UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX)
 #define SENTRY_NATIVE
 #elif UNITY_WEBGL
 #define SENTRY_WEBGL
@@ -108,7 +108,7 @@ namespace Sentry.Unity
 
         private Il2CppMethods _il2CppMethods
 // Lowest supported version to have all required methods below
-#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER || !UNITY_64
+#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER
             ;
 #else
             = new Il2CppMethods(
@@ -125,7 +125,7 @@ namespace Sentry.Unity
         [DllImport("__Internal")]
         private static extern IntPtr il2cpp_gchandle_get_target(int gchandle);
 
-        // Available in Unity `2019.4.34f1` (and later)
+        // Available in Unity `2019.4.34f1` (and later)f
         // void il2cpp_free(void* ptr)
         [DllImport("__Internal")]
         private static extern void il2cpp_free(IntPtr ptr);


### PR DESCRIPTION
There is something off about the way we call native code on `x86` so I'm guarding the IL2CPP feature with `UNITY_64` for now:
```
error LNK2019: unresolved external symbol _il2cpp_gchandle_get_target@4 referenced in function _SentryUnityInfo_il2cpp_gchandle_get_target_m42BE043B96499DAF199C1045023BE6DE1B0FF6EA
  Hint on symbols that are defined and could potentially match:
    _il2cpp_gchandle_get_target
```
This can easily be reproduced with our own samples and `throw_cpp`.