### PR TITLE
🚫 Move dependency on `UnityEngine.Analytics` to `SentryInitialization.cs` 

### DIFF
--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -108,6 +108,17 @@ namespace Sentry.Unity
             ;
         }
 
+        public string AnalyticsUserId
+        {
+            get =>
+#if ENABLE_CLOUD_SERVICES_ANALYTICS
+                UnityEngine.Analytics.AnalyticsSessionInfo.userId
+#else
+                null
+#endif
+            ;
+        }
+
         public Il2CppMethods Il2CppMethods => _il2CppMethods;
 
         private Il2CppMethods _il2CppMethods

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -2,7 +2,6 @@ using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Analytics;
 
 namespace Sentry.Unity.Native
 {
@@ -42,8 +41,7 @@ namespace Sentry.Unity.Native
                 options.EnableScopeSync = true;
                 options.NativeContextWriter = new NativeContextWriter();
 
-                // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
-                options.DefaultUserId = AnalyticsSessionInfo.userId;
+                // Use the default UserId in native too.
                 if (options.DefaultUserId is not null)
                 {
                     options.ScopeObserver.SetUser(new User { Id = options.DefaultUserId });

--- a/src/Sentry.Unity/ISentryUnityInfo.cs
+++ b/src/Sentry.Unity/ISentryUnityInfo.cs
@@ -6,6 +6,7 @@ namespace Sentry.Unity
     {
         public bool IL2CPP { get; }
         public string? Platform { get; }
+        public string? AnalyticsUserId { get; }
         public Il2CppMethods? Il2CppMethods { get; }
     }
 

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -2,7 +2,6 @@ using System;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using UnityEngine;
-using UnityEngine.Analytics;
 
 namespace Sentry.Unity
 {
@@ -147,8 +146,6 @@ namespace Sentry.Unity
             }
             else
             {
-                options.DefaultUserId = AnalyticsSessionInfo.userId;
-
                 // This is only provided on a best-effort basis for other than the explicitly supported platforms.
                 if (options.BackgroundWorker is null)
                 {

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -177,6 +177,11 @@ namespace Sentry.Unity
             StackTraceMode = StackTraceMode.Original;
             IsEnvironmentUser = false;
 
+            if (unityInfo?.AnalyticsUserId is string userId && !string.IsNullOrWhiteSpace(userId))
+            {
+                DefaultUserId = userId;
+            }
+
             if (application.ProductName is string productName
                 && !string.IsNullOrWhiteSpace(productName)
                 && productName.Any(c => c != '.')) // productName consisting solely of '.'

--- a/src/Sentry.Unity/WebGL/SentryWebGL.cs
+++ b/src/Sentry.Unity/WebGL/SentryWebGL.cs
@@ -1,5 +1,4 @@
 using Sentry.Extensibility;
-using UnityEngine.Analytics;
 
 namespace Sentry.Unity.WebGL
 {
@@ -37,9 +36,6 @@ namespace Sentry.Unity.WebGL
                 options.DiagnosticLogger?.LogWarning("Attaching screenshots on WebGL is disabled - " +
                     "it currently produces blank screenshots mid-frame.");
             }
-
-            // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
-            options.DefaultUserId = AnalyticsSessionInfo.userId;
 
             // Indicate that this platform doesn't support running background threads.
             options.MultiThreading = false;

--- a/test/Sentry.Unity.Android.Tests/SentryNativeAndroidTests.cs
+++ b/test/Sentry.Unity.Android.Tests/SentryNativeAndroidTests.cs
@@ -97,6 +97,7 @@ namespace Sentry.Unity.Android.Tests
     {
         public bool IL2CPP { get; set; }
         public string? Platform { get; }
+        public string? AnalyticsUserId { get; }
         public Il2CppMethods? Il2CppMethods { get; }
     }
 }

--- a/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
+++ b/test/Sentry.Unity.iOS.Tests/SentryNativeIosTests.cs
@@ -8,6 +8,7 @@ namespace Sentry.Unity.iOS.Tests
     {
         public bool IL2CPP { get; set; }
         public string? Platform { get; }
+        public string? AnalyticsUserId { get; }
         public Il2CppMethods? Il2CppMethods { get; }
     }
 


### PR DESCRIPTION
I've tried to move the dependency on the analytics engine to fix #968 but this didn't work. Keeping this PR draft open for now until a solution is found.

```
SentryInitialization.cs(115,17): error CS1069: The type name 'AnalyticsSessionInfo' could not be found in the namespace 'UnityEngine.Analytics'. This type has been forwarded to assembly 'UnityEngine.UnityAnalyticsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Enable the built in package 'Unity Analytics' in the Package Manager window to fix this error.
```