### PR TITLE
chore: Updated `TargetFramework`handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,8 @@ jobs:
 
       - name: Load env
         id: env
-        run: |
-          UNITY_VERSION=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")
-          echo "UNITY_VERSION=${UNITY_VERSION}" >> $GITHUB_ENV
-        
+        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
+
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
       - name: Restore Unity Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       matrix:
         # Building the SDK with Unity 2022 requires ns2.1 - skipping for now
         unity-version: ['2019', '2020', '2021']
-      env:
-        UNITY_VERSION: ${{ matrix.unity-version }}
+    env:
+      UNITY_VERSION: ${{ matrix.unity-version }}
     steps:
       - name: Hello
         run: echo $env:UNITY_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,7 @@ jobs:
       matrix:
         # Building the SDK with Unity 2022 requires ns2.1 - skipping for now
         unity-version: ['2019', '2020', '2021']
-    env:
-      UNITY_VERSION: ${{ matrix.unity-version }}
     steps:
-      - name: Hello
-        run: echo $env:UNITY_VERSION
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -66,8 +61,10 @@ jobs:
 
       - name: Load env
         id: env
-        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
-
+        run: |
+          echo "{UNITY_VERSION}={$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")}" >> $GITHUB_ENV
+          echo "unityVersion=$GITHUB_ENV:UNITY_VERSION" >> $env:GITHUB_OUTPUT
+          
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
       - name: Restore Unity Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Load env
         id: env
         run: |
-          echo "{UNITY_VERSION}={$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")}" >> $GITHUB_ENV
-          echo "unityVersion=$GITHUB_ENV:UNITY_VERSION" >> $env:GITHUB_OUTPUT
+          UNITY_VERSION=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")
+          echo "UNITY_VERSION=${UNITY_VERSION}" >> $GITHUB_ENV
           
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           UNITY_VERSION=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")
           echo "UNITY_VERSION=${UNITY_VERSION}" >> $GITHUB_ENV
-          
+        
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
       - name: Restore Unity Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
       matrix:
         # Building the SDK with Unity 2022 requires ns2.1 - skipping for now
         unity-version: ['2019', '2020', '2021']
+      env:
+        UNITY_VERSION: ${{ matrix.unity-version }}
     steps:
+      - name: Hello
+        run: echo $env:UNITY_VERSION
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,11 +5,11 @@
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([System.Environment]::GetEnvironmentVariable('unityVersion')) != ''">
+  <PropertyGroup Condition="$(UNITY_VERSION) != ''">
     <UnityVersion>$(UNITY_VERSION)</UnityVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([System.Environment]::GetEnvironmentVariable('unityVersion')) == ''">
+  <PropertyGroup Condition="$(UNITY_VERSION) == ''">
     <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
     <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
     <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,26 +9,18 @@
     <DevPackageFolderName>package-dev</DevPackageFolderName>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
-    <!-- Must be set here but will be overwritten below once the UnityVersion is ±resolved -->
-    <!-- When using Unity 2022 the default will change to netstandard2.1 -->
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <!-- Might be overwritten below in 'ResetTargetFrameworks' for older Unity versions -->
+    <TargetFramework>netstandard2.1</TargetFramework>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <!-- Note: for ./tests directory, this target is overwritten -->
   <Target Name="ResetTargetFrameworks" DependsOnTargets="FindUnity" BeforeTargets="CollectPackageReferences">
-    <!-- Blocked by https://github.com/getsentry/sentry-unity/issues/513 -->
-    <!-- With 2022 Unity packages are already targeting ns2.1 and Unity itself only has that as an option so we must target ns2.1 here too: -->
-    <!-- <PropertyGroup Condition="$(UnityVersion.StartsWith('2021.2')) or $(UnityVersion.StartsWith('2022'))">
-      <TargetFrameworks>netstandard2.1</TargetFrameworks>
-    </PropertyGroup> -->
-    <!-- Lowest version supported at this time is 2019 and up to 2021 ns2.0 is the only option. -->
-    <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020')) or $(UnityVersion.StartsWith('2021.1'))">
-      <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <!-- The default for versions 2019 and 2020 is ns2.0 -->
+    <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
+      <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
-    <!-- Being specific on which Unity version we support allows us to quickly ajust these settings when adding support to new editors.
-    Future 2022 or 2023 versions likely will target net6.0 so not rolling forward. Instead break the build here. -->
-    <Message Text="Selected TFM: $(TargetFrameworks) for Unity version $(UnityVersion), project: $(MSBuildProjectName)" Importance="High" />
+    <Message Text="Selected TFM: $(TargetFramework) for Unity version $(UnityVersion), project: $(MSBuildProjectName)" Importance="High" />
   </Target>
 
   <ItemGroup>
