### PR TITLE
fix: Added missing screenshot tests

### DIFF
--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -27,7 +27,7 @@ namespace Sentry.Unity
         {
             // Note: we need to check explicitly that we're on the same thread. While Unity would throw otherwise
             // when capturing the screenshot, it would only do so on development builds. On release, it just crashes...
-            if (_behaviour.IsMainThread is null || !_behaviour.IsMainThread())
+            if (_behaviour.MainThreadData.IsMainThread())
             {
                 _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on other than main (UI) thread.");
                 return Stream.Null;

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -27,16 +27,16 @@ namespace Sentry.Unity
         {
             // Note: we need to check explicitly that we're on the same thread. While Unity would throw otherwise
             // when capturing the screenshot, it would only do so on development builds. On release, it just crashes...
-            if (!_behaviour.MainThreadData.IsMainThread())
+            if (_behaviour.IsMainThread is null || !_behaviour.IsMainThread())
             {
                 _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on other than main (UI) thread.");
                 return Stream.Null;
             }
 
-            return new MemoryStream(CaptureScreenshot());
+            return new MemoryStream(CaptureScreenshot(Screen.width, Screen.height));
         }
 
-        private int GetTargetResolution(ScreenshotQuality quality)
+        internal static int GetTargetResolution(ScreenshotQuality quality)
         {
             return quality switch
             {
@@ -47,11 +47,8 @@ namespace Sentry.Unity
             };
         }
 
-        private byte[] CaptureScreenshot()
+        internal byte[] CaptureScreenshot(int width, int height)
         {
-            var width = Screen.width;
-            var height = Screen.height;
-
             // Make sure the screenshot size does not exceed the target size by scaling the image while conserving the
             // original ratio based on which, width or height, is the smaller
             if (_options.ScreenshotQuality is not ScreenshotQuality.Full)

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -118,7 +118,6 @@ namespace Sentry.Unity
     internal partial class SentryMonoBehaviour
     {
         internal readonly MainThreadData MainThreadData = new();
-        internal Func<bool>? IsMainThread;
 
         private ISentrySystemInfo? _sentrySystemInfo;
         internal ISentrySystemInfo SentrySystemInfo
@@ -133,11 +132,7 @@ namespace Sentry.Unity
 
         // Note: Awake is called only once and synchronously while the object is built.
         // We want to do it this way instead of a StartCoroutine() so that we have the context info ASAP.
-        private void Awake()
-        {
-            IsMainThread = () => MainThreadData.IsMainThread();
-            CollectData();
-        }
+        private void Awake() => CollectData();
 
         internal void CollectData()
         {

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -118,6 +118,7 @@ namespace Sentry.Unity
     internal partial class SentryMonoBehaviour
     {
         internal readonly MainThreadData MainThreadData = new();
+        internal Func<bool>? IsMainThread;
 
         private ISentrySystemInfo? _sentrySystemInfo;
         internal ISentrySystemInfo SentrySystemInfo
@@ -132,7 +133,11 @@ namespace Sentry.Unity
 
         // Note: Awake is called only once and synchronously while the object is built.
         // We want to do it this way instead of a StartCoroutine() so that we have the context info ASAP.
-        private void Awake() => CollectData();
+        private void Awake()
+        {
+            IsMainThread = () => MainThreadData.IsMainThread();
+            CollectData();
+        }
 
         internal void CollectData()
         {

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -219,11 +219,6 @@ namespace Sentry.Unity
             };
         }
 
-        public SentryUnityOptions(bool attachScreenshot) : this()
-        {
-            AttachScreenshot = attachScreenshot;
-        }
-
         public override string ToString()
         {
             return $@"Sentry SDK Options:

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -122,7 +122,7 @@ namespace Sentry.Unity
         /// </remarks>
         public bool Il2CppLineNumberSupportEnabled { get; set; } = true;
 
-        /// This option is hidden due to incompatibility between IL2CPP and Enhanced mode.
+        // This option is hidden due to incompatibility between IL2CPP and Enhanced mode.
         private new StackTraceMode StackTraceMode { get; set; }
 
         // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).
@@ -217,6 +217,11 @@ namespace Sentry.Unity
                 { LogType.Error, true},
                 { LogType.Exception, true},
             };
+        }
+
+        public SentryUnityOptions(bool attachScreenshot) : this()
+        {
+            AttachScreenshot = attachScreenshot;
         }
 
         public override string ToString()

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -42,6 +42,11 @@
         <HintPath>$(UnityManagedPath)/UnityEngine/UnityEngine.CoreModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
+      <!-- Used for texture.loadImage in tests -->
+      <Reference Include="UnityEngine.ImageConversionModule">
+        <HintPath>$(UnityManagedPath)/UnityEngine/UnityEngine.ImageConversionModule.dll</HintPath>
+        <Private>false</Private>
+      </Reference>
     </ItemGroup>
     <Error Condition="!Exists('$(UnityTemplateAssemblyPath)/UnityEngine.TestRunner.dll')" Text="TestRunner not found. Expected: $(UnityTemplateAssemblyPath)/UnityEngine.TestRunner.dll"></Error>
   </Target>

--- a/test/Scripts.Integration.Test/common.ps1
+++ b/test/Scripts.Integration.Test/common.ps1
@@ -299,7 +299,7 @@ function CheckSymbolServerOutput([string] $buildMethod, [string] $symbolServerOu
         {
             $expectedFiles = @(
                 "IntegrationTest: count=$($withSources ? 3 : 2)",
-                'Sentry: count=6',
+                'Sentry: count=8',
                 "UnityFramework: count=$($withSources ? 5 : 4)",
                 'libiPhone-lib.dylib: count=1'
             )
@@ -308,7 +308,7 @@ function CheckSymbolServerOutput([string] $buildMethod, [string] $symbolServerOu
         {
             $expectedFiles = @(
                 "IntegrationTest: count=$($withSources ? 3 : 2)",
-                'Sentry: count=6',
+                'Sentry: count=8',
                 "UnityFramework: count=$($withSources ? 4 : 3)",
                 'libiPhone-lib.dylib: count=1'
             )

--- a/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Sentry.Unity.Tests
+{
+    public class ScreenshotAttachmentTests : DisabledSelfInitializationTests
+    {
+        private class Fixture
+        {
+            public SentryUnityOptions Options = new(attachScreenshot: true);
+            public bool IsMainThread = true;
+
+            public ScreenshotAttachmentContent GetSut()
+            {
+                var gameObject = new GameObject("TestSentryMonoBehaviour");
+                var sentryMonoBehaviour = gameObject.AddComponent<SentryMonoBehaviour>();
+                sentryMonoBehaviour.IsMainThread = () => IsMainThread;
+
+                return new ScreenshotAttachmentContent(Options, sentryMonoBehaviour);
+            }
+        }
+
+        private Fixture _fixture = null!;
+
+        [SetUp]
+        public new void Setup() => _fixture = new Fixture();
+
+        [Test]
+        [TestCase(ScreenshotQuality.High, 1920)]
+        [TestCase(ScreenshotQuality.Medium, 1280)]
+        [TestCase(ScreenshotQuality.Low, 854)]
+        public void GetTargetResolution_ReturnsTargetMaxSize(ScreenshotQuality quality, int expectedValue)
+        {
+            var actualValue = ScreenshotAttachmentContent.GetTargetResolution(quality);
+
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [Test]
+        public void GetStream_IsMainThread_ReturnsStream()
+        {
+            _fixture.IsMainThread = true;
+            var sut = _fixture.GetSut();
+
+            var stream = sut.GetStream();
+
+            Assert.IsNotNull(stream);
+        }
+
+        [Test]
+        public void GetStream_IsNonMainThread_ReturnsNullStream()
+        {
+            _fixture.IsMainThread = false;
+            var sut = _fixture.GetSut();
+
+            var stream = sut.GetStream();
+
+            Assert.AreEqual(Stream.Null, stream);
+        }
+
+        [Test]
+        [TestCase(ScreenshotQuality.High, 1920)]
+        [TestCase(ScreenshotQuality.Medium, 1280)]
+        [TestCase(ScreenshotQuality.Low, 854)]
+        public void CaptureScreenshot_QualitySet_ScreenshotDoesNotExceedDimensionLimit(ScreenshotQuality quality, int maximumAllowedDimension)
+        {
+            _fixture.Options.ScreenshotQuality = quality;
+            var sut = _fixture.GetSut();
+
+            var bytes = sut.CaptureScreenshot(2000, 2000);
+            var texture = new Texture2D(1,1); // Size does not matter. Will be overwritten by loading
+            texture.LoadImage(bytes);
+
+            Assert.IsTrue(texture.width <= maximumAllowedDimension && texture.height <= maximumAllowedDimension);
+        }
+
+        [Test]
+        public void CaptureScreenshot_QualitySetToFull_ScreenshotInFullSize()
+        {
+            var testScreenSize = 2000;
+            _fixture.Options.ScreenshotQuality = ScreenshotQuality.Full;
+            var sut = _fixture.GetSut();
+
+            var bytes = sut.CaptureScreenshot(testScreenSize, testScreenSize);
+            var texture = new Texture2D(1,1); // Size does not matter. Will be overwritten by loading
+            texture.LoadImage(bytes);
+
+            Assert.IsTrue(texture.width == testScreenSize && texture.height == testScreenSize);
+        }
+    }
+}

--- a/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
@@ -9,7 +9,7 @@ namespace Sentry.Unity.Tests
     {
         private class Fixture
         {
-            public SentryUnityOptions Options = new() {AttachScreenshot = true};
+            public SentryUnityOptions Options = new() { AttachScreenshot = true };
             public bool IsMainThread = true;
 
             public ScreenshotAttachmentContent GetSut()
@@ -70,7 +70,7 @@ namespace Sentry.Unity.Tests
             var sut = _fixture.GetSut();
 
             var bytes = sut.CaptureScreenshot(2000, 2000);
-            var texture = new Texture2D(1,1); // Size does not matter. Will be overwritten by loading
+            var texture = new Texture2D(1, 1); // Size does not matter. Will be overwritten by loading
             texture.LoadImage(bytes);
 
             Assert.IsTrue(texture.width <= maximumAllowedDimension && texture.height <= maximumAllowedDimension);
@@ -84,7 +84,7 @@ namespace Sentry.Unity.Tests
             var sut = _fixture.GetSut();
 
             var bytes = sut.CaptureScreenshot(testScreenSize, testScreenSize);
-            var texture = new Texture2D(1,1); // Size does not matter. Will be overwritten by loading
+            var texture = new Texture2D(1, 1); // Size does not matter. Will be overwritten by loading
             texture.LoadImage(bytes);
 
             Assert.IsTrue(texture.width == testScreenSize && texture.height == testScreenSize);

--- a/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
@@ -9,7 +9,7 @@ namespace Sentry.Unity.Tests
     {
         private class Fixture
         {
-            public SentryUnityOptions Options = new(attachScreenshot: true);
+            public SentryUnityOptions Options = new() {AttachScreenshot = true};
             public bool IsMainThread = true;
 
             public ScreenshotAttachmentContent GetSut()


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/914
Note: We already discussed if we should not have an API to query the `IsMainThread` the SDK uses internally. Maybe this might be reused?

#skip-changelog