### PR TITLE
fix: iOS native samples ObjectiveCPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-
 ### Fixes
 
+- iOS samples were missing the Objective-C plugin ([#921](https://github.com/getsentry/sentry-unity/pull/921))
 - Save SampleRate to Options.asset ([#916](https://github.com/getsentry/sentry-unity/pull/916))
 
 ### Features

--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m
@@ -1,0 +1,47 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+void throwObjectiveC()
+{
+#ifdef __EXCEPTIONS
+    NSLog(@"Throwing an Objective-C Exception");
+    @throw [NSException exceptionWithName:@"Objective-C Exception"
+                                   reason:@"Sentry Unity Objective-C Support."
+                                 userInfo:nil];
+#else
+    NSLog(@"Objective-C Exceptions are disabled. "
+           "Consider enabling it in the Xcode project: "
+           "GCC_ENABLE_OBJC_EXCEPTIONS");
+#endif
+}
+
+char *getTestArgObjectiveC()
+{
+    NSArray *args = NSProcessInfo.processInfo.arguments;
+
+    // NSLog(@"getTestArgObjectiveC() args count = %lul", args.count);
+    // for (int i = 0; i < args.count; i++) {
+    //     NSLog(@"getTestArgObjectiveC() args[%d] = %@", i, args[i]);
+    // }
+
+    if (args.count < 3) {
+        return NULL;
+    }
+
+    if (![args[1] isEqualToString:@"--test"]) {
+        return NULL;
+    }
+
+    // create a null terminated C string on the heap as expected by marshalling
+    // see Tips for iOS in https://docs.unity3d.com/Manual/PluginsForIOS.html
+    const char *nsStringUtf8 = [args[2] UTF8String];
+    size_t len = strlen(nsStringUtf8) + 1;
+    char *cString = (char *)malloc(len);
+    strcpy(cString, nsStringUtf8);
+    cString[len - 1] = 0;
+
+    return cString;
+}
+
+NS_ASSUME_NONNULL_END

--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m
@@ -16,32 +16,4 @@ void throwObjectiveC()
 #endif
 }
 
-char *getTestArgObjectiveC()
-{
-    NSArray *args = NSProcessInfo.processInfo.arguments;
-
-    // NSLog(@"getTestArgObjectiveC() args count = %lul", args.count);
-    // for (int i = 0; i < args.count; i++) {
-    //     NSLog(@"getTestArgObjectiveC() args[%d] = %@", i, args[i]);
-    // }
-
-    if (args.count < 3) {
-        return NULL;
-    }
-
-    if (![args[1] isEqualToString:@"--test"]) {
-        return NULL;
-    }
-
-    // create a null terminated C string on the heap as expected by marshalling
-    // see Tips for iOS in https://docs.unity3d.com/Manual/PluginsForIOS.html
-    const char *nsStringUtf8 = [args[2] UTF8String];
-    size_t len = strlen(nsStringUtf8) + 1;
-    char *cString = (char *)malloc(len);
-    strcpy(cString, nsStringUtf8);
-    cString[len - 1] = 0;
-
-    return cString;
-}
-
 NS_ASSUME_NONNULL_END

--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m.meta
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/ObjectiveCPlugin.m.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: 0f5778fc7813434aacea6ae0acb6a55d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -368,6 +368,8 @@ Samples~/unity-of-bugs/Scripts/NativeSupport/NativeButtons.cs
 Samples~/unity-of-bugs/Scripts/NativeSupport/NativeButtons.cs.meta
 Samples~/unity-of-bugs/Scripts/NativeSupport/NativeSupportScene.cs
 Samples~/unity-of-bugs/Scripts/NativeSupport/NativeSupportScene.cs.meta
+Samples~/unity-of-bugs/Scripts/NativeSupport/ObjectiveCPlugin.m
+Samples~/unity-of-bugs/Scripts/NativeSupport/ObjectiveCPlugin.m.meta
 Samples~/unity-of-bugs/Scripts/NativeSupport/WebGLButtons.cs
 Samples~/unity-of-bugs/Scripts/NativeSupport/WebGLButtons.cs.meta
 CHANGELOG.md


### PR DESCRIPTION
The `ObjectiveCPlugin.m` is missing from the samples.