### PR TITLE
ci: update OS versions in mobile test matrix & fix flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
+    # No point to run on tags - the releasee is already pushed to the release repo.
+    tags-ignore:
+      - '**'
   workflow_dispatch: # e.g. to manually trigger on foreign PRs
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     # No point to run on tags - the releasee is already pushed to the release repo.
     tags-ignore:
       - '**'
+    # We must explicitly specify `branches` configuration when we specify `tags-ignore` - otherwise it won't run at all.
+    branches:
+      - '**'
   workflow_dispatch: # e.g. to manually trigger on foreign PRs
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,7 @@ jobs:
           target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
-          arch: x86
+          arch: x86_64
           cores: 2
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
@@ -480,7 +480,7 @@ jobs:
           target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
-          arch: x86
+          arch: x86_64
           cores: 2
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,11 @@ jobs:
           name: testapp-Android-${{ matrix.unity-version }}
           path: samples/IntegrationTest/Build
 
+      - name: Setup HAXM
+        run: |
+          brew install --cask intel-haxm
+          kextstat
+
       # outputs variables: api-level, label, target
       - name: Configure Android Settings
         id: droid-settings
@@ -454,7 +459,7 @@ jobs:
           arch: x86
           cores: 2
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: false
           script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
@@ -478,7 +483,7 @@ jobs:
           arch: x86
           cores: 2
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: false
           script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: testapp-android-screenshot-${{ matrix.api-level }}-${{ matrix.unity-version }}
+          name: testapp-android-logs-${{ matrix.api-level }}-${{ matrix.unity-version }}
           path: |
             samples/IntegrationTest/Build/screen.png
             samples/IntegrationTest/Build/logcat.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,7 +527,7 @@ jobs:
 
   ios-smoke-test-run:
     needs: [ios-smoke-test-build]
-    name: Run iOS ${{ matrix.ios-runtime }} Smoke Test - ${{ matrix.unity-version }}
+    name: Run iOS ${{ matrix.ios }} Smoke Test - ${{ matrix.unity-version }}
     runs-on: macos-12
     strategy:
       fail-fast: false
@@ -539,7 +539,11 @@ jobs:
         # On the other hand https://developer.apple.com/support/app-store/ shows 14 % phones and 18 % tablets use iOS 14
         # as of May 31, 2022. Therefore, let's stick to testing iOS 14 until 2023.
         # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
-        ios-runtime: ['12.5', '14.8', '15.7', latest] # last updated October 2022
+        # Also make sure to match the versions available here:
+        #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
+        #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+        ios: ['12.4', '14.5', '15.4', latest] # last updated October 2022
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -552,23 +556,23 @@ jobs:
 
       - name: Setup xcode-install
         # Github Virtual machine already sets the runtime and simulator for the latest release.
-        if: ${{ matrix.ios-runtime != 'latest'}}
+        if: ${{ matrix.ios != 'latest'}}
         run: gem install xcode-install
 
-      - name: Setup ${{matrix.ios-runtime}} runtime
-        if: ${{ matrix.ios-runtime != 'latest'}}
-        run: xcversion simulators --install='iOS ${{matrix.ios-runtime}}'
+      - name: Setup ${{matrix.ios}} runtime
+        if: ${{ matrix.ios != 'latest'}}
+        run: xcversion simulators --install='iOS ${{matrix.ios}}'
 
-      - name: Setup ${{matrix.ios-runtime}} Simulator
-        if: ${{ matrix.ios-runtime != 'latest' }}
+      - name: Setup ${{matrix.ios}} Simulator
+        if: ${{ matrix.ios != 'latest' }}
         # We need to setup an simulator in order to xCode to populate the simulators for the given runtime.
-        run: xcrun simctl create InitialSimulator "iPhone 8" "iOS${{ matrix.ios-runtime }}"
+        run: xcrun simctl create InitialSimulator "iPhone 8" "iOS${{ matrix.ios }}"
 
       - name: Smoke test
         id: smoke-test-ios
         timeout-minutes: 10
         run: |
