### PR TITLE
fix: Save SampleRate to Options.asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+### Fixes
+
 - Save SampleRate to Options.asset ([#916](https://github.com/getsentry/sentry-unity/pull/916))
 
 ## 0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Save SampleRate to Options.asset ([#916](https://github.com/getsentry/sentry-unity/pull/916))
+
 ## 0.22.0
 
 ### Fixes

--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -23,9 +23,8 @@ MonoBehaviour:
   <EnvironmentOverride>k__BackingField: 
   <AttachStacktrace>k__BackingField: 0
   <AttachScreenshot>k__BackingField: 1
-  <ScreenshotMaxWidth>k__BackingField: 0
-  <ScreenshotMaxHeight>k__BackingField: 0
   <ScreenshotQuality>k__BackingField: 75
+  <ScreenshotCompression>k__BackingField: 75
   <MaxBreadcrumbs>k__BackingField: 100
   <ReportAssembliesMode>k__BackingField: 1
   <SendDefaultPii>k__BackingField: 0
@@ -33,6 +32,7 @@ MonoBehaviour:
   <EnableOfflineCaching>k__BackingField: 1
   <MaxCacheItems>k__BackingField: 30
   <InitCacheFlushTimeout>k__BackingField: 2000
+  <SampleRate>k__BackingField: 1
   <ShutdownTimeout>k__BackingField: 2000
   <MaxQueueItems>k__BackingField: 30
   <IosNativeSupportEnabled>k__BackingField: 1

--- a/samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset
+++ b/samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset
@@ -255,7 +255,7 @@ PlayerSettings:
   clonedFromGUID: 5f34be1353de5cf4398729fda238591b
   templatePackageId: com.unity.template.2d@3.3.2
   templateDefaultScene: Assets/Scenes/SampleScene.unity
-  AndroidTargetArchitectures: 4
+  AndroidTargetArchitectures: 2
   AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -659,7 +659,9 @@ PlayerSettings:
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
   switchUseMicroSleepForYield: 1
+  switchEnableRamDiskSupport: 0
   switchMicroSleepForYieldTime: 25
+  switchRamDiskSpaceSize: 12
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -754,6 +756,7 @@ PlayerSettings:
   ps5UseAudio3dBackend: 0
   ps5ScriptOptimizationLevel: 2
   ps5Audio3dVirtualSpeakerCount: 14
+  ps5VrrSupport: 0
   ps5UpdateReferencePackage: 
   ps5disableAutoHideSplash: 0
   ps5OperatingSystemCanDisableSplashScreen: 0

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/TransportTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/TransportTab.cs
@@ -39,15 +39,13 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             //                                        "before sending to Sentry."),
             //     Options.RequestBodyCompressionLevel);
 
-            var sampleRate = options.SampleRate ??= 1.0f;
-            sampleRate = EditorGUILayout.Slider(
+            options.SampleRate = EditorGUILayout.Slider(
                 new GUIContent("Event Sample Rate", "Indicates the percentage of events that are " +
                                                     "captured. Setting this to 0.1 captures 10% of events. " +
                                                     "Setting this to 1.0 captures all events." +
                                                     "\nThis affects only errors and logs, not performance " +
                                                     "(transactions) data. See TraceSampleRate for that."),
-                sampleRate, 0.01f, 1);
-            options.SampleRate = (sampleRate < 1.0f) ? sampleRate : null;
+                options.SampleRate, 0.01f, 1);
 
             options.ShutdownTimeout = EditorGUILayout.IntField(
                 new GUIContent("Shut Down Timeout [ms]", "How many milliseconds to wait before shutting down to " +

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -43,7 +43,7 @@ namespace Sentry.Unity.Editor
             EditorGUILayout.Toggle("Enable Offline Caching", options.EnableOfflineCaching);
             EditorGUILayout.IntField("Max Cache Items", options.MaxCacheItems);
             EditorGUILayout.IntField("Init Flush Timeout [ms]", options.InitCacheFlushTimeout);
-            EditorGUILayout.FloatField("Event Sample Rate", options.SampleRate ?? 1.0f);
+            EditorGUILayout.FloatField("Event Sample Rate", options.SampleRate);
             EditorGUILayout.IntField("Shut Down Timeout [ms]", options.ShutdownTimeout);
             EditorGUILayout.IntField("Max Queue Items", options.MaxQueueItems);
 

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -57,7 +57,6 @@ namespace Sentry.Unity
         /// Time in milliseconds for flushing the cache at startup
         /// </summary>
         [field: SerializeField] public int InitCacheFlushTimeout { get; set; } = (int)TimeSpan.Zero.TotalMilliseconds;
-
         [field: SerializeField] public float SampleRate { get; set; } = 1.0f;
         [field: SerializeField] public int ShutdownTimeout { get; set; } = 2000;
         [field: SerializeField] public int MaxQueueItems { get; set; } = 30;

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -57,7 +57,8 @@ namespace Sentry.Unity
         /// Time in milliseconds for flushing the cache at startup
         /// </summary>
         [field: SerializeField] public int InitCacheFlushTimeout { get; set; } = (int)TimeSpan.Zero.TotalMilliseconds;
-        [field: SerializeField] public float? SampleRate { get; set; }
+
+        [field: SerializeField] public float SampleRate { get; set; } = 1.0f;
         [field: SerializeField] public int ShutdownTimeout { get; set; } = 2000;
         [field: SerializeField] public int MaxQueueItems { get; set; } = 30;
         [field: SerializeField] public bool IosNativeSupportEnabled { get; set; } = true;
@@ -114,7 +115,7 @@ namespace Sentry.Unity
                 IsEnvironmentUser = IsEnvironmentUser,
                 MaxCacheItems = MaxCacheItems,
                 InitCacheFlushTimeout = TimeSpan.FromMilliseconds(InitCacheFlushTimeout),
-                SampleRate = SampleRate,
+                SampleRate = SampleRate == 1.0f ? null : SampleRate, // To skip the random check for dropping events
                 ShutdownTimeout = TimeSpan.FromMilliseconds(ShutdownTimeout),
                 MaxQueueItems = MaxQueueItems,
                 // Because SentryOptions.Debug is used inside the .NET SDK to setup the ConsoleLogger we

--- a/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -29,6 +29,8 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains("EnvironmentOverride", optionsAsString);
             StringAssert.Contains("AttachStacktrace", optionsAsString);
             StringAssert.Contains("AttachScreenshot", optionsAsString);
+            StringAssert.Contains("ScreenshotQuality", optionsAsString);
+            StringAssert.Contains("ScreenshotCompression", optionsAsString);
             StringAssert.Contains("MaxBreadcrumbs", optionsAsString);
             StringAssert.Contains("ReportAssembliesMode", optionsAsString);
             StringAssert.Contains("SendDefaultPii", optionsAsString);
@@ -36,6 +38,7 @@ namespace Sentry.Unity.Editor.Tests
             StringAssert.Contains("EnableOfflineCaching", optionsAsString);
             StringAssert.Contains("MaxCacheItems", optionsAsString);
             StringAssert.Contains("InitCacheFlushTimeout", optionsAsString);
+            StringAssert.Contains("SampleRate", optionsAsString);
             StringAssert.Contains("ShutdownTimeout", optionsAsString);
             StringAssert.Contains("MaxQueueItems", optionsAsString);
             StringAssert.Contains("IosNativeSupportEnabled", optionsAsString);

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -79,7 +79,7 @@ namespace Sentry.Unity.Tests
             scriptableOptions.MaxCacheItems = expectedOptions.MaxCacheItems;
             scriptableOptions.EnableOfflineCaching = enableOfflineCaching;
             scriptableOptions.InitCacheFlushTimeout = (int)expectedOptions.InitCacheFlushTimeout.TotalMilliseconds;
-            scriptableOptions.SampleRate = expectedOptions.SampleRate;
+            scriptableOptions.SampleRate = (float)expectedOptions.SampleRate;
             scriptableOptions.ShutdownTimeout = (int)expectedOptions.ShutdownTimeout.TotalMilliseconds;
             scriptableOptions.MaxQueueItems = expectedOptions.MaxQueueItems;
             scriptableOptions.ReleaseOverride = expectedOptions.Release;


### PR DESCRIPTION
Due to being nullable `SampleRate` never actually got saved to the SentryOptions.asset. 
We pass it as `null` to the actual SentryUnityOptions to skip event drop checks in case it's `1.0f`.