### PR TITLE
fix: Removed exception from screenshot attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - iOS samples were missing the Objective-C plugin ([#921](https://github.com/getsentry/sentry-unity/pull/921))
 - Save SampleRate to Options.asset ([#916](https://github.com/getsentry/sentry-unity/pull/916))
 - Increase CLI file upload limit to 10 MiB ([#922](https://github.com/getsentry/sentry-unity/pull/922))
+- ANR detection no longer creates an error by trying to capture a screenshot from a background thread ([#937](https://github.com/getsentry/sentry-unity/pull/937))
 
 ### Features
 

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -31,10 +31,8 @@ namespace Sentry.Unity
             // when capturing the screenshot, it would only do so on development builds. On release, it just crashes...
             if (!_behaviour.MainThreadData.IsMainThread())
             {
-                _options.DiagnosticLogger?.LogDebug("Won't capture screenshot because we're not on the main thread");
-                // Throwing here to avoid empty attachment being sent to Sentry.
-                // return new MemoryStream();
-                throw new Exception("Sentry: cannot capture screenshot attachment on other than the main (UI) thread.");
+                _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on other than main (UI) thread.");
+                return new MemoryStream();
             }
 
             return new MemoryStream(CaptureScreenshot());

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -32,7 +32,7 @@ namespace Sentry.Unity
             if (!_behaviour.MainThreadData.IsMainThread())
             {
                 _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on other than main (UI) thread.");
-                return new MemoryStream();
+                return Stream.Null;
             }
 
             return new MemoryStream(CaptureScreenshot());


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/925

With the .NET SDK filtering empty streams from being added to events, we can now return an empty `MemoryStream` instead of throwing an exception.