### PR TITLE
fix: Google Ads dependency conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fixed a crash during startup due in connection to the Google Ads Unity package ([#953](https://github.com/getsentry/sentry-unity/pull/953))
 - Fixed an 'Undefined symbols' issue within the Sentry Native Bridge when building for iOS ([#932](https://github.com/getsentry/sentry-unity/pull/932))
 - ANR detection no longer creates an error by trying to capture a screenshot from a background thread ([#937](https://github.com/getsentry/sentry-unity/pull/937))
 - Screenshots quality no longer scales off of current resolution but tries match thresholds instead ([#939](https://github.com/getsentry/sentry-unity/pull/939))

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -100,6 +100,7 @@ namespace Sentry.Unity.Editor.Android
             androidManifest.SetSDK("sentry.java.android.unity");
             _logger.LogDebug("Setting DSN: {0}", _options!.Dsn);
             androidManifest.SetDsn(_options.Dsn!);
+
             if (_options.Debug)
             {
                 _logger.LogDebug("Setting Debug: {0}", _options.Debug);
@@ -142,6 +143,7 @@ namespace Sentry.Unity.Editor.Android
 
             // Disabling the native in favor of the C# layer for now
             androidManifest.SetAutoSessionTracking(false);
+            androidManifest.SetAutoAppLifecycleBreadcrumbs(false);
             androidManifest.SetAnr(false);
             // TODO: We need an opt-out for this:
             androidManifest.SetNdkScopeSync(true);
@@ -339,6 +341,9 @@ namespace Sentry.Unity.Editor.Android
 
         internal void SetAutoSessionTracking(bool enableAutoSessionTracking)
             => SetMetaData($"{SentryPrefix}.auto-session-tracking.enable", enableAutoSessionTracking.ToString());
+
+        public void SetAutoAppLifecycleBreadcrumbs(bool enableAutoAppLifeCycleBreadcrumbs)
+            => SetMetaData($"{SentryPrefix}.bbreadcrumbs.app-lifecycle", enableAutoAppLifeCycleBreadcrumbs.ToString());
 
         internal void SetAnr(bool enableAnr)
             => SetMetaData($"{SentryPrefix}.anr.enable", enableAnr.ToString());


### PR DESCRIPTION
Google Ads comes with its own `External Dependency Manager` that copies the `aar` into the project's plugin folder. This leads to issues during runtime.
Since we don't use the Android AppLifecycle (`session auto tracking`) feature we disable adding breadcrumbs by default.

```
FATAL EXCEPTION: main
Process: com.DefaultCompany.SentryIOAndroidCrash, PID: 736
java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider: androidx.startup.StartupException: java.lang.AbstractMethodError: abstract method "void androidx.lifecycle.DefaultLifecycleObserver.onCreate(androidx.lifecycle.LifecycleOwner)"
	at android.app.ActivityThread.installProvider(ActivityThread.java:7774)
	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7286)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7026)
	at android.app.ActivityThread.access$1800(ActivityThread.java:254)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2184)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:233)
	at android.os.Looper.loop(Looper.java:344)
	at android.app.ActivityThread.main(ActivityThread.java:8210)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1034)
Caused by: androidx.startup.StartupException: java.lang.AbstractMethodError: abstract method "void androidx.lifecycle.DefaultLifecycleObserver.onCreate(androidx.lifecycle.LifecycleOwner)"
	at androidx.startup.AppInitializer.doInitialize(AppInitializer.java:187)
	at androidx.startup.AppInitializer.discoverAndInitialize(AppInitializer.java:238)
	at androidx.startup.AppInitializer.discoverAndInitialize(AppInitializer.java:206)
	at androidx.startup.InitializationProvider.onCreate(InitializationProvider.java:45)
	at android.content.ContentProvider.attachInfo(ContentProvider.java:2413)
	at android.content.ContentProvider.attachInfo(ContentProvider.java:2383)
	at android.app.ActivityThread.installProvider(ActivityThread.java:7769)
	... 11 more
Caused by: java.lang.AbstractMethodError: abstract method "void androidx.lifecycle.DefaultLifecycleObserver.onCreate(androidx.lifecycle.LifecycleOwner)"
	at androidx.lifecycle.FullLifecycleObserverAdapter.onStateChanged(FullLifecycleObserverAdapter.java:36)
	at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
	at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.java:265)
	at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:307)
	at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:148)
	at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
	at androidx.lifecycle.ProcessLifecycleOwner.attach(ProcessLifecycleOwner.java:161)
	at androidx.lifecycle.ProcessLifecycleOwner.init(ProcessLifecycleOwner.java:106)
	at androidx.lifecycle.ProcessLifecycleInitializer.create(ProcessLifecycleInitializer.java:47)
	at androidx.lifecycle.ProcessLifecycleInitializer.create(ProcessLifecycleInitializer.java:31)
	at androidx.startup.AppInitializer.doInitialize(AppInitializer.java:180)
	... 17 more
```