### PR TITLE
fix: Capture failed reinstall backend gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed a crash during startup due in connection to the Google Ads Unity package ([#953](https://github.com/getsentry/sentry-unity/pull/953))
+- The SDK failing to reinstall the backend will no longer lead to events being sent to Sentry ([#962](https://github.com/getsentry/sentry-unity/pull/962))
 
 ### Dependencies
 

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -1,3 +1,4 @@
+using System;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 
@@ -38,11 +39,19 @@ namespace Sentry.Unity.Android
                     return crashedLastRun.Value;
                 };
 
-                options.DiagnosticLogger?.LogDebug("Reinstalling native backend.");
+                try
+                {
+                    options.DiagnosticLogger?.LogDebug("Reinstalling native backend.");
 
-                // At this point Unity has taken the signal handler and will not invoke the original handler (Sentry)
-                // So we register our backend once more to make sure user-defined data is available in the crash report.
-                SentryNative.ReinstallBackend();
+                    // At this point Unity has taken the signal handler and will not invoke the original handler (Sentry)
+                    // So we register our backend once more to make sure user-defined data is available in the crash report.
+                    SentryNative.ReinstallBackend();
+                }
+                catch (Exception e)
+                {
+                    options.DiagnosticLogger?.LogError(
+                        "Failed to reinstall backend. Captured native crashes will miss scope data and tag.", e);
+                }
 
                 ApplicationAdapter.Instance.Quitting += () =>
                 {


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/960
Failing to reinstall the backend (I've seen the events but failed to reproduce it myself) leads to the SDK capturing exceptions it creates itself.