-          $runtime = "${{ matrix.ios-runtime }}"
+          $runtime = "${{ matrix.ios }}"
           If ($runtime -ne "latest")
           {
             $runtime = "iOS " + $runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [27, 28, 29, 30, 31] # last updated October 2022
+        api-level: [27, 28, 29, 30, 31, latest] # last updated October 2022
         unity-version: ['2019', '2020', '2021', '2022']
         include:
           # API 21 is barely used but let's check it as the minimum supported version for now.
@@ -439,12 +439,8 @@ jobs:
           {
             Write-Output "Current API is $apiLevel"
           }
-          # Setup Arch and Target
-          $target = $apiLevel -ge 30 ? 'google_apis' : 'default'
-          Write-Output "Current Target is $target"
           "api-level=$apiLevel" >> $env:GITHUB_OUTPUT
           "label=$($label ?? $apiLevel)" >> $env:GITHUB_OUTPUT
-          "target=$target" >> $env:GITHUB_OUTPUT
 
       - name: Android API ${{ steps.droid-settings.outputs.label }} emulator setup + Smoke test
         id: smoke-test
@@ -452,7 +448,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
           api-level: ${{ steps.droid-settings.outputs.api-level }}
-          # target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
@@ -476,7 +471,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
           api-level: ${{ steps.droid-settings.outputs.api-level }}
-          # target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
@@ -484,7 +478,9 @@ jobs:
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: false
-          script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
+          script: |
+            echo "::Warning::Retrying Android API ${{ steps.droid-settings.outputs.label }} test due to previous step failure: '${{ steps.smoke-test.outputs.status }}'"
+            pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Upload screenshot if smoke test failed
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,19 +399,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [21, 27, 29, 30]
+        api-level: [27, 28, 29, 30, 31] # last updated October 2022
         unity-version: ['2019', '2020', '2021', '2022']
-        exclude:
-          # API 21 is no longer supported since Unity 2021.2.10f1
+        include:
+          # API 21 is barely used but let's check it as the minimum supported version for now.
           - api-level: 21
-            unity-version: '2021'
-          - api-level: 21
-            unity-version: '2022'
-          # Smoke test currently crashes on API 30 with Unity 2021 & 2022 build on CI, see issue #719
-          - api-level: 30
-            unity-version: '2021'
-          - api-level: 30
-            unity-version: '2022'
+            unity-version: 2019
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -530,14 +523,18 @@ jobs:
   ios-smoke-test-run:
     needs: [ios-smoke-test-build]
     name: Run iOS ${{ matrix.ios-runtime }} Smoke Test - ${{ matrix.unity-version }}
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
         unity-version: ['2019', '2020', '2021', '2022']
+        # Check https://support.apple.com/en-us/HT201222 for the latest minor version for a given major one.
+        # That page also shows which iPhones are supported with whith iOS version, therefore we don't need to test
+        # iOS 13 and 14 because there are no devices that support those version while not supporting iOS 15.
+        # On the other hand https://developer.apple.com/support/app-store/ shows 14 % phones and 18 % tablets use iOS 14
+        # as of May 31, 2022. Therefore, let's stick to testing iOS 14 until 2023.
         # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
-        # TODO: put 12.0 back
-        ios-runtime: ['12.4', '13.0', '14.1', latest]
+        ios-runtime: ['12.5', '14.8', '15.7', latest] # last updated October 2022
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,12 +495,14 @@ jobs:
             echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} test due to previous step failure: '${{ steps.smoke-test.outputs.status }}'"
             pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
