### PR TITLE
Fix integration test on the main branch

### DIFF
--- a/test/Scripts.Integration.Test/create-project.ps1
+++ b/test/Scripts.Integration.Test/create-project.ps1
@@ -24,6 +24,8 @@ RunUnityCustom $UnityPath @("-batchmode", "-createProject", "$NewProjectPath", "
 Write-Host "Copying Editor scripts to integration project:"
 New-Item -Path "$NewProjectAssetsPath" -Name "Editor" -ItemType "directory"
 Copy-Item -Recurse "$IntegrationScriptsPath/Editor/*" -Destination "$NewProjectAssetsPath/Editor/"
+New-Item -Path "$NewProjectAssetsPath" -Name "Scenes" -ItemType "directory"
+Copy-Item -Recurse "$IntegrationScriptsPath/Scenes/*" -Destination "$NewProjectAssetsPath/Scenes/"
 Write-Host " OK"
 
 # Update ProjectSettings

--- a/test/Scripts.Integration.Test/update-sentry.ps1
+++ b/test/Scripts.Integration.Test/update-sentry.ps1
@@ -27,9 +27,7 @@ RunUnityAndExpect "AddSentryPackage" "Sentry Package Installation:" "Sentry setu
 
 Write-Host -NoNewline "Copying Integration Test Files"
 New-Item -Path "$NewProjectAssetsPath" -Name "Scripts" -ItemType "directory"
-New-Item -Path "$NewProjectAssetsPath" -Name "Scenes" -ItemType "directory"
 Copy-Item -Recurse "$IntegrationScriptsPath/Scripts/*" -Destination "$NewProjectAssetsPath/Scripts/"
-Copy-Item -Recurse "$IntegrationScriptsPath/Scenes/*" -Destination "$NewProjectAssetsPath/Scenes/"
 
 Write-Host " OK"
 


### PR DESCRIPTION
The integration test build without sentry SDK (i.e. the first build) is currently disabled elsewhere than on the main branch because it "never" breaks. It broke in the recent split of integration test: #637 with error "Cannot build untitled scene.", as there was no scene in the app.

This PR moves the SmokeTester scene copy to an earlier point. It's OK to do this even though scripts (that are only copied later when the Sentry SDK is added) are bound to the scene - Unity just warns about the missing scripts but doesn't break the build.

#skip-changelog