### PR TITLE
ci: update deprecated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
-          script: sudo pwsh ./scripts/smoke-test-droid.ps1 -IsCI -IsIntegrationTest
+          script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Kill emulator if AVD failed.
         if: ${{ steps.smoke-test.outputs.smoke-status != 'Completed' }}
@@ -466,7 +466,7 @@ jobs:
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
-          script: sudo pwsh ./scripts/smoke-test-droid.ps1 -IsCI -IsIntegrationTest
+          script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Throw error if Smoke test failed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # Tag: 0.9.1
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # pin@0.11.0
         with:
           access_token: ${{ github.token }}
 
@@ -61,7 +61,7 @@ jobs:
         unity-version: ['2019', '2020', '2021']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Checkout submodules
         run: ./scripts/init-submodules.sh src/sentry-dotnet
@@ -73,7 +73,7 @@ jobs:
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
       - name: Restore Unity Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             samples/unity-of-bugs/Library/Packages
@@ -103,37 +103,37 @@ jobs:
       - name: Download CLI
         run: pwsh ./scripts/download-sentry-cli.ps1
 
-      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+      - uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: Android-sdk
           path: package-dev/Plugins/Android
           wait-timeout: 3600
 
-      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+      - uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: Android-libraries
           path: modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
           wait-timeout: 3600
 
-      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+      - uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: iOS-sdk
           path: package-dev/Plugins/iOS
           wait-timeout: 3600
 
-      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+      - uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: macOS-sdk
           path: package-dev/Plugins/macOS
           wait-timeout: 3600
 
-      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+      - uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: Linux-sdk
           path: package-dev/Plugins/Linux
           wait-timeout: 3600
 
-      - uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+      - uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: Windows-sdk
           path: package-dev/Plugins/Windows
@@ -162,7 +162,7 @@ jobs:
         run: ./scripts/pack.ps1
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
         with:
           name: ${{ github.sha }}
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload test artifacts (playmode)
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test results (playmode)
           path: artifacts/test/playmode
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload test artifacts (editmode)
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test results (editmode)
           path: artifacts/test/editmode
@@ -210,7 +210,7 @@ jobs:
       UNITY_PATH: docker exec unity unity-editor
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Load env
         id: env
@@ -239,7 +239,7 @@ jobs:
         run: sudo pwsh ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+        uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           name: ${{ github.sha }}
           wait-timeout: 3600
@@ -260,7 +260,7 @@ jobs:
           sudo rm -rf *_BackUpThisFolder_ButDontShipItWithYourGame
 
       - name: Upload test app for smoke test
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build
@@ -268,7 +268,7 @@ jobs:
 
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: failed-project-${{ matrix.platform }}-${{ matrix.unity-version }}
           path: samples/IntegrationTest
@@ -279,10 +279,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Download UPM package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           # Artifact name is the commit sha. Which is what craft uses to find the relevant artifact.
           name: ${{ github.sha }}
@@ -315,7 +315,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Load env
         id: env
@@ -343,7 +343,7 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
+        uses: vaind/download-artifact@cbec071ac01e26699bc70c82f63ef724b3b0a91d
         with:
           # Artifact name is the commit sha. Which is what craft uses to find the relevant artifact.
           name: ${{ github.sha }}
@@ -389,10 +389,10 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Download test app artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: testapp-Android-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build
@@ -478,7 +478,7 @@ jobs:
 
       - name: Upload screenshot if smoke test failed
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: testapp-android-screenshot-${{ matrix.api-level }}-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build/screen.png
@@ -493,10 +493,10 @@ jobs:
         unity-version: ['2019', '2020', '2021', '2022']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Download XCode app artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: testapp-iOS-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build
@@ -506,7 +506,7 @@ jobs:
         run: ./Scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}"
 
       - name: Upload iOS test app for smoke test.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: testapp-iOS-compiled-${{ matrix.unity-version }}
           # Ignore the files that are not required for the test.
@@ -531,10 +531,10 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Download app artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: testapp-iOS-compiled-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator
@@ -575,10 +575,10 @@ jobs:
         platform: ['WebGL', 'Linux']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: Download test app artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         id: download
         with:
           name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,7 @@ jobs:
 
       - name: Load env
         id: env
-        shell: pwsh
-        run: echo "::set-output name=unityVersion::$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")"
+        run: echo "unityVersion=$(pwsh ./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $GITHUB_OUTPUT
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -215,7 +214,7 @@ jobs:
 
       - name: Load env
         id: env