@@ -40,8 +32,8 @@
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->
   <Target Name="ReferenceUnity" DependsOnTargets="FindUnity" BeforeTargets="BeforeResolveReferences">
-    <Error Condition="'$(UnityManagedPath)' == ''" Text="'UnityManagedPath' not defined. Can't find UnityEngine.dll."></Error>
-    <Error Condition="!Exists('$(UnityManagedPath)/UnityEngine.dll')" Text="Couldn't find UnityEngine at $(UnityManagedPath)/UnityEngine.dll."></Error>
+    <Error Condition="'$(UnityManagedPath)' == ''" Text="'UnityManagedPath' not defined. Can't find UnityEngine.dll." />
+    <Error Condition="!Exists('$(UnityManagedPath)/UnityEngine.dll')" Text="Couldn't find UnityEngine at $(UnityManagedPath)/UnityEngine.dll." />
     <ItemGroup>
       <Reference Include="UnityEngine">
         <HintPath>$(UnityManagedPath)/UnityEngine.dll</HintPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <Version>0.25.1</Version>
+
+    <!-- TODO: why are we doing this-->
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
+    <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
+    <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
+    <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>
+
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -9,19 +16,16 @@
     <DevPackageFolderName>package-dev</DevPackageFolderName>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
-    <!-- Might be overwritten below in 'ResetTargetFrameworks' for older Unity versions -->
-    <TargetFramework>netstandard2.1</TargetFramework>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
-  <!-- Note: for ./tests directory, this target is overwritten -->
-  <Target Name="ResetTargetFrameworks" DependsOnTargets="FindUnity" BeforeTargets="CollectPackageReferences">
-    <!-- The default for versions 2019 and 2020 is ns2.0 -->
-    <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
-      <TargetFramework>netstandard2.0</TargetFramework>
-    </PropertyGroup>
-    <Message Text="Selected TFM: $(TargetFramework) for Unity version $(UnityVersion), project: $(MSBuildProjectName)" Importance="High" />
-  </Target>
+  <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(UnityVersion.StartsWith('2021')) or $(UnityVersion.StartsWith('2022'))">
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
@@ -29,6 +33,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.0" PrivateAssets="All" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <Target Name="PrintVersions" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
+    <Message Text="%0aBuilding the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)%0a" Importance="High" />
+  </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->
   <Target Name="ReferenceUnity" DependsOnTargets="FindUnity" BeforeTargets="BeforeResolveReferences">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,11 +5,11 @@
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(UNITY_VERSION) != ''">
+  <PropertyGroup Condition="$([System.Environment]::GetEnvironmentVariable('unityVersion')) != ''">
     <UnityVersion>$(UNITY_VERSION)</UnityVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(UNITY_VERSION) == ''">
+  <PropertyGroup Condition="$([System.Environment]::GetEnvironmentVariable('unityVersion')) == ''">
     <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
     <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
     <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,20 +1,4 @@
 <Project>
-
-  <PropertyGroup>
-    <!-- TODO: why are we doing this-->
-    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(UNITY_VERSION) != ''">
-    <UnityVersion>$(UNITY_VERSION)</UnityVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(UNITY_VERSION) == ''">
-    <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
-    <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
-    <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>
-  </PropertyGroup>
-
   <PropertyGroup>
     <Version>0.25.1</Version>
     <LangVersion>9</LangVersion>
@@ -25,6 +9,19 @@
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
     <SignAssembly>false</SignAssembly>
+    <!-- The RepoRoot gets used in the conditional propertygroup for finding the Unity version -->
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
+  </PropertyGroup>
+
+  <!-- With this it's possible for the local environment (i.e. CI) to override the version  -->
+  <PropertyGroup Condition="$(UNITY_VERSION) != ''">
+    <UnityVersion>$(UNITY_VERSION)</UnityVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(UNITY_VERSION) == ''">
+    <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
+    <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
+    <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
@@ -44,7 +41,6 @@
 
   <Target Name="PrintVersions" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
     <Message Text="%0aBuilding the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)%0a" Importance="High" />
-    <Message Text="HUE: $(Fake)" Importance="High" />
   </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,22 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.25.1</Version>
