### PR TITLE
fix: nuget building flake

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,6 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Especially in CI we've seen a lot of this lately.
```
Unable to resolve 'UnoptimizedAssemblyDetector (>= 0.1.1)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'Roslynator.Analyzers (>= 4.1.1)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'Nullable (>= 1.3.1)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'SIL.ReleaseTasks (>= 2.5.0)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'Microsoft.SourceLink.GitHub (>= 1.1.1)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'NETStandard.Library (>= 2.0.3)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'System.Reflection.Metadata (>= 5.0.0)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'System.Buffers (>= 4.5.1)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'System.Threading.Tasks.Extensions (>= 4.5.4)' for '.NETStandard,Version=v2.0
Unable to resolve 'Microsoft.Bcl.AsyncInterfaces (>= 5.0.0)' for '.NETStandard,Version=v2.0'.
Unable to resolve 'System.Text.Json (>= 5.0.2)' for '.NETStandard,Version=v2.0'.
```

Updating the nuget.config to mirror the .NET SDK one hopefully resolves this.


#skip-changelog