-        run: echo "::set-output name=unityVersion::$(pwsh ./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")"
+        run: echo "unityVersion=$(pwsh ./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $GITHUB_OUTPUT
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -320,7 +319,7 @@ jobs:
 
       - name: Load env
         id: env
-        run: echo "::set-output name=unityVersion::$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")"
+        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
 
       - name: Setup Unity
         uses: getsentry/setup-unity@46c2e082d98cc3a825a5b59038cb31705fe9ff56
@@ -398,7 +397,7 @@ jobs:
           name: testapp-Android-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build
 
-      # outputs variables: version-label, api-level, target, arch
+      # outputs variables: api-level, label, target
       - name: Configure Android Settings
         id: droid-settings
         shell: pwsh
@@ -412,21 +411,20 @@ jobs:
             $result = [regex]::Match($response, " \(API level (?<model>\d+)\)")
             $apiLevel = $result.Groups["model"].Value
             Write-Output "Latest API is $apiLevel"
-            echo "::set-output name=api-level::$apiLevel"
-            echo "::set-output name=version-label::$apiLevel (latest)"
+            $label = "$apiLevel (latest)"
           }
           else
           {
             Write-Output "Current API is $apiLevel"
-            echo "::set-output name=api-level::$apiLevel"
-            echo "::set-output name=version-label::$arch"
           }
           # Setup Arch and Target
           $target = $apiLevel -ge 30 ? 'google_apis' : 'default'
           Write-Output "Current Target is $target"
-          echo "::set-output name=target::$target"
+          "api-level=$apiLevel" >> $env:GITHUB_OUTPUT
+          "label=$($label ?? $apiLevel)" >> $env:GITHUB_OUTPUT
+          "target=$target" >> $env:GITHUB_OUTPUT
 
-      - name: Android API ${{ steps.droid-settings.outputs.version-label }} emulator  setup  + Smoke test
+      - name: Android API ${{ steps.droid-settings.outputs.label }} emulator setup + Smoke test
         id: smoke-test
         continue-on-error: true
         timeout-minutes: 30
@@ -451,7 +449,7 @@ jobs:
           adb emu kill
           sleep 7
 
-      - name: Android API ${{ steps.droid-settings.outputs.version-label }} emulator setup + Smoke test (Retry)
+      - name: Android API ${{ steps.droid-settings.outputs.label }} emulator setup + Smoke test (Retry)
         id: smoke-test-retry
         continue-on-error: true
         timeout-minutes: 30

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: 'Release a new version: ${{ github.event.inputs.version }}'
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get submodules status
         run: git submodule status | tee submodules-status
@@ -26,7 +26,7 @@ jobs:
         shell: bash
 
       - name: Restore from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
@@ -60,13 +60,13 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: dotnet msbuild /t:Build${{ inputs.target }}SDK /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.target }}-sdk
           path: package-dev/Plugins/${{ inputs.target }}
           retention-days: ${{ github.ref_name == 'main' && 14 || 1 }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ inputs.target == 'Android' }}
         with:
           name: ${{ inputs.target }}-libraries

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -71,7 +71,7 @@ jobs:
           "changeset=$changeset" >> $env:GITHUB_OUTPUT
           echo "Latest version: $version ($changeset)"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -67,8 +67,8 @@ jobs:
           $items = $page.Links.Href | Select-String -Pattern $hubPrefix | ForEach-Object { $_.ToString().Substring($hubPrefix.Length) }
           $items = $items | Select-String -Pattern "${{ matrix.unity-prefix }}"
           $version,$changeset = $items[0].ToString().split("/")