-
     <!-- TODO: why are we doing this-->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(UNITY_VERSION) != ''">
+    <UnityVersion>$(UNITY_VERSION)</UnityVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(UNITY_VERSION) == ''">
     <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
     <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
     <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>
+  </PropertyGroup>
 
+  <PropertyGroup>
+    <Version>0.25.1</Version>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -36,6 +44,7 @@
 
   <Target Name="PrintVersions" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
     <Message Text="%0aBuilding the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)%0a" Importance="High" />
+    <Message Text="HUE: $(Fake)" Importance="High" />
   </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,10 @@
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
     <SignAssembly>false</SignAssembly>
+
+    <!-- This is the default for our lowest supported version 2019 LTS: netstandard2.0 -->
+    <!-- It gets overridden in the test/props -->
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- The RepoRoot gets used in the conditional propertygroup for finding the Unity version -->
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
   </PropertyGroup>
@@ -18,18 +22,11 @@
     <UnityVersion>$(UNITY_VERSION)</UnityVersion>
   </PropertyGroup>
 
+  <!-- If there is no Unity version in the environment we default to reading it from the settings of the samples project -->
   <PropertyGroup Condition="$(UNITY_VERSION) == ''">
     <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
     <ProjectSettingsFileContent>$([System.IO.File]::ReadAllText($(UnitySampleProjectUnityVersion)))</ProjectSettingsFileContent>
     <UnityVersion>$([System.Text.RegularExpressions.Regex]::Match("$(ProjectSettingsFileContent)", ": +([^\s]+)").Groups[1].Value)</UnityVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(UnityVersion.StartsWith('2021')) or $(UnityVersion.StartsWith('2022'))">
-    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,10 +35,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.0" PrivateAssets="All" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
-
-  <Target Name="PrintVersions" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
-    <Message Text="%0aBuilding the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)%0a" Importance="High" />
-  </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->
   <Target Name="ReferenceUnity" DependsOnTargets="FindUnity" BeforeTargets="BeforeResolveReferences">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project InitialTargets="FindUnity">
+<Project>
   <PropertyGroup>
     <!-- Assumes building projects in this repo (not submodules). i.e: src/Sentry.Unity -->
     <UnitySampleProjectPath>$(MSBuildProjectDirectory)/../../samples/unity-of-bugs/</UnitySampleProjectPath>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project InitialTargets="FindUnity">
   <PropertyGroup>
     <!-- Assumes building projects in this repo (not submodules). i.e: src/Sentry.Unity -->
     <UnitySampleProjectPath>$(MSBuildProjectDirectory)/../../samples/unity-of-bugs/</UnitySampleProjectPath>
@@ -8,8 +8,6 @@
     <IOSBuildMethod>Builder.BuildIOSPlayer</IOSBuildMethod>
     <IOSBuildPath>$(PlayerBuildPath)iOS/Xcode</IOSBuildPath>
     <!-- Assumes running `dotnet` from the root of the repo: -->
-    <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))/</RepoRoot>
-    <UnitySampleProjectUnityVersion>$(RepoRoot)samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt</UnitySampleProjectUnityVersion>
     <UnityTestPlayModeResultFilePath>../../artifacts/test/playmode/results.xml</UnityTestPlayModeResultFilePath>
     <UnityTestEditModeResultFilePath>../../artifacts/test/editmode/results.xml</UnityTestEditModeResultFilePath>
     <SentryArtifactsDestination>$(RepoRoot)package-dev/Plugins/</SentryArtifactsDestination>
@@ -26,15 +24,8 @@
     <SentryWindowsArtifactsDestination>$(SentryArtifactsDestination)Windows/Sentry/</SentryWindowsArtifactsDestination>
   </PropertyGroup>
 
-  <Target Name="BuildSentry">
-
-  </Target>
-
   <!-- Use the Unity Editor version set in the sample project of the repo -->
-  <Target Name="FindUnity" BeforeTargets="Build">
-    <LocateUnityVersion ProjectSettingsPath="$(UnitySampleProjectUnityVersion)">
-      <Output PropertyName="UnityVersion" TaskParameter="UnityVersion" />
-    </LocateUnityVersion>
+  <Target Name="FindUnity">
     <Message Text="Unity Version: $(UnityVersion)" Importance="Normal" />
 
     <!-- Unity paths on Windows -->
