### PR TITLE
feat: Package update notification

### DIFF
--- a/package-dev/Editor/SentryPackageManager.cs
+++ b/package-dev/Editor/SentryPackageManager.cs
@@ -1,0 +1,25 @@
+#if UNITY_2020_3_OR_NEWER
+using UnityEditor;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor
+{
+    public static class SentryPackageManager
+    {
+        [InitializeOnLoadMethod]
+        public static void SentryPackageUpdate()
+        {
+            UnityEditor.PackageManager.Events.registeredPackages += eventArgs =>
+            {
+                if (eventArgs.changedFrom.Count > 0)
+                {
+                    var from = eventArgs.changedFrom[0];
+                    var to = eventArgs.changedTo[0];
+
+                    Debug.Log($"Package changed from {from.name}-{from.version} to {to.name}-{to.version}");
+                }
+            };
+        }
+    }
+}
+#endif

--- a/package-dev/Editor/io.sentry.unity.dev.editor.asmdef
+++ b/package-dev/Editor/io.sentry.unity.dev.editor.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "io.sentry.unity.dev.editor",
+    "rootNamespace": "",
+    "references": [
+        ""
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [
+        ""
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}


### PR DESCRIPTION
With something like this, we can detect updates and also from which version. So we can notify about things like experimental features no longer being experimental on the wizard.

`Package changed from io.sentry.unity.dev-0.0.1 to io.sentry.unity.dev-0.0.2`