### PR TITLE
fix: keep previously set IL2CPP compiler arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Don't access Unity `AnalyticsSessionInfo.userId` on unknown platforms ([#971](https://github.com/getsentry/sentry-unity/pull/971))
+- Keep previously set IL2CPP compiler arguments (i.e append instead of overwriting) ([#972](https://github.com/getsentry/sentry-unity/pull/972))
 
 ### Dependencies
 

--- a/src/Sentry.Unity.Editor/Il2CppOption.cs
+++ b/src/Sentry.Unity.Editor/Il2CppOption.cs
@@ -12,8 +12,8 @@ namespace Sentry.Unity.Editor
         public void OnPreprocessBuild(BuildReport report)
         {
             var arguments = "--emit-source-mapping";
-            Debug.Log($"Setting additional IL2CPP arguments = '{arguments}' for platform {report.summary.platform}");
-            PlayerSettings.SetAdditionalIl2CppArgs(arguments);
+            Debug.Log($"Setting additional IL2CPP arguments '{arguments}' for platform {report.summary.platform}");
+            PlayerSettings.SetAdditionalIl2CppArgs(PlayerSettings.GetAdditionalIl2CppArgs() + $" {arguments}");
         }
     }
 }


### PR DESCRIPTION
fixes #965