### PR TITLE
ci: don't run all the integration tests on the release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
   # We could just create the project later in `smoke-test-build` but then it's executed for each job in the matrix
   # and reduces concurrency because of Unity licence limits.
   smoke-test-create:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     name: Prepare Smoke Test ${{ matrix.unity-version }}
     runs-on: ubuntu-latest
     needs: [package-validation]
@@ -249,6 +250,7 @@ jobs:
 
   # A Linux, docker-based build to prepare a game ("player") for some platforms. The tests run in `smoke-test-run`.
   smoke-test-build:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     name: Build ${{ matrix.platform }} Smoke Test - ${{ matrix.unity-version }}
     needs: [smoke-test-create]
     runs-on: ubuntu-latest
@@ -322,6 +324,7 @@ jobs:
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
 
   desktop-smoke-test:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     name: Run ${{ matrix.os }} Smoke Test - ${{ matrix.unity-version }}
     needs: [smoke-test-create]
     runs-on: ${{ matrix.os }}-latest
@@ -396,6 +399,7 @@ jobs:
         run: ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Crash
 
   android-smoke-test:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [smoke-test-build]
     name: Run Android ${{ matrix.api-level }} Unity ${{ matrix.unity-version }} Smoke Test
     runs-on: macos-latest
@@ -509,6 +513,7 @@ jobs:
           path: ${{ env.ARTIFACTS_PATH }}
 
   ios-smoke-test-build:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [smoke-test-build]
     name: Compile iOS Smoke Test - ${{ matrix.unity-version }}
     runs-on: macos-latest
@@ -540,6 +545,7 @@ jobs:
             !**/Release-iphonesimulator/UnityFramework.framework/*
 
   ios-smoke-test-run:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [ios-smoke-test-build]
     name: Run iOS ${{ matrix.ios }} Smoke Test - ${{ matrix.unity-version }}
     runs-on: macos-12
@@ -594,6 +600,7 @@ jobs:
           ./Scripts/smoke-test-ios.ps1 Test "$runtime" -IsIntegrationTest
 
   smoke-test-run:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [smoke-test-build]
     name: Run  ${{ matrix.platform }} Unity ${{ matrix.unity-version }} Smoke Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's all tested already when a release is launched. The integration tests are flaky no matter what we do... This regularly breaks releases. 

Assuming we don't run release when the main branch is not green, it shouldn't be necessary to run integration tests again on the release branch - thus we can make a release faster and without failing all the time.

