### PR TITLE
fix: Releasing temp render texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Releasing temp render texture after capturing a screenshot ([#983](https://github.com/getsentry/sentry-unity/pull/983))
+
 ### Dependencies
 
 - Bump Java SDK from v6.4.1 to v6.4.2 ([#980](https://github.com/getsentry/sentry-unity/pull/980))


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/975

Releasing the resized temp render texture.