### PR TITLE
fix: IL2CPP additional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Additional IL2CPP arguments get added only once ([#997](https://github.com/getsentry/sentry-unity/pull/997))
 - Releasing temp render texture after capturing a screenshot ([#983](https://github.com/getsentry/sentry-unity/pull/983))
 
 ### Features

--- a/src/Sentry.Unity.Editor/Il2CppOption.cs
+++ b/src/Sentry.Unity.Editor/Il2CppOption.cs
@@ -1,3 +1,5 @@
+using System;
+using Sentry.Extensibility;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
@@ -7,13 +9,52 @@ namespace Sentry.Unity.Editor
 {
     internal class Il2CppOption : IPreprocessBuildWithReport
     {
+        private const string SourceMappingArgument = "--emit-source-mapping";
+
         public int callbackOrder => 0;
 
         public void OnPreprocessBuild(BuildReport report)
         {
-            var arguments = "--emit-source-mapping";
-            Debug.Log($"Setting additional IL2CPP arguments '{arguments}' for platform {report.summary.platform}");
-            PlayerSettings.SetAdditionalIl2CppArgs(PlayerSettings.GetAdditionalIl2CppArgs() + $" {arguments}");
+            if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
+            {
+                return;
+            }
+
+            var options = SentryScriptableObject
+                .Load<ScriptableSentryUnityOptions>(ScriptableSentryUnityOptions.GetConfigPath())
+                ?.ToSentryUnityOptions(BuildPipeline.isBuildingPlayer);
+
+            if (options is null)
+            {
+                return;
+            }
+
+            if (options.Il2CppLineNumberSupportEnabled)
+            {
+                options.DiagnosticLogger?.LogDebug("IL2CPP line number support enabled - Adding additional IL2CPP arguments.");
+
+                var arguments = PlayerSettings.GetAdditionalIl2CppArgs();
+                if (arguments.Contains(SourceMappingArgument))
+                {
+                    options.DiagnosticLogger?.LogDebug("Additional argument '{0}' already present.", SourceMappingArgument);
+                    return;
+                }
+
+                PlayerSettings.SetAdditionalIl2CppArgs(PlayerSettings.GetAdditionalIl2CppArgs() + $" {SourceMappingArgument}");
+            }
+            else
+            {
+                var arguments = PlayerSettings.GetAdditionalIl2CppArgs();
+                if (arguments.Contains(SourceMappingArgument))
+                {
+                    options.DiagnosticLogger?.LogDebug("IL2CPP line number support disabled - Removing additional IL2CPP arguments.");
+
+                    arguments = arguments.Remove(arguments.IndexOf(SourceMappingArgument, StringComparison.Ordinal),
+                        SourceMappingArgument.Length);
+                    PlayerSettings.SetAdditionalIl2CppArgs(arguments);
+                }
+            }
+
         }
     }
 }

--- a/test/Sentry.Unity.Editor.Tests/Il2CppBuildPreProcess.cs
+++ b/test/Sentry.Unity.Editor.Tests/Il2CppBuildPreProcess.cs
@@ -83,7 +83,5 @@ namespace Sentry.Unity.Editor.Tests
             Assert.That(resultingArguments, Does.Contain(expectedArgument));
             Assert.That(resultingArguments, Does.Not.Contain(Il2CppBuildPreProcess.SourceMappingArgument));
         }
-
-
     }
 }

--- a/test/Sentry.Unity.Editor.Tests/Il2CppBuildPreProcess.cs
+++ b/test/Sentry.Unity.Editor.Tests/Il2CppBuildPreProcess.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Sentry.Unity.Editor.Tests
+{
+    public class Il2CppBuildPreProcessTests
+    {
+        private string arguments = null!;
+        private string resultingArguments = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            arguments = string.Empty;
+            resultingArguments = string.Empty;
+        }
+
+        [Test]
+        public void SetAdditionalArguments_Il2CppEnabled_AddsArguments()
+        {
+            var options = new SentryUnityOptions { Il2CppLineNumberSupportEnabled = true };
+
+            Il2CppBuildPreProcess.SetAdditionalIl2CppArguments(options, () => arguments, s => resultingArguments = s);
+
+            Assert.That(resultingArguments, Does.Contain(Il2CppBuildPreProcess.SourceMappingArgument));
+        }
+
+        [Test]
+        public void SetAdditionalArguments_Il2CppDisabled_FoesNotAddArguments()
+        {
+            var options = new SentryUnityOptions { Il2CppLineNumberSupportEnabled = false };
+
+            Il2CppBuildPreProcess.SetAdditionalIl2CppArguments(options, () => arguments, s => resultingArguments = s);
+
+            Assert.That(resultingArguments, Does.Not.Contain(Il2CppBuildPreProcess.SourceMappingArgument));
+        }
+
+        [Test]
+        public void SetAdditionalArguments_Il2CppEnabled_ExistingArgumentsDoNotGetOverwritten()
+        {
+            var options = new SentryUnityOptions { Il2CppLineNumberSupportEnabled = true };
+            var expectedArgument = "--MyArgument";
+            arguments = expectedArgument;
+
+            Il2CppBuildPreProcess.SetAdditionalIl2CppArguments(options, () => arguments, s => resultingArguments = s);
+
+            Assert.That(resultingArguments, Does.Contain(Il2CppBuildPreProcess.SourceMappingArgument)); // sanity check
+            Assert.That(resultingArguments, Does.Contain(expectedArgument));
+        }
+
+        [Test]
+        public void SetAdditionalArguments_Il2CppEnabledAndArgumentAlreadyAdded_AddsArgumentsOnlyOnce()
+        {
+            var options = new SentryUnityOptions { Il2CppLineNumberSupportEnabled = true };
+
+            Il2CppBuildPreProcess.SetAdditionalIl2CppArguments(options, () => arguments, s => resultingArguments = s);
+            Assert.That(resultingArguments, Does.Contain(Il2CppBuildPreProcess.SourceMappingArgument)); // sanity check
+
+            Il2CppBuildPreProcess.SetAdditionalIl2CppArguments(options, () => arguments, s => resultingArguments = s);
+
+            Assert.That(resultingArguments, Does.Contain(Il2CppBuildPreProcess.SourceMappingArgument)); // sanity check
+            var occurrences = 0;
+            var i = 0;
+            while ((i = resultingArguments.IndexOf(Il2CppBuildPreProcess.SourceMappingArgument, i, StringComparison.Ordinal)) != -1)
+            {
+                i += Il2CppBuildPreProcess.SourceMappingArgument.Length;
+                occurrences++;
+            }
+
+            Assert.AreEqual(1, occurrences);
+        }
+
+        [Test]
+        public void SetAdditionalArguments_Il2CppDisabledAndArgumentAlreadyAdded_RemovesArguments()
+        {
+            var options = new SentryUnityOptions { Il2CppLineNumberSupportEnabled = false };
+            var expectedArgument = "--MyArgument";
+            arguments = $"{expectedArgument} {Il2CppBuildPreProcess.SourceMappingArgument}";
+
+            Il2CppBuildPreProcess.SetAdditionalIl2CppArguments(options, () => arguments, s => resultingArguments = s);
+
+            Assert.That(resultingArguments, Does.Contain(expectedArgument));
+            Assert.That(resultingArguments, Does.Not.Contain(Il2CppBuildPreProcess.SourceMappingArgument));
+        }
+
+
+    }
+}


### PR DESCRIPTION
The additional arguments get saved to disk at `<project>/ProjectSettings/ProjectSettings.asset`.
So we should manage adding and removing the argument.