### PR TITLE
fix: Symbol upload logging for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed logging for automated debug symbol upload for iOS ([#1091](https://github.com/getsentry/sentry-unity/pull/1091))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v7.30.2 to v7.31.1 ([#1079](https://github.com/getsentry/sentry-unity/pull/1079), [#1082](https://github.com/getsentry/sentry-unity/pull/1082))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Dependencies
 
-- Bump Cocoa SDK from v7.30.2 to v7.31.0 ([#1079](https://github.com/getsentry/sentry-unity/pull/1079))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7310)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.2...7.31.0)
+- Bump Cocoa SDK from v7.30.2 to v7.31.1 ([#1079](https://github.com/getsentry/sentry-unity/pull/1079), [#1082](https://github.com/getsentry/sentry-unity/pull/1082))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7311)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.30.2...7.31.1)
 - Bump CLI from v2.8.1 to v2.9.0 ([#1080](https://github.com/getsentry/sentry-unity/pull/1080))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#290)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.8.1...2.9.0)

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -22,14 +22,8 @@ namespace Sentry.Unity.Editor.iOS
         private readonly string _mainPath = Path.Combine("MainApp", "main.mm");
         private readonly string _optionsPath = Path.Combine("MainApp", OptionsName);
         private readonly string _uploadScript = @"
-
 process_upload_symbols() {{
-    ./{0} --log-level=debug upload-dif {1} --force-foreground $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log
-    if [ ""$?"" -eq ""0"" ] ; then
-        echo ""note: Debug symbol upload successful.""
-    else
-        echo ""error: Debug symbol upload failed. See './sentry-symbols-upload.log' for more information.""
-    fi
+    ./{0} upload-dif --force-foreground {1} $BUILT_PRODUCTS_DIR 2>&1 | tee ./sentry-symbols-upload.log
 }}
 
 export SENTRY_PROPERTIES=sentry.properties

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -24,7 +24,7 @@ namespace Sentry.Unity.Editor.iOS
         private readonly string _uploadScript = @"
 
 process_upload_symbols() {{
-    ./{0} --log-level=debug upload-dif {1} $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log
+    ./{0} --log-level=debug upload-dif {1} --force-foreground $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log
     if [ ""$?"" -eq ""0"" ] ; then
         echo ""note: Debug symbol upload successful.""
     else

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -24,7 +24,7 @@ namespace Sentry.Unity.Editor.iOS
         private readonly string _uploadScript = @"
 
 process_upload_symbols() {{
-    ./{0} --log-level=debug upload-dif {1} $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log &
+    ./{0} --log-level=debug upload-dif {1} $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log
     if [ ""$?"" -eq ""0"" ] ; then
         echo ""note: Debug symbol upload successful.""
     else

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -25,7 +25,7 @@ namespace Sentry.Unity.Editor.iOS
 
 process_upload_symbols() {{
     ./{0} --log-level=debug upload-dif {1} $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log &
-    if [ $? -eq 0] ; then
+    if [ $? -eq ""0"" ] ; then
         echo ""note: Debug symbol upload successful.""
     else
         echo ""error: Debug symbol upload failed. See './sentry-symbols-upload.log' for more information.""

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -28,15 +28,15 @@ process_upload_symbols() {{
 
 export SENTRY_PROPERTIES=sentry.properties
 if [ ""$ENABLE_BITCODE"" = ""NO"" ] ; then
-    echo ""note: Uploading debug symbols (Bitcode disabled).""
+    echo ""Uploading debug symbols (Bitcode disabled).""
     process_upload_symbols
 else
     echo ""Bitcode is enabled""
     if [ ""$ACTION"" = ""install"" ] ; then
-        echo ""note: Uploading debug symbols and bcsymbolmaps (Bitcode enabled).""
+        echo ""Uploading debug symbols and bcsymbolmaps (Bitcode enabled).""
         process_upload_symbols
     else
-        echo ""note: Skipping debug symbol upload because Bitcode is enabled and this is a non-install build.""
+        echo ""Skipping debug symbol upload because Bitcode is enabled and this is a non-install build.""
     fi
 fi
 ";

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -24,7 +24,12 @@ namespace Sentry.Unity.Editor.iOS
         private readonly string _uploadScript = @"
 
 process_upload_symbols() {{
-    ./{0} --log-level=info upload-dif {1} $BUILT_PRODUCTS_DIR 2>&1 | tee ./sentry-symbols-upload.log
+    ./{0} --log-level=debug upload-dif {1} $BUILT_PRODUCTS_DIR &> sentry-symbols-upload.log &
+    if [ $? -eq 0] ; then
+        echo ""note: Debug symbol upload successful.""
+    else
+        echo ""error: Debug symbol upload failed. See './sentry-symbols-upload.log' for more information.""
+    fi
 }}
 
 export SENTRY_PROPERTIES=sentry.properties

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -77,7 +77,7 @@ namespace Sentry.Unity
 
         [field: SerializeField] public Sentry.Unity.ScriptableOptionsConfiguration? OptionsConfiguration { get; set; }
 
-        /// Actual type is `Sentry.Unity.Editor.ScriptableOptionsConfiguration` but we can't reference it here because we don't depend on the editor Assembly.
+        // Actual type is `Sentry.Unity.Editor.ScriptableOptionsConfiguration` but we can't reference it here because we don't depend on the editor Assembly.
         [field: SerializeField] public ScriptableObject? BuildtimeOptionsConfiguration { get; set; }
 
         [field: SerializeField] public bool Debug { get; set; } = true;

--- a/test/Scripts.Integration.Test/common.ps1
+++ b/test/Scripts.Integration.Test/common.ps1
@@ -289,8 +289,8 @@ function CheckSymbolServerOutput([string] $buildMethod, [string] $symbolServerOu
             If ($unity2020OrHigher)
             {
                 $expectedFiles = @(
-                    "libil2cpp.sym.so: count=$($withSources ? 3 : 2)",
-                    "libil2cpp.dbg.so: count=$($withSources ? 2 : 1)"
+                    "libil2cpp.sym.so: count=$($withSources ? 2 : 1)",
+                    "libil2cpp.dbg.so: count=$($withSources ? 3 : 2)"
                 ) + $expectedFiles
             }
             else

--- a/test/Scripts.Integration.Test/integration-test.ps1
+++ b/test/Scripts.Integration.Test/integration-test.ps1
@@ -67,7 +67,7 @@ If (-not(Test-Path -Path "$NewProjectPath") -Or $Recreate)
     Write-Host "Adding Sentry"
     ./test/Scripts.Integration.Test/add-sentry.ps1 "$UnityPath"
     Write-Host "Configuring Sentry"
-    ./test/Scripts.Integration.Test/configure-sentry.ps1 "$UnityPath" -Platform $Platform
+    ./test/Scripts.Integration.Test/configure-sentry.ps1 "$UnityPath" -Platform $Platform -CheckSymbols
 }
 
 $buildDir = "Samples/IntegrationTest/Build"


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1071
- Forcing the symbol upload in the foreground to have the logs available in the Xcode console.
- Removing the log level from the command because we write it into the `.properties` already
- Removed `note:` because it was messing with the order of logs