### PR TITLE
chore: disable update-deps on PR merge

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -4,6 +4,7 @@ on:
   # Run every day.
   schedule:
     - cron: '0 3 * * *'
+  # Allow a manual trigger to be able to run the update when there are new dependencies or after a PR merge to resolve CHANGELOG conflicts.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -4,10 +4,7 @@ on:
   # Run every day.
   schedule:
     - cron: '0 3 * * *'
-  # And on on every PR merge so we get the updated dependencies ASAP, and to make sure the changelog doesn't conflict.
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   cocoa:


### PR DESCRIPTION
causes a lot of stress on CI which is an issue due to the limited number of Unity licences

#skip-changelog