### PR TITLE
fix: Screenshot quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - iOS samples were missing the Objective-C plugin ([#921](https://github.com/getsentry/sentry-unity/pull/921))
 - Save SampleRate to Options.asset ([#916](https://github.com/getsentry/sentry-unity/pull/916))
 - Increase CLI file upload limit to 10 MiB ([#922](https://github.com/getsentry/sentry-unity/pull/922))
+- Screenshots quality no longer scales off of current resolution but tries match thresholds instead ([#939](https://github.com/getsentry/sentry-unity/pull/939))
 
 ### Features
 

--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   <EnvironmentOverride>k__BackingField: 
   <AttachStacktrace>k__BackingField: 0
   <AttachScreenshot>k__BackingField: 1
-  <ScreenshotQuality>k__BackingField: 75
+  <ScreenshotQuality>k__BackingField: 2
   <ScreenshotCompression>k__BackingField: 75
   <MaxBreadcrumbs>k__BackingField: 100
   <ReportAssembliesMode>k__BackingField: 1

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/EnrichmentTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/EnrichmentTab.cs
@@ -88,9 +88,9 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             options.ScreenshotQuality = (ScreenshotQuality)EditorGUILayout.EnumPopup(
                 new GUIContent("Quality", "The resolution quality of the screenshot.\n" +
                                           "'Full': Fully of the current resolution\n" +
-                                          "'High': Half of the current resolution\n" +
-                                          "'Medium': Third of the current resolution\n" +
-                                          "'Low': Quarter of the current resolution"),
+                                          "'High': 1080p\n" +
+                                          "'Medium': 720p\n" +
+                                          "'Low': 480p"),
                 options.ScreenshotQuality);
 
             options.ScreenshotCompression = EditorGUILayout.IntSlider(

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -56,7 +56,7 @@ namespace Sentry.Unity
 
             // Make sure the screenshot size does not exceed the target size by scaling the image while conserving the
             // original ratio based on which, width or height, is the smaller
-            if(_options.ScreenshotQuality is not ScreenshotQuality.Full)
+            if (_options.ScreenshotQuality is not ScreenshotQuality.Full)
             {
                 var targetResolution = GetTargetResolution(_options.ScreenshotQuality);
                 var ratioW = targetResolution / (float)width;


### PR DESCRIPTION
Currently, the screenshot quality was relative to the current screen size which creates issues when a project supports a wide range of different resolutions, making "half the current resolution" on small screens barely usable.

Instead, we can map `High, Medium, Low` to "ranges" of resolutions akin to what Youtube videos offer.
```
ScreenshotQuality.Full => // Don't touch
ScreenshotQuality.High => 1920,     // 1080p
ScreenshotQuality.Medium => 1280,   // 720p
ScreenshotQuality.Low => 854,       // 480p
```
We take the wider side (portrait or landscape) and scale the screenshot to match while preserving the aspect ratio. (defacto @vaind's original implementation) with an user-facing enum instead of a `vec2 max resolution`. 