### PR TITLE
fix: Throwing new NullReference instead of 'null' in samples

### DIFF
--- a/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs
@@ -6,16 +6,30 @@ using UnityEngine.Assertions;
 
 public class BugFarmButtons : MonoBehaviour
 {
+    private DateTime _now;
+
     private void Start()
     {
         Debug.Log("Sample Start 🦋");
         Debug.LogWarning("Here come the bugs 🐞🦋🐛🐜🕷!");
     }
 
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            var start = DateTime.Now;
+            while ((DateTime.Now - start).Seconds < 6)
+            {
+
+            }
+        }
+    }
+
     public void AssertFalse() => Assert.AreEqual(true, false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void ThrowNull() => throw null;
+    public void ThrowNull() => throw new NullReferenceException();
 
     public void ThrowExceptionAndCatch()
     {

--- a/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs
@@ -6,24 +6,10 @@ using UnityEngine.Assertions;
 
 public class BugFarmButtons : MonoBehaviour
 {
-    private DateTime _now;
-
     private void Start()
     {
         Debug.Log("Sample Start 🦋");
         Debug.LogWarning("Here come the bugs 🐞🦋🐛🐜🕷!");
-    }
-
-    private void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.Space))
-        {
-            var start = DateTime.Now;
-            while ((DateTime.Now - start).Seconds < 6)
-            {
-
-            }
-        }
     }
 
     public void AssertFalse() => Assert.AreEqual(true, false);


### PR DESCRIPTION
#skip-changelog