@@ -349,52 +340,6 @@ Related: https://forum.unity.com/threads/6572-debugger-agent-unable-to-listen-on
     <Exec EnvironmentVariables="IgnoreExitCode=true" IgnoreStandardErrorWarningFormat="true" Command="pwsh &quot;$(RepoRoot)scripts/unity.ps1&quot; $(UnityExec) -batchmode -nographics -runTests -testPlatform EditMode -projectPath $(UnitySampleProjectPath) -testResults $(UnityTestEditModeResultFilePath)"/>
     <UnityTestResults Path="$(UnityTestEditModeResultFilePath)" />
   </Target>
-
-  <!-- Read Unity Version -->
-  <UsingTask TaskName="LocateUnityVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <ProjectSettingsPath ParameterType="System.String" Required="true" />
-      <UnityVersion ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-
-    <Task>
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Linq" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-if (Environment.GetEnvironmentVariable("UNITY_VERSION") is { } unityVersion)
-{
-    Log.LogMessage("Unity Version from environment variable: " + unityVersion);
-    UnityVersion = unityVersion;
-    return true;
-}
-
-if (Environment.GetEnvironmentVariable("UNITY_PATH") is { } unityPath)
-{
-    UnityVersion = File.ReadAllText(unityPath + "/version").Trim();
-    Log.LogMessage("Unity Version from path " + unityPath + " is: " + UnityVersion);
-    return true;
-}
-
-if (!File.Exists(ProjectSettingsPath))
-{
-    Log.LogError("Can't find Unity version because project settings file not found at " + ProjectSettingsPath);
-    return false;
-}
-
-var version = File.ReadLines(ProjectSettingsPath).FirstOrDefault(l => l.StartsWith("m_EditorVersion: "));
-if (version == null)
-{
-    Log.LogError("Unity version not found in file: " + ProjectSettingsPath);
-    return false;
-}
-UnityVersion = version.Substring("m_EditorVersion: ".Length);
-
-Log.LogMessage("Unity Version: " + version);
-]]>
-      </Code>
-    </Task>
-  </UsingTask>
 
   <!-- Locate the TestRunner.dlls by filling the wildcard with the template version number. 3d is the default template -->
   <UsingTask TaskName="LocateTestRunner" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -317,10 +317,10 @@ Related: https://forum.unity.com/threads/6572-debugger-agent-unable-to-listen-on
   </Target>
 
   <!-- Run PlayMode tests with dotnet msbuild /t:UnityPlayModeTest test/Sentry.Unity.Tests -->
-  <Target Name="UnityPlayModeTest" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Tests'">
+  <Target Name="UnityPlayModeTest" DependsOnTargets="FindUnity" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Tests'">
     <Error Condition="$(UnityExec) == ''" Text="Couldn't find Unity." />
 
-    <Message Importance="High" Text="Running Unity PlayMode tests."></Message>
+    <Message Importance="High" Text="Running Unity PlayMode tests." />
 
     <!-- Unity exits with a non-zero exit code when running tests. We ignore it and manually check the test results instead. -->
     <Delete Files="$(UnityTestPlayModeResultFilePath)" />
@@ -329,10 +329,10 @@ Related: https://forum.unity.com/threads/6572-debugger-agent-unable-to-listen-on
   </Target>
 
   <!-- Run EditMode tests with dotnet msbuild /t:UnityEditModeTest test/Sentry.Unity.Editor.Tests -->
-  <Target Name="UnityEditModeTest" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Editor.Tests'">
+  <Target Name="UnityEditModeTest" DependsOnTargets="FindUnity" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Editor.Tests'">
     <Error Condition="$(UnityExec) == ''" Text="Couldn't find Unity." />
 
-    <Message Importance="High" Text="Running Unity EditMode tests."></Message>
+    <Message Importance="High" Text="Running Unity EditMode tests." />
 
     <!-- Unity exits with a non-zero exit code when running tests. We ignore it and manually check the test results instead. -->
     <!-- IgnoreStandardErrorWarningFormat="true" because of the intentional compilation error printed in GenerateOptions_NewSentryOptionsGarbageAppended_FailsToCompile(). -->

--- a/scripts/ci-docker.sh
+++ b/scripts/ci-docker.sh
@@ -35,7 +35,7 @@ docker run -td --name $container \
     -v $JAVA_HOME_11_X64:$JAVA_HOME_11_X64 \
     -v /usr/share/dotnet:/usr/share/dotnet \
     -v /opt/microsoft/powershell/7:/opt/microsoft/powershell/7 \
