### PR TITLE
fix: screenshot orientation on some devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Additional IL2CPP arguments get added only once ([#997](https://github.com/getsentry/sentry-unity/pull/997))
 - Releasing temp render texture after capturing a screenshot ([#983](https://github.com/getsentry/sentry-unity/pull/983))
+- Automatic screenshot mirroring on select devices. ([#1019](https://github.com/getsentry/sentry-unity/pull/1019))
 
 ### Features
 

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -75,8 +75,8 @@ namespace Sentry.Unity
 
             // The image may be mirrored on some platforms - mirror it back.
             // See https://docs.unity3d.com/2019.4/Documentation/Manual/SL-PlatformDifferences.html for more info.
-            // Note, we can't use the `` macro because it's only available in shaders. Instead, there's
-            // https://docs.unity3d.com/2019.4/Documentation/ScriptReference/SystemInfo-graphicsUVStartsAtTop.html
+            // Note, we can't use the `UNITY_UV_STARTS_AT_TOP` macro because it's only available in shaders.
+            // Instead, there's https://docs.unity3d.com/2019.4/Documentation/ScriptReference/SystemInfo-graphicsUVStartsAtTop.html
             if (SentrySystemInfoAdapter.Instance.GraphicsUVStartsAtTop ?? true)
             {
                 Graphics.Blit(renderTextureFull, renderTextureResized, new Vector2(1, -1), new Vector2(0, 1));

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -72,15 +72,18 @@ namespace Sentry.Unity
             var renderTextureFull = RenderTexture.GetTemporary(Screen.width, Screen.height);
             ScreenCapture.CaptureScreenshotIntoRenderTexture(renderTextureFull);
             var renderTextureResized = RenderTexture.GetTemporary(width, height);
-            // On all (currently supported) platforms except Android, the image is mirrored horizontally & vertically.
-            // So we must mirror it back.
-            if (ApplicationAdapter.Instance.Platform is (RuntimePlatform.Android or RuntimePlatform.LinuxPlayer))
+
+            // The image may be mirrored on some platforms - mirror it back.
+            // See https://docs.unity3d.com/2019.4/Documentation/Manual/SL-PlatformDifferences.html for more info.
+            // Note, we can't use the `` macro because it's only available in shaders. Instead, there's
+            // https://docs.unity3d.com/2019.4/Documentation/ScriptReference/SystemInfo-graphicsUVStartsAtTop.html
+            if (SentrySystemInfoAdapter.Instance.GraphicsUVStartsAtTop ?? true)
             {
-                Graphics.Blit(renderTextureFull, renderTextureResized);
+                Graphics.Blit(renderTextureFull, renderTextureResized, new Vector2(1, -1), new Vector2(0, 1));
             }
             else
             {
-                Graphics.Blit(renderTextureFull, renderTextureResized, new Vector2(1, -1), new Vector2(0, 1));
+                Graphics.Blit(renderTextureFull, renderTextureResized);
             }
             RenderTexture.ReleaseTemporary(renderTextureFull);
             // Remember the previous render target and change it to our target texture.

--- a/src/Sentry.Unity/SystemInfoAdapter.cs
+++ b/src/Sentry.Unity/SystemInfoAdapter.cs
@@ -32,6 +32,7 @@ namespace Sentry.Unity
         bool? SupportsComputeShaders { get; }
         bool? SupportsGeometryShaders { get; }
         int? GraphicsShaderLevel { get; }
+        bool? GraphicsUVStartsAtTop { get; }
         Lazy<bool>? IsDebugBuild { get; }
         string? InstallMode { get; }
         Lazy<string>? TargetFrameRate { get; }
@@ -76,6 +77,7 @@ namespace Sentry.Unity
         public bool? SupportsComputeShaders => SystemInfo.supportsComputeShaders;
         public bool? SupportsGeometryShaders => SystemInfo.supportsGeometryShaders;
         public int? GraphicsShaderLevel => SystemInfo.graphicsShaderLevel;
+        public bool? GraphicsUVStartsAtTop => SystemInfo.graphicsUVStartsAtTop;
         public Lazy<bool> IsDebugBuild => new(() => Debug.isDebugBuild);
         public string? InstallMode => Application.installMode.ToString();
         public Lazy<string> TargetFrameRate => new(() => Application.targetFrameRate.ToString());

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -577,6 +577,7 @@ namespace Sentry.Unity.Tests
         public bool? SupportsComputeShaders { get; set; }
         public bool? SupportsGeometryShaders { get; set; }
         public int? GraphicsShaderLevel { get; set; }
+        public bool? GraphicsUVStartsAtTop { get; }
         public Lazy<bool>? IsDebugBuild { get; set; }
         public string? InstallMode { get; set; }
         public Lazy<string>? TargetFrameRate { get; set; }


### PR DESCRIPTION
replaces #1017 
fixes #935 

Tested manually on Unity 2021: mac (editor & player), iOS & Android; Unity 2019: Windows (editor & player), Linux

@bitsandfoxes can you check the device reported to be broken in the issue?