### PR TITLE
Feat/native screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Attach screenshots to native errors on iOS/macOS ([#878](https://github.com/getsentry/sentry-unity/pull/878))
+- Attach screenshots to native errors on iOS ([#878](https://github.com/getsentry/sentry-unity/pull/878))
 - Bump CLI to v2.3.1 ([#875](https://github.com/getsentry/sentry-unity/pull/875))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#231)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.3.0...2.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Attach screenshots to native errors on iOS/macOS ([#878](https://github.com/getsentry/sentry-unity/pull/878))
 - Bump CLI to v2.3.1 ([#875](https://github.com/getsentry/sentry-unity/pull/875))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#231)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.3.0...2.3.1)

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -4,14 +4,14 @@ namespace Sentry.Unity.Editor.iOS
 {
     internal interface INativeOptions
     {
-        public void CreateFile(string path, SentryOptions options);
+        public void CreateFile(string path, SentryUnityOptions options);
     }
 
     internal class NativeOptions : INativeOptions
     {
-        public void CreateFile(string path, SentryOptions options) => File.WriteAllText(path, Generate(options));
+        public void CreateFile(string path, SentryUnityOptions options) => File.WriteAllText(path, Generate(options));
 
-        internal string Generate(SentryOptions options)
+        internal string Generate(SentryUnityOptions options)
         {
             var nativeOptions = $@"#import <Foundation/Foundation.h>
 
@@ -32,6 +32,7 @@ static NSDictionary* getSentryOptions()
         @""enableAutoSessionTracking"": @NO,
         @""enableAppHangTracking"": @NO,
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
+        @""attachScreenshot"" : @""{options.AttachScreenshot}"",
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}""
     }};

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -135,6 +135,11 @@ namespace Sentry.Unity.Editor.Android
             // _logger.LogDebug("Setting SendDefaultPii: {0}", options.SendDefaultPii);
             // // androidManifest.SetSendDefaultPii(options.SendDefaultPii);
 
+            // Note: doesn't work - produces a blank (white) screenshot
+            // _logger.LogDebug("Setting AttachScreenshot: {0}", _options.AttachScreenshot);
+            // androidManifest.SetAttachScreenshot(_options.AttachScreenshot);
+            androidManifest.SetAttachScreenshot(false);
+
             // Disabling the native in favor of the C# layer for now
             androidManifest.SetAutoSessionTracking(false);
             androidManifest.SetAnr(false);
@@ -319,6 +324,9 @@ namespace Sentry.Unity.Editor.Android
             SetMetaData($"{SentryPrefix}.sample-rate", sampleRate.ToString());
 
         internal void SetRelease(string release) => SetMetaData($"{SentryPrefix}.release", release);
+
+        internal void SetAttachScreenshot(bool value) => SetMetaData($"{SentryPrefix}.attach-screenshot", value.ToString());
+
         internal void SetEnvironment(string environment) => SetMetaData($"{SentryPrefix}.environment", environment);
 
         internal void SetSDK(string name) => SetMetaData($"{SentryPrefix}.sdk.name", name);

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -335,7 +335,7 @@ namespace Sentry.Unity.Editor.Android
             => SetMetaData($"{SentryPrefix}.auto-session-tracking.enable", enableAutoSessionTracking.ToString());
 
         internal void SetAnr(bool enableAnr)
-            => SetMetaData($"{SentryPrefix}.io.sentry.anr.enable", enableAnr.ToString());
+            => SetMetaData($"{SentryPrefix}.anr.enable", enableAnr.ToString());
 
         internal void SetNdkScopeSync(bool enableNdkScopeSync)
             => SetMetaData($"{SentryPrefix}.ndk.scope-sync.enable", enableNdkScopeSync.ToString());

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -48,8 +48,10 @@ namespace Sentry.Unity.iOS
             options.DiagnosticLogger?.LogDebug("Setting SendDefaultPii: {0}", options.SendDefaultPii);
             OptionsSetInt(cOptions, "sendDefaultPii", options.SendDefaultPii ? 1 : 0);
 
-            options.DiagnosticLogger?.LogDebug("Setting AttachScreenshot: {0}", options.AttachScreenshot);
-            OptionsSetInt(cOptions, "attachScreenshot", options.AttachScreenshot ? 1 : 0);
+            // macOS screenshots currently don't work, because there's no UIKit. Cocoa logs: "Sentry - info:: NO UIKit"
+            // options.DiagnosticLogger?.LogDebug("Setting AttachScreenshot: {0}", options.AttachScreenshot);
+            // OptionsSetInt(cOptions, "attachScreenshot", options.AttachScreenshot ? 1 : 0);
+            OptionsSetInt(cOptions, "attachScreenshot", 0);
 
             options.DiagnosticLogger?.LogDebug("Setting MaxBreadcrumbs: {0}", options.MaxBreadcrumbs);
             OptionsSetInt(cOptions, "maxBreadcrumbs", options.MaxBreadcrumbs);

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -48,6 +48,9 @@ namespace Sentry.Unity.iOS
             options.DiagnosticLogger?.LogDebug("Setting SendDefaultPii: {0}", options.SendDefaultPii);
             OptionsSetInt(cOptions, "sendDefaultPii", options.SendDefaultPii ? 1 : 0);
 
+            options.DiagnosticLogger?.LogDebug("Setting AttachScreenshot: {0}", options.AttachScreenshot);
+            OptionsSetInt(cOptions, "attachScreenshot", options.AttachScreenshot ? 1 : 0);
+
             options.DiagnosticLogger?.LogDebug("Setting MaxBreadcrumbs: {0}", options.MaxBreadcrumbs);
             OptionsSetInt(cOptions, "maxBreadcrumbs", options.MaxBreadcrumbs);
 

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -89,7 +89,7 @@ namespace Sentry.Unity
 
             var bytes = screenshot.EncodeToJPG(Quality);
             _options.DiagnosticLogger?.Log(SentryLevel.Debug,
-                    "Screenshot captured at {0}x{1}: {0} bytes", null, width, height, bytes.Length);
+                    "Screenshot captured at {0}x{1}: {2} bytes", null, width, height, bytes.Length);
             return bytes;
         }
     }

--- a/test/Sentry.Unity.Editor.iOS.Tests/NativeOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/NativeOptionsTests.cs
@@ -17,7 +17,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
 
             const string testOptionsFileName = "testOptions.m";
             var nativeOptions = new NativeOptions();
-            var nativeOptionsString = nativeOptions.Generate(new SentryOptions());
+            var nativeOptionsString = nativeOptions.Generate(new SentryUnityOptions());
             File.WriteAllText(testOptionsFileName, nativeOptionsString);
 
             var process = Process.Start("clang", $"-fsyntax-only {testOptionsFileName}");
@@ -38,7 +38,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
 
             const string testOptionsFileName = "testOptions.m";
             var nativeOptions = new NativeOptions();
-            var nativeOptionsString = nativeOptions.Generate(new SentryOptions());
+            var nativeOptionsString = nativeOptions.Generate(new SentryUnityOptions());
             nativeOptionsString += "AppendedTextToFailCompilation";
 
             File.WriteAllText(testOptionsFileName, nativeOptionsString);
@@ -57,7 +57,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
             const string testOptionsFileName = "testOptions.m";
             var nativeOptions = new NativeOptions();
 
-            nativeOptions.CreateFile(testOptionsFileName, new SentryOptions());
+            nativeOptions.CreateFile(testOptionsFileName, new SentryUnityOptions());
 
             Assert.IsTrue(File.Exists(testOptionsFileName));
 

--- a/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
@@ -16,7 +16,7 @@ namespace Sentry.Unity.Editor.iOS.Tests
 
         private class NativeOptionsTest : INativeOptions
         {
-            public void CreateFile(string path, SentryOptions options) { }
+            public void CreateFile(string path, SentryUnityOptions options) { }
         }
 
         private class Fixture


### PR DESCRIPTION
closes #862 

adds support for iOS native screenshots (the only ones that work out of the box)

and fixes
* disabling ANR on Android
* logging captured screenshot size