-    -e UNITY_VERSION=unityVersion \
+    -e UNITY_VERSION=$unityVersion \
     --workdir /sentry-unity $image
 
 $suexec $container groupadd -g $gid $user

--- a/scripts/ci-docker.sh
+++ b/scripts/ci-docker.sh
@@ -35,6 +35,7 @@ docker run -td --name $container \
     -v $JAVA_HOME_11_X64:$JAVA_HOME_11_X64 \
     -v /usr/share/dotnet:/usr/share/dotnet \
     -v /opt/microsoft/powershell/7:/opt/microsoft/powershell/7 \
+    -e UNITY_VERSION=unityVersion \
     --workdir /sentry-unity $image
 
 $suexec $container groupadd -g $gid $user

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,4 +7,8 @@
     <PackageEditorPath>$(DevPackagePath)/Editor</PackageEditorPath>
   </PropertyGroup>
 
+  <Target Name="PrintVersions" BeforeTargets="BeforeResolveReferences" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
+    <Message Text="%0aBuilding the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)" Importance="High" />
+  </Target>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <Target Name="PrintVersions" BeforeTargets="BeforeResolveReferences" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'">
-    <Message Text="%0aBuilding the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)" Importance="High" />
+    <Message Text="Building the Unity SDK with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)" Importance="High" />
   </Target>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,11 +8,10 @@
 
   <!-- Note: this OVERWRITES the ResetTargetFrameworks target from the parent dir -->
   <Target Name="ResetTargetFrameworks" DependsOnTargets="FindUnity">
-    <!-- With 2022 Unity packages are already targeting ns2.1 and Unity itself only has that as an option so we must target ns2.1 here too: -->
-    <PropertyGroup Condition="$(UnityVersion.StartsWith('2021')) or $(UnityVersion.StartsWith('2022'))">
-      <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
+      <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
-    <Message Text="Selected TFM: $(TargetFrameworks) for Unity version $(UnityVersion), project: $(MSBuildProjectName)" Importance="High" />
+    <Message Text="Selected TFM: $(TargetFramework) for Unity version $(UnityVersion), project: $(MSBuildProjectName)" Importance="High" />
   </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,18 +1,10 @@
-<Project InitialTargets="ResetTargetFrameworks">
+<Project>
   <Import Project="../Directory.Build.props" />
 
   <PropertyGroup>
     <PackageRuntimeTestsPath>../../$(DevPackageFolderName)/Tests/Runtime</PackageRuntimeTestsPath>
     <PackageEditorTestsPath>../../$(DevPackageFolderName)/Tests/Editor</PackageEditorTestsPath>
   </PropertyGroup>
-
-  <!-- Note: this OVERWRITES the ResetTargetFrameworks target from the parent dir -->
-  <Target Name="ResetTargetFrameworks" DependsOnTargets="FindUnity">
-    <PropertyGroup Condition="$(UnityVersion.StartsWith('2019')) or $(UnityVersion.StartsWith('2020'))">
-      <TargetFramework>netstandard2.0</TargetFramework>
-    </PropertyGroup>
-    <Message Text="Selected TFM: $(TargetFramework) for Unity version $(UnityVersion), project: $(MSBuildProjectName)" Importance="High" />
-  </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->
   <Target Name="ReferenceUnityEditor" BeforeTargets="BeforeResolveReferences">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -39,7 +39,7 @@
         <Private>false</Private>
       </Reference>
     </ItemGroup>
-    <Error Condition="!Exists('$(UnityTemplateAssemblyPath)/UnityEngine.TestRunner.dll')" Text="TestRunner not found. Expected: $(UnityTemplateAssemblyPath)/UnityEngine.TestRunner.dll"></Error>
+    <Error Condition="!Exists('$(UnityTemplateAssemblyPath)/UnityEngine.TestRunner.dll')" Text="TestRunner not found. Expected: $(UnityTemplateAssemblyPath)/UnityEngine.TestRunner.dll" />
   </Target>
 
   <PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <Target Name="PrintVersions" BeforeTargets="BeforeResolveReferences" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Tests'">
-    <Message Text="%0aBuilding the Tests with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)" Importance="High" />
+    <Message Text="Building the Tests with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)" Importance="High" />
   </Target>
 
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,6 +6,15 @@
     <PackageEditorTestsPath>../../$(DevPackageFolderName)/Tests/Editor</PackageEditorTestsPath>
   </PropertyGroup>
 
