### PR TITLE
fix: hide StackTraceMode from options to avoid accidental errors when used with IL2CPP

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -396,7 +396,7 @@ Log.LogMessage("Unity Version: " + version);
     </Task>
   </UsingTask>
 
-    <!-- Locate the TestRunner.dlls by filling the wildcard with the template version number. 3d is the default template -->
+  <!-- Locate the TestRunner.dlls by filling the wildcard with the template version number. 3d is the default template -->
   <UsingTask TaskName="LocateTestRunner" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <UnityLibcache ParameterType="System.String" Required="true" />

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -116,6 +116,9 @@ namespace Sentry.Unity
         /// </remarks>
         public bool Il2CppLineNumberSupportEnabled { get; set; } = true;
 
+        /// This option is hidden due to incompatibility between IL2CPP and Enhanced mode.
+        private new StackTraceMode StackTraceMode { get; set; }
+
         // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).
         internal string? _defaultUserId;
         internal string? DefaultUserId
@@ -175,8 +178,9 @@ namespace Sentry.Unity
             RequestBodyCompressionLevel = CompressionLevelWithAuto.NoCompression;
             InitCacheFlushTimeout = System.TimeSpan.Zero;
 
-            // Ben.Demystifer not compatible with IL2CPP
-            StackTraceMode = StackTraceMode.Original;
+            // Ben.Demystifer not compatible with IL2CPP. We could allow Enhanced in the future for Mono.
+            // See https://github.com/getsentry/sentry-unity/issues/675
+            base.StackTraceMode = StackTraceMode.Original;
             IsEnvironmentUser = false;
 
             if (application.ProductName is string productName

--- a/test/Sentry.Unity.Tests/SentryUnityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityTests.cs
@@ -23,7 +23,6 @@ namespace Sentry.Unity.Tests
         {
             var options = new SentryUnityOptions();
             options.AttachStacktrace = true;
-            options.StackTraceMode = StackTraceMode.Original;
             var sut = new SentryStackTraceFactory(options);
 
             IList<SentryStackFrame> framesSentry = null!;


### PR DESCRIPTION
closes #879 
closes #46 

I've implemented the solution suggested here: https://github.com/getsentry/sentry-unity/issues/879#issuecomment-1209525458 - not sure it's the best thing to do since we're completely forbidding anyone to use the `Enhanced` mode, even with Mono.

I was also thinking about using a custom setter that would throw in case you tried to set `Enhanced` with IL2CPP but we need to have `ISentryUnity` info provided and it doesn't seem like we must have it at all times (not a mandatory argument to Options at the moment).