-      - name: Upload screenshot if smoke test failed
+      - name: Upload artifacts on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: testapp-android-screenshot-${{ matrix.api-level }}-${{ matrix.unity-version }}
-          path: samples/IntegrationTest/Build/screen.png
+          path: |
+            samples/IntegrationTest/Build/screen.png
+            samples/IntegrationTest/Build/logcat.txt
 
   ios-smoke-test-build:
     needs: [smoke-test-build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,8 +452,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
           api-level: ${{ steps.droid-settings.outputs.api-level }}
-          #api-level 30 image is only available with google services.
-          target: ${{ steps.droid-settings.outputs.target }}
+          # target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
@@ -477,7 +476,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
           api-level: ${{ steps.droid-settings.outputs.api-level }}
-          target: ${{ steps.droid-settings.outputs.target }}
+          # target: ${{ steps.droid-settings.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,12 +399,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [27, 28, 29, 30, 31, latest] # last updated October 2022
+        api-level: [27, 28, 29, 30, 31] # last updated October 2022
         unity-version: ['2019', '2020', '2021', '2022']
         include:
           # API 21 is barely used but let's check it as the minimum supported version for now.
           - api-level: 21
-            unity-version: 2019
+            unity-version: '2019'
+        exclude:
+          # Seems like there's an error in Unity with Android API 30 - disabling.
+          # https://github.com/getsentry/sentry-unity/issues/719#issuecomment-1129129952
+          - api-level: 30
+            unity-version: '2021'
+          - api-level: 30
+            unity-version: '2022'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -422,7 +429,7 @@ jobs:
 
       # outputs variables: api-level, label, target
       - name: Configure Android Settings
-        id: droid-settings
+        id: config
         run: |
           # Setup API Level
           $apiLevel = '${{ matrix.api-level }}'
@@ -439,15 +446,20 @@ jobs:
           {
             Write-Output "Current API is $apiLevel"
           }
+          # Setup Arch and Target
+          $target = $apiLevel -ge 30 ? 'google_apis' : 'default'
+          Write-Output "Current Target is $target"
+          "target=$target" >> $env:GITHUB_OUTPUT
           "api-level=$apiLevel" >> $env:GITHUB_OUTPUT
           "label=$($label ?? $apiLevel)" >> $env:GITHUB_OUTPUT
 
-      - name: Android API ${{ steps.droid-settings.outputs.label }} emulator setup + Smoke test
+      - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test
         id: smoke-test
         timeout-minutes: 15
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
-          api-level: ${{ steps.droid-settings.outputs.api-level }}
+          api-level: ${{ steps.config.outputs.api-level }}
+          target: ${{ steps.config.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
@@ -464,13 +476,14 @@ jobs:
           adb emu kill
           sleep 7
 
-      - name: Android API ${{ steps.droid-settings.outputs.label }} emulator setup + Smoke test (Retry)
+      - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test (Retry)
         timeout-minutes: 15
         # Retry the tests if the previous fail happened on the emulator startup.
         if: ${{ (steps.smoke-test.outputs.status == 'flaky') || (steps.smoke-test.outputs.status == '') }}
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         with:
-          api-level: ${{ steps.droid-settings.outputs.api-level }}
+          api-level: ${{ steps.config.outputs.api-level }}
+          target: ${{ steps.config.outputs.target }}
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
@@ -479,7 +492,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: false
           script: |
-            echo "::Warning::Retrying Android API ${{ steps.droid-settings.outputs.label }} test due to previous step failure: '${{ steps.smoke-test.outputs.status }}'"
+            echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} test due to previous step failure: '${{ steps.smoke-test.outputs.status }}'"
             pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Upload screenshot if smoke test failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,9 +500,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: testapp-android-logs-${{ matrix.api-level }}-${{ matrix.unity-version }}
-          path: |
-            samples/IntegrationTest/Build/screen.png
-            samples/IntegrationTest/Build/logcat.txt
+          path: samples/IntegrationTest/test-artifacts
 
   ios-smoke-test-build:
     needs: [smoke-test-build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,7 @@ jobs:
           "label=$($label ?? $apiLevel)" >> $env:GITHUB_OUTPUT
 
       - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test
-        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
+        uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0
         id: smoke-test
         timeout-minutes: 30
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,9 +433,9 @@ jobs:
       - name: Record test session
         shell: bash
         run: |
-          brew install ffmpeg
+          command -v ffmpeg || brew install ffmpeg
           mkdir -p ${{ env.ARTIFACTS_PATH }}
-          ffmpeg -f avfoundation -i 0 -t 120 ${{ env.ARTIFACTS_PATH }}out.mov &
+          ffmpeg -nostdin -f avfoundation -i 1 ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &
 
       # outputs variables: api-level, label, target
       - name: Configure Android Settings
@@ -504,6 +504,10 @@ jobs:
           script: |
             echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} because the previous step finished with: '${{ steps.smoke-test.outputs.status }}'"
             pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
+
+      - name: Stop screen recording
+        continue-on-error: true
+        run: killall ffmpeg
 
       - name: Upload artifacts on failure
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,7 @@ jobs:
           kextstat
 
       - name: Record test session
+        shell: bash
         run: |
           brew install ffmpeg
           mkdir -p ${{ env.ARTIFACTS_PATH }}
@@ -473,13 +474,11 @@ jobs:
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
-          cores: 2
+          cores: 3
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: true
-          script: |
-            adb shell 'su;setprop debug.hwui.renderer skiagl;stop;start'
-            pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
+          script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Kill emulator if AVD failed.
         if: ${{ steps.smoke-test.outputs.status != 'success' }}
@@ -498,7 +497,7 @@ jobs:
           force-avd-creation: false
           ram-size: 2048M
           arch: x86_64
-          cores: 2
+          cores: 3
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
           emulator-options: -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,6 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
-    # No point to run on tags - the releasee is already pushed to the release repo.
-    tags-ignore:
-      - '**'
-    # We must explicitly specify `branches` configuration when we specify `tags-ignore` - otherwise it won't run at all.
-    branches:
-      - '**'
   workflow_dispatch: # e.g. to manually trigger on foreign PRs
 
 env:
@@ -460,9 +454,10 @@ jobs:
           "label=$($label ?? $apiLevel)" >> $env:GITHUB_OUTPUT
 
       - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test
+        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         id: smoke-test
         timeout-minutes: 15
-        uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
+        continue-on-error: true
         with:
           api-level: ${{ steps.config.outputs.api-level }}
           target: ${{ steps.config.outputs.target }}
@@ -483,10 +478,9 @@ jobs:
           sleep 7
 
       - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test (Retry)
-        timeout-minutes: 15
-        # Retry the tests if the previous fail happened on the emulator startup.
-        if: ${{ (steps.smoke-test.outputs.status == 'flaky') || (steps.smoke-test.outputs.status == '') }}
+        if: ${{ steps.smoke-test.outputs.status != 'success' }}
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
+        timeout-minutes: 15
         with:
           api-level: ${{ steps.config.outputs.api-level }}
           target: ${{ steps.config.outputs.target }}
@@ -498,7 +492,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: false
           script: |
-            echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} test due to previous step failure: '${{ steps.smoke-test.outputs.status }}'"
+            echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} because the previous step finished with: '${{ steps.smoke-test.outputs.status }}'"
             pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Upload artifacts on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,15 +430,6 @@ jobs:
           brew install --cask intel-haxm
           kextstat
 