+  <!-- Starting with the 2021 LTS Unity's TestRunner targets netstandard2.1 -->
+  <PropertyGroup Condition="$(UnityVersion.StartsWith('2021')) or $(UnityVersion.StartsWith('2022'))">
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name="PrintVersions" BeforeTargets="BeforeResolveReferences" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Tests'">
+    <Message Text="%0aBuilding the Tests with:%0a    UnityVersion: $(UnityVersion)%0a    TargetFramework: $(TargetFramework)" Importance="High" />
+  </Target>
+
   <!-- Add reference once we figure out where the DLL is (find Unity version and install location) -->
   <Target Name="ReferenceUnityEditor" BeforeTargets="BeforeResolveReferences">
     <ItemGroup>


### PR DESCRIPTION
The context:
Building the SDK depends on the `TestRunner.dll` that comes with the Unity installation. Which version of Unity depends on the version that last [last opened the sample project](https://github.com/getsentry/sentry-unity/blob/b37e98159bf94cc165d2a0ddb23e41771b59bff2/Directory.Build.targets#L354) (locally, 2019 by default) or that has been set in the environment.

With the 2021 LTS and 2022 going forward, `TestRunner.dll` starts depending on netstandard2.1. This creates issues when trying to build the Tests.

The problem:
Setting the default target framework in the `PropertyGroup` and then overwriting it within a target seems to create some order of execution related issues. The overwritten version would be set to the variable but (somehow?) not get applied when actually building. That's also why we can't skip assigning a default TFM in the first place.

We also can't conditionally modify the `PropertyGroup` itself because we rely on the `FindUnity` target and the `LocateUnityVersion` task to run first. The output of those is not available when `PropertyGroups` get validated.

The solution:
With the new approach, we make use of `property functions` to grab the Unity version from the project settings file when needed. With this, we are no longer bound to running some targets and we are able to modify property groups themselves conditionally. (i.e. only in the tests props).

The new buildlog:
```
➜  sentry-unity git:(chore/default-targetframework) ✗ dotnet build
MSBuild version 17.3.0+92e077650 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
  Sentry -> /Users/bitfox/Workspace/sentry-unity/src/sentry-dotnet/src/Sentry/bin/Debug/netstandard2.0/Sentry.dll
  Building the Unity SDK with:
      UnityVersion: 2021.3.13f1
      TargetFramework: netstandard2.0
  Building the Tests with:
      UnityVersion: 2021.3.13f1
      TargetFramework: netstandard2.1
  Sentry.Unity -> /Users/bitfox/Workspace/sentry-unity/package-dev/Runtime/Sentry.Unity.dll
  Sentry.Unity.Android -> /Users/bitfox/Workspace/sentry-unity/package-dev/Runtime/Sentry.Unity.Android.dll
  Sentry.Unity.Native -> /Users/bitfox/Workspace/sentry-unity/package-dev/Runtime/Sentry.Unity.Native.dll
  Sentry.Unity.Editor -> /Users/bitfox/Workspace/sentry-unity/package-dev/Editor/Sentry.Unity.Editor.dll
  Sentry.Unity.Tests -> /Users/bitfox/Workspace/sentry-unity/package-dev/Tests/Runtime/Sentry.Unity.Tests.dll
  Sentry.Unity.iOS -> /Users/bitfox/Workspace/sentry-unity/package-dev/Runtime/Sentry.Unity.iOS.dll
  Sentry.Unity.Android.Tests -> /Users/bitfox/Workspace/sentry-unity/package-dev/Tests/Runtime/Sentry.Unity.Android.Tests.dll
  Sentry.Unity.Editor.iOS -> /Users/bitfox/Workspace/sentry-unity/package-dev/Editor/iOS/Sentry.Unity.Editor.iOS.dll
  Sentry.Unity.Editor.Tests -> /Users/bitfox/Workspace/sentry-unity/package-dev/Tests/Editor/Sentry.Unity.Editor.Tests.dll
  Sentry.Unity.iOS.Tests -> /Users/bitfox/Workspace/sentry-unity/package-dev/Tests/Runtime/Sentry.Unity.iOS.Tests.dll
  Sentry.Unity.Editor.iOS.Tests -> /Users/bitfox/Workspace/sentry-unity/package-dev/Tests/Editor/Sentry.Unity.Editor.iOS.Tests.dll
```

#skip-changelog