### PR TITLE
fix: Mobile IL2CPP line number support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Correctly byte-swap ELF build-ids ([#872](https://github.com/getsentry/sentry-unity/pull/872))
 - Wizard autoselects with only one option available ([#891](https://github.com/getsentry/sentry-unity/pull/891))
+- Reenabled IL2CPP line number support for mobile ([#902](https://github.com/getsentry/sentry-unity/pull/902))
 
 ### Features
 

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -10,6 +10,10 @@
 #endif
 #endif
 
+#if ENABLE_IL2CPP && UNITY_2020_3_OR_NEWER && (SENTRY_NATIVE_COCOA || SENTRY_NATIVE_ANDROID || SENTRY_NATIVE)
+#define IL2CPP_LINENUMBER_SUPPORT
+#endif
+
 using System;
 #if UNITY_2020_3_OR_NEWER
 using System.Buffers;
@@ -108,7 +112,7 @@ namespace Sentry.Unity
 
         private Il2CppMethods _il2CppMethods
             // Lowest supported version to have all required methods below
-#if !ENABLE_IL2CPP || !UNITY_2020_3_OR_NEWER || !UNITY_64
+#if !IL2CPP_LINENUMBER_SUPPORT
             ;
 #else
             = new Il2CppMethods(


### PR DESCRIPTION
The `UNITY_64` seems to block off the mobile platforms so I introduced a new definition based on our own `SENTRY_NAVIVE_*` definitions.