-          echo "::set-output name=version::$version"
-          echo "::set-output name=changeset::$changeset"
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "changeset=$changeset" >> $env:GITHUB_OUTPUT
           echo "Latest version: $version ($changeset)"
 
       - uses: actions/checkout@v2

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -170,7 +170,15 @@ function CheckAndCloseActiveSystemAlerts([string] $deviceId, [string] $deviceApi
 function SignalActionSmokeStatus
 {
     param ($smokeStatus)
-    "smoke-status=$smokeStatus" >> $env:GITHUB_OUTPUT
+    if (Test-Path env:GITHUB_OUTPUT)
+    {
+        Write-Host "Writing smoke-status=$smokeStatus to ${env:GITHUB_OUTPUT}"
+        "smoke-status=$smokeStatus" >> $env:GITHUB_OUTPUT
+    }
+    else
+    {
+        Write-Host "smoke-status=$smokeStatus"
+    }
 }
 
 # Filter device List

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -86,28 +86,35 @@ function CloseSystemAlert([string] $deviceId, [string] $deviceApi, [string] $ale
         $alertOption2Label = $null
         $alertOption2Coord = $null
 
-        if ($splitXml.Count -ne 1) {
+        if ($splitXml.Count -ne 1)
+        {
             # We have a "valid" XML
             # Use Regex to get the message and the options labels + coordinates.
-            foreach ($iterator in $splitXml) {
-                if ($iterator.Contains("alertTitle")) {
+            foreach ($iterator in $splitXml)
+            {
+                if ($iterator.Contains("alertTitle"))
+                {
                     $titleRegex = [regex]::Match($iterator, "text=\`"(?<text>.+)\`" resource-id")
                     $alertTitle = $titleRegex.Groups["text"].Value
                 }
-                elseif ($iterator.Contains("Button")) {
+                elseif ($iterator.Contains("Button"))
+                {
                     $buttonRegex = [regex]::Match($iterator, "text=\`"(?<text>.+)\`" resource-id.* bounds=\`"\[(?<horStart>\d+),(?<verStart>\d+)\]\[(?<horEnd>\d+),(?<verEnd>\d+)\]\`"")
-                    if ($null -eq $alertOption1Label) {
+                    if ($null -eq $alertOption1Label)
+                    {
                         $alertOption1Label = $buttonRegex.Groups["text"].Value
                         $alertOption1Coord = ($buttonRegex.Groups["horStart"].Value, $buttonRegex.Groups["verStart"].Value, $buttonRegex.Groups["horEnd"].Value, $buttonRegex.Groups["verEnd"].Value)
                     }
-                    else {
+                    else
+                    {
                         $alertOption2Label = $buttonRegex.Groups["text"].Value
                         $alertOption2Coord = ($buttonRegex.Groups["horStart"].Value, $buttonRegex.Groups["verStart"].Value, $buttonRegex.Groups["horEnd"].Value, $buttonRegex.Groups["verEnd"].Value)
                     }
                 }
             }
 
-            if ($null -ne $alertTitle) {
+            if ($null -ne $alertTitle)
+            {
                 Write-Warning "Found Alert on Screen, TITLE: $alertTitle `n Options: `n $alertOption1Label at $alertOption1Coord `n $alertOption2Label at $alertOption2Coord "
 
                 if ($null -eq $alertOption2Label)
@@ -116,7 +123,7 @@ function CloseSystemAlert([string] $deviceId, [string] $deviceApi, [string] $ale
                     $tapY = [int]([int]$alertOption1Coord[1] + [int]$alertOption1Coord[3] ) / 2
                     $tapLabel = $alertOption1Label
                 }
-                else 
+                else
                 {
                     $tapX = [int]([int]$alertOption2Coord[0] + [int]$alertOption2Coord[2] ) / 2
                     $tapY = [int]([int]$alertOption2Coord[1] + [int]$alertOption2Coord[3] ) / 2
@@ -163,7 +170,7 @@ function CheckAndCloseActiveSystemAlerts([string] $deviceId, [string] $deviceApi
 function SignalActionSmokeStatus
 {
     param ($smokeStatus)
-    echo "::set-output name=smoke-status::$smokeStatus"
+    "smoke-status=$smokeStatus" >> $env:GITHUB_OUTPUT
 }
 
 # Filter device List

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -1,6 +1,5 @@
 param (
     [Parameter(Position = 0)]
-    [Switch] $IsCI,
     [Switch] $IsIntegrationTest
 )
 
@@ -12,14 +11,6 @@ Write-Host "#   ANDROID                                     #"
 Write-Host "#            VALIDATOR                          #"
 Write-Host "#                       SCRIPT                  #"
 Write-Host "#################################################"
-
-# When launched from the CI android-emulator-runner the usual GH-actions' CI variable is missing.
-# We set it here manually because CrashTestWithServer uses it to determine some configuration.
-if ($IsCI)
-{
-    $env:CI = "true"
-}
-
 
 if ($IsIntegrationTest)
 {


### PR DESCRIPTION
outstanding issue: `setup-unity` action needs to be updated to node16 & latest `@actions/core` - I've tried doing it quickly in [a fork](https://github.com/vaind/setup-unity/tree/chore/update-deps) but windows build didn't work so let's wait for the upstream maintainer to do it