### PR TITLE
ci: Add action to generate stackaid.json

### DIFF
--- a/.github/workflows/stackaid.yml
+++ b/.github/workflows/stackaid.yml
@@ -1,0 +1,11 @@
+name: 'fund-on-stackaid'
+on:
+  push:
+    branches:
+      - main
+jobs:
+  stackaid-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: stackaid/generate-stackaid-json@v1.9


### PR DESCRIPTION
This action will generate a stackaid.json file, listing the dependencies that Sentry wants to fund on StackAid. FYI, I'm one of the @stackaid founders helping @chadwhitacre setup Sentry's funding.