-      - name: Record test session
-        shell: bash
-        run: |
-          set -x
-          command -v ffmpeg || brew install ffmpeg
-          mkdir -p ${{ env.ARTIFACTS_PATH }}
-          ffmpeg -codecs
-          ffmpeg -nostdin -f avfoundation -i 0 -video_size 720x480 -framerate 5 -an ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &
-
       # outputs variables: api-level, label, target
       - name: Configure Android Settings
         id: config
@@ -506,10 +497,6 @@ jobs:
           script: |
             echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} because the previous step finished with: '${{ steps.smoke-test.outputs.status }}'"
             pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
-
-      - name: Stop screen recording
-        continue-on-error: true
-        run: killall ffmpeg
 
       - name: Upload artifacts on failure
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,11 +433,11 @@ jobs:
       - name: Record test session
         shell: bash
         run: |
+          set -x
           command -v ffmpeg || brew install ffmpeg
           mkdir -p ${{ env.ARTIFACTS_PATH }}
-          ffmpeg -f avfoundation -list_devices true -i ""
           ffmpeg -codecs
-          ffmpeg -nostdin -f avfoundation -i 1 -video_size 720x480 -framerate 5 ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &
+          ffmpeg -nostdin -f avfoundation -i 0 -video_size 720x480 -framerate 5 -an ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &
 
       # outputs variables: api-level, label, target
       - name: Configure Android Settings
@@ -468,7 +468,7 @@ jobs:
       - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
         id: smoke-test
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           api-level: ${{ steps.config.outputs.api-level }}
@@ -492,7 +492,7 @@ jobs:
       - name: Android API ${{ steps.config.outputs.label }} emulator setup + Smoke test (Retry)
         if: ${{ steps.smoke-test.outputs.status != 'success' }}
         uses: reactivecircus/android-emulator-runner@76c2bf6f95ed6458fd659a1bdb680a0f8df232dc
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           api-level: ${{ steps.config.outputs.api-level }}
           target: ${{ steps.config.outputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,9 @@ jobs:
             unity-version: '2021'
           - api-level: 30
             unity-version: '2022'
+    env:
+      ARTIFACTS_PATH: samples/IntegrationTest/test-artifacts/
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -426,6 +429,12 @@ jobs:
         run: |
           brew install --cask intel-haxm
           kextstat
+
+      - name: Record test session
+        run: |
+          brew install ffmpeg
+          mkdir -p ${{ env.ARTIFACTS_PATH }}
+          ffmpeg -f avfoundation -i 0 -t 120 ${{ env.ARTIFACTS_PATH }}out.mov &
 
       # outputs variables: api-level, label, target
       - name: Configure Android Settings
@@ -466,9 +475,11 @@ jobs:
           arch: x86_64
           cores: 2
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
-          disable-animations: false
-          script: pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
+          emulator-options: -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
+          disable-animations: true
+          script: |
+            adb shell 'su;setprop debug.hwui.renderer skiagl;stop;start'
+            pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
 
       - name: Kill emulator if AVD failed.
         if: ${{ steps.smoke-test.outputs.status != 'success' }}
@@ -489,8 +500,8 @@ jobs:
           arch: x86_64
           cores: 2
           disk-size: 4096M # Some runs have out of storage error when installing the smoke test.
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
-          disable-animations: false
+          emulator-options: -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
+          disable-animations: true
           script: |
             echo "::Warning::Retrying Android API ${{ steps.config.outputs.label }} because the previous step finished with: '${{ steps.smoke-test.outputs.status }}'"
             pwsh ./scripts/smoke-test-droid.ps1 -IsIntegrationTest
@@ -500,7 +511,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: testapp-android-logs-${{ matrix.api-level }}-${{ matrix.unity-version }}
-          path: samples/IntegrationTest/test-artifacts
+          path: ${{ env.ARTIFACTS_PATH }}
 
   ios-smoke-test-build:
     needs: [smoke-test-build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,9 @@ jobs:
         run: |
           command -v ffmpeg || brew install ffmpeg
           mkdir -p ${{ env.ARTIFACTS_PATH }}
-          ffmpeg -nostdin -f avfoundation -i 1 ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &
+          ffmpeg -f avfoundation -list_devices true -i ""
+          ffmpeg -codecs
+          ffmpeg -nostdin -f avfoundation -i 1 -video_size 720x480 -framerate 5 ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &
 
       # outputs variables: api-level, label, target
       - name: Configure Android Settings

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -54,9 +54,13 @@ function GetDeviceUiLog([string] $deviceId, [string] $deviceApi)
 
 function LogCat([string] $deviceId, [string] $appPID)
 {
-    if ($null -eq $appPID -or $deviceApi -eq "21")
+    if ([string]::IsNullOrEmpty($appPID))
     {
         adb -s $device logcat -d
+    }
+    elseif ($deviceApi -eq "21")
+    {
+        adb -s $device shell "logcat -d | grep -E '\( *$appPID\)'"
     }
     else
     {

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -403,6 +403,8 @@ foreach ($device in $DeviceList)
     }
     catch
     {
+        Write-Warning "Caught exception: $_"
+        Write-Host $_.ScriptStackTrace
         OnError $device $deviceApi
         ExitNow "failed" $_;
     }

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -73,7 +73,7 @@ function PidOf([string] $deviceId, [string] $processName)
     if ($deviceApi -eq "21")
     {
         # `pidof` doesn't exist - take second column from the `ps` output for the given process instead.
-        ((adb -s $deviceId shell "ps | grep '$processName'") -Split " +")[1]
+        (adb -s $deviceId shell "ps | grep '$processName'") -Split " +" | Select-Object -Skip 1 -First 1
     }
     else
     {

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -40,7 +40,7 @@ function ArtifactsPath
 if (Test-Path env:CI)
 {
     # Take Screenshot of VM to verify emulator start
-    screencapture "$(ArtifactsPath)host-screenshot.jpg"
+    screencapture "$(ArtifactsPath)/host-screenshot.jpg"
 }
 
 function TakeScreenshot([string] $deviceId)

--- a/scripts/smoke-test-droid.ps1
+++ b/scripts/smoke-test-droid.ps1
@@ -311,8 +311,7 @@ foreach ($device in $DeviceList)
 
         $timedOut = $true
         $appPID = $null
-        $stopwatch = [System.Diagnostics.Stopwatch]::new()
-        $stopwatch.Start()
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         While ($stopwatch.Elapsed.TotalSeconds -lt 60)
         {
             # Check if the app started - it's not absolutely necessary to get the PID, just useful to achieve good log output.

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -126,16 +126,8 @@ function Test
     Write-Host "::endgroup::"
 
     $devicesRan = 0
-    $skippedItems = 0
     ForEach ($device in $deviceList)
     {
-        If ($skippedItems -lt $skipCount)
-        {
-            # Write-Host "Skipping Simulator $($device.Name) UUID $($device.UUID)" -ForegroundColor Green
-            $device.TestSkipped = $true
-            $skippedItems++
-            continue
-        }
         If ($devicesRan -ge $DevicesToRun)
         {
             # Write-Host "Skipping Simulator $($device.Name) UUID $($device.UUID)" -ForegroundColor Green

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -155,7 +155,7 @@ function Test
 
                 if ("$SuccessString" -eq "")
                 {
-                    $SuccessString = "${$Name.ToUpper()} TEST: PASS"
+                    $SuccessString = "$($Name.ToUpper()) TEST: PASS"
                 }
 
                 Write-Host -NoNewline "'$Name' test STATUS: "

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -14,7 +14,6 @@ Write-Host "Args received Action=$Action, SelectedRuntime=$SelectedRuntime, IsIn
 #          'iOS <version>' to run on the specified runtime ex: iOS 12.4
 # $DevicesToRun: the amount of devices to run
 #          '0' or empty will run on 1 device, otherwise on the specified amount.
-$ErrorActionPreference = "Stop"
 
 . $PSScriptRoot/../test/Scripts.Integration.Test/common.ps1
 

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -126,6 +126,7 @@ function Test
     Write-Host "::endgroup::"
 
     $devicesRan = 0
+    $skippedItems = 0
     ForEach ($device in $deviceList)
     {
         If ($skippedItems -lt $skipCount)

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -104,7 +104,7 @@ function Test
         throw " Runtime (-- $SelectedRuntime --) not found"
     }
 
-    foreach ($device in $deviceListRaw[$runtimeIndex..$deviceListRaw.Count])
+    foreach ($device in $deviceListRaw[$runtimeIndex..($deviceListRaw.Count - 1)])
     {
         If ($device.StartsWith("--"))
         {
@@ -251,7 +251,7 @@ function Test
 function LatestRuntime
 {
     $runtimes = xcrun simctl list runtimes iOS
-    $lastRuntime = $runtimes[$runtimesnewArray.Count – 1]
+    $lastRuntime = $runtimes | Select-Object -Last 1
     $result = [regex]::Match($lastRuntime, "(?<runtime>iOS [0-9.]+)")
     if ($result.Success -eq $False)
     {

--- a/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
@@ -22,9 +22,11 @@ public class SmokeTester : MonoBehaviour
 
     public void Start()
     {
-        Debug.Log("SmokeTester.Start() running");
+        Debug.Log("SmokeTester starting");
 
         var arg = GetTestArg();
+        Debug.Log($"SmokeTester arg: '{arg}'");
+
         if (arg == "smoke")
         {
             SmokeTest();
@@ -101,10 +103,9 @@ public class SmokeTester : MonoBehaviour
 
     public static void SmokeTest()
     {
-        t.name = "SMOKE";
+        t.Start("SMOKE");
         try
         {
-            Debug.Log("SMOKE TEST: Start");
             int crashed = _crashedLastRun();
             t.Expect($"options.CrashedLastRun ({crashed}) == false (0)", crashed == 0);
 
@@ -173,7 +174,7 @@ public class SmokeTester : MonoBehaviour
 
     public static void CrashTest()
     {
-        Debug.Log("CRASH TEST: Start");
+        t.Start("CRASH");
 
         AddContext();
 
@@ -187,7 +188,7 @@ public class SmokeTester : MonoBehaviour
 
     public static void HasntCrashedTest()
     {
-        t.name = "HASNT-CRASHED";
+        t.Start("HASNT-CRASHED");
         int crashed = _crashedLastRun();
         t.Expect($"options.CrashedLastRun ({crashed}) == false (0)", crashed == 0);
         t.Pass();
@@ -195,7 +196,7 @@ public class SmokeTester : MonoBehaviour
 
     public static void HasCrashedTest()
     {
-        t.name = "HAS-CRASHED";
+        t.Start("HAS-CRASHED");
         int crashed = _crashedLastRun();
         t.Expect($"options.CrashedLastRun ({crashed}) == true (1)", crashed == 1);
         t.Pass();
@@ -226,7 +227,7 @@ public class SmokeTester : MonoBehaviour
 
     private class TestHandler : HttpClientHandler
     {
-        public String name;
+        private String name;
 
         private List<string> _requests = new List<string>();
 
@@ -237,6 +238,12 @@ public class SmokeTester : MonoBehaviour
         private int _testNumber = 0;
 
         public int exitCode = 0;
+
+        public void Start(String testName)
+        {
+            name = testName;
+            Debug.Log($"{name} TEST: start");
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -262,7 +269,7 @@ public class SmokeTester : MonoBehaviour
         {
             if (exitCode != 0)
             {
-                Debug.Log($"Ignoring spurious Exit({code}). Application is already exiting with code {exitCode}");
+                Debug.Log($"{name} TEST: Ignoring spurious Exit({code}). Application is already exiting with code {exitCode}");
             }
             else
             {

--- a/test/Scripts.Integration.Test/common.ps1
+++ b/test/Scripts.Integration.Test/common.ps1
@@ -109,6 +109,7 @@ function CrashTestWithServer([ScriptBlock] $CrashTestCallback, [string] $Success
             else
             {
                 Write-Warning "crash test $run/$runs : FAILED, retrying. The error was: $_"
+                Write-Host $_.ScriptStackTrace
                 continue
             }
         }

--- a/test/Scripts.Integration.Test/common.ps1
+++ b/test/Scripts.Integration.Test/common.ps1
@@ -1,8 +1,16 @@
 # Note: this is currently used by integration test scripts as well as "smoke-test-*.ps1" scripts.
 # If/when those are merged to some extent, maybe this file could be merged into `globals.ps1`.
 
-function RunApiServer([string] $ServerScript, [string] $Uri = "http://localhost:8000")
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+
+function RunApiServer([string] $ServerScript, [string] $Uri)
 {
+    if ([string]::IsNullOrEmpty($Uri))
+    {
+        $Uri = SymbolServerUrlFor ((Test-Path variable:UnityPath) ? $UnityPath : '')
+    }
+
     $result = "" | Select-Object -Property process, outFile, errFile, stop, output, dispose
     Write-Host "Starting the $ServerScript on $Uri"
     $result.outFile = New-TemporaryFile
@@ -146,14 +154,14 @@ function CrashTestWithServer([ScriptBlock] $CrashTestCallback, [string] $Success
 
 function SymbolServerUrlFor([string] $UnityPath, [string] $Platform = "")
 {
-    # Note: iOS has special handling - it's the "update-sentry" script runs elsewhere than the actual build & upload.
+    # Note: iOS has special handling - its "update-sentry" script runs elsewhere than the actual build & upload.
     ($UnityPath.StartsWith("docker ") -and ($Platform -ne "iOS")) ? 'http://172.17.0.1:8000' : 'http://localhost:8000'
 }
 
 function RunWithSymbolServer([ScriptBlock] $Callback)
 {
     # start the server
-    $httpServer = RunApiServer "symbol-upload-server" (SymbolServerUrlFor $UnityPath)
+    $httpServer = RunApiServer "symbol-upload-server"
 
     # run the test
     try

--- a/test/Scripts.Integration.Test/create-project.ps1
+++ b/test/Scripts.Integration.Test/create-project.ps1
@@ -34,7 +34,7 @@ $projectSettings = Get-Content $projectSettingsPath
 # Don't print stack traces in debug logs. See ./samples/unity-of-bugs/ProjectSettings/PresetManager.asset
 $projectSettings = $projectSettings -replace "m_StackTraceTypes: ?[01]+", "m_StackTraceTypes: 010000000000000000000000000000000100000001000000"
 # Build Android for x86_64 - for the emulator
-$projectSettings = $projectSettings -replace "AndroidTargetArchitectures: ?[0-9]+", "AndroidTargetArchitectures: 4"
+$projectSettings = $projectSettings -replace "AndroidTargetArchitectures: ?[0-9]+", "AndroidTargetArchitectures: 8"
 # Build for iOS Simulator
 $projectSettings = $projectSettings -replace "iPhoneSdkVersion: ?[0-9]+", "iPhoneSdkVersion: 989"
 $projectSettings | Out-File $projectSettingsPath

--- a/test/Scripts.Integration.Test/integration-test.ps1
+++ b/test/Scripts.Integration.Test/integration-test.ps1
@@ -18,6 +18,8 @@ $UnityPath = $null
 
 If ($IsMacOS) {
 	$UnityPath = "/Applications/Unity/Hub/Editor/$UnityVersion*/Unity.app/"
+} elseif ($IsWindows) {
+	$UnityPath = "C:/Program Files/Unity/Hub/Editor/$UnityVersion/Editor/Unity.exe"
 }
 
 If (-not(Test-Path -Path $UnityPath)) {

--- a/test/Scripts.Integration.Test/run-smoke-test.ps1
+++ b/test/Scripts.Integration.Test/run-smoke-test.ps1
@@ -77,8 +77,6 @@ else
     Write-Warning 'On windows, this would normally be: -AppDataDir "$env:UserProfile\AppData\LocalLow\DefaultCompany\unity-of-bugs\"'
 }
 
-Set-StrictMode -Version latest
-
 function RunTest([string] $type)
 {
     Write-Host "::group::Test: '$type'"


### PR DESCRIPTION
* closes #719 
* related also to #698 
* ensures HW acceleration is enabled for Android: see https://github.com/ReactiveCircus/android-emulator-runner/pull/279/files mentioning macos no longer comes with HAXM preinstalled
* some more CI log output improvements
* sets scripts `$ErrorActionPreference = "Stop"` & fixes the previously silent errors
* switches to x86_64 Android build
* ~records Android CI sessions~ - this slows down CI and doesn't actually show anything useful. below is the code for backup: [`61e6a34` (#1035)](https://github.com/getsentry/sentry-unity/pull/1035/commits/61e6a348ca509cccda05083099c34d63ecb5ec26)
```yaml
      # This slows down the CI significantly so let's see if
      - name: Record test session
        shell: bash
        run: |
          set -x
          command -v ffmpeg || brew install ffmpeg
          mkdir -p ${{ env.ARTIFACTS_PATH }}
          ffmpeg -codecs
          ffmpeg -nostdin -f avfoundation -i 0 -video_size 720x480 -framerate 5 -an ${{ env.ARTIFACTS_PATH }}out.mkv > ${{ env.ARTIFACTS_PATH }}ffmpeg.log 2>&1 &

... steps to run tests

      - name: Stop screen recording
        continue-on-error: true
        run: killall ffmpeg
```