### PR TITLE
fix: don't access Unity `AnalyticsSessionInfo.userId` on unknown platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Don't access Unity `AnalyticsSessionInfo.userId` on unknown platforms ([#971](https://github.com/getsentry/sentry-unity/pull/971))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v7.24.1 to v7.25.0 ([#967](https://github.com/getsentry/sentry-unity/pull/967))
@@ -14,6 +18,7 @@
 
 - Fixed a crash during startup due in connection to the Google Ads Unity package ([#953](https://github.com/getsentry/sentry-unity/pull/953))
 - The SDK failing to reinstall the backend will no longer lead to events being sent to Sentry ([#962](https://github.com/getsentry/sentry-unity/pull/962))
+- Don't access Unity `AnalyticsSessionInfo.userId` on unknown platforms ([#971](https://github.com/getsentry/sentry-unity/pull/971))
 
 ### Features
 

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -2,7 +2,6 @@ using System;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using UnityEngine;
-using UnityEngine.Analytics;
 
 namespace Sentry.Unity
 {
@@ -147,8 +146,6 @@ namespace Sentry.Unity
             }
             else
             {
-                options.DefaultUserId = AnalyticsSessionInfo.userId;
-
                 // This is only provided on a best-effort basis for other than the explicitly supported platforms.
                 if (options.BackgroundWorker is null)
                 {


### PR DESCRIPTION
fixes #968 

replaces & closes #970