### PR TITLE
fix: Native layer not closing

### DIFF
--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -108,6 +108,15 @@ namespace Sentry.Unity
                 }
 #endif
             }
+            else
+            {
+                // Closing down the native layer that are set up during build and self-initialize
+#if SENTRY_NATIVE_COCOA
+                    SentryNativeCocoa.Close(options.DiagnosticLogger);
+#elif SENTRY_NATIVE_ANDROID
+                    SentryNativeAndroid.Close(options.DiagnosticLogger);
+#endif
+            }
         }
     }
 

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -53,15 +53,20 @@ namespace Sentry.Unity.Android
                         "Failed to reinstall backend. Captured native crashes will miss scope data and tag.", e);
                 }
 
-                ApplicationAdapter.Instance.Quitting += () =>
-                {
-                    // Sentry Native is initialized and closed by the Java SDK, no need to call into it directly
-                    options.DiagnosticLogger?.LogDebug("Closing the sentry-java SDK");
-                    SentryJava.Close();
-                };
+                ApplicationAdapter.Instance.Quitting += () => Close(options.DiagnosticLogger);
 
                 options.DefaultUserId = SentryJava.GetInstallationId();
             }
+        }
+
+        /// <summary>
+        /// Closes the native Android support.
+        /// </summary>
+        public static void Close(IDiagnosticLogger? logger = null)
+        {
+            // Sentry Native is initialized and closed by the Java SDK, no need to call into it directly
+            logger?.LogDebug("Closing the sentry-java SDK");
+            SentryJava.Close();
         }
     }
 }

--- a/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
+++ b/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
@@ -63,7 +63,7 @@ namespace Sentry.Unity.iOS
         }
 
         /// <summary>
-        /// Closes the native Android support.
+        /// Closes the native Cocoa support.
         /// </summary>
         public static void Close(IDiagnosticLogger? logger = null)
         {

--- a/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
+++ b/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
@@ -55,15 +55,20 @@ namespace Sentry.Unity.iOS
 
                 return crashedLastRun;
             };
-            ApplicationAdapter.Instance.Quitting += () =>
-            {
-                options.DiagnosticLogger?.LogDebug("Closing the sentry-cocoa SDK");
-                SentryCocoaBridgeProxy.Close();
-            };
+            ApplicationAdapter.Instance.Quitting += () => Close(options.DiagnosticLogger);
             if (sentryUnityInfo.IL2CPP)
             {
                 options.DefaultUserId = SentryCocoaBridgeProxy.GetInstallationId();
             }
+        }
+
+        /// <summary>
+        /// Closes the native Android support.
+        /// </summary>
+        public static void Close(IDiagnosticLogger? logger = null)
+        {
+            logger?.LogDebug("Closing the sentry-cocoa SDK");
+            SentryCocoaBridgeProxy.Close();
         }
     }
 }


### PR DESCRIPTION
On mobile, the native layer is getting set up during buildtime and is self-initializing.
If the SDK gets disabled during runtime (i.e. in the `Configure` callback, then the native layer needs to be closed down too.

Something like `SentryUnity.Close()` is still missing, which allows for the programmatic closing of all of Sentry.