### PR TITLE
feat: Mono PDB files upload during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Mono PDB files upload during build ([#1106](https://github.com/getsentry/sentry-unity/pull/1106))
+
 ### Dependencies
 
 - Bump Java SDK from v6.9.1 to v6.9.2 ([#1107](https://github.com/getsentry/sentry-unity/pull/1107))

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -153,7 +153,6 @@ namespace Sentry.Unity.Editor.Native
                 if (isMono)
                 {
                     addPath("MonoBleedingEdge/EmbedRuntime");
-                    addFilesMatching($"{projectDir}/Temp", new[] { "**/UnityEngine.*.pdb", "**/Assembly-CSharp.pdb" });
                     addFilesMatching(buildOutputDir, new[] { "*.pdb" });
                 }
                 else
@@ -168,11 +167,17 @@ namespace Sentry.Unity.Editor.Native
                 if (isMono)
                 {
                     addPath(Path.GetFileNameWithoutExtension(executableName) + "_Data/MonoBleedingEdge/x86_64");
+                    addFilesMatching(buildOutputDir, new[] { "*.debug" });
                 }
             }
             else if (target is BuildTarget.StandaloneOSX)
             {
                 addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/macOS/Sentry/Sentry.dylib.dSYM"));
+            }
+
+            if (isMono)
+            {
+                addFilesMatching($"{projectDir}/Temp", new[] { "**/UnityEngine.*.pdb", "**/Assembly-CSharp.pdb" });
             }
 
             var cliArgs = "upload-dif ";

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -162,6 +162,7 @@ namespace Sentry.Unity.Editor.Native
             }
             else if (target is BuildTarget.StandaloneLinux64)
             {
+                addPath("GameAssembly.so");
                 addPath("UnityPlayer.so");
                 addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/Linux/Sentry/libsentry.dbg.so"));
                 if (isMono)

--- a/src/Sentry.Unity.Editor/Sentry.Unity.Editor.csproj
+++ b/src/Sentry.Unity.Editor/Sentry.Unity.Editor.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="../sentry-dotnet/src/Sentry/Sentry.csproj" Private="false" IncludeAssets="compile" />
     <ProjectReference Include="../Sentry.Unity/Sentry.Unity.csproj" Private="false" IncludeAssets="compile" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" Private="false" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -1,5 +1,7 @@
 Documentation~/index.md
 Editor/iOS.meta
+Editor/Microsoft.Extensions.FileSystemGlobbing.dll
+Editor/Microsoft.Extensions.FileSystemGlobbing.dll.meta
 Editor/sentry-cli.meta
 Editor/Sentry.Mono.Cecil.dll
 Editor/Sentry.Mono.Cecil.dll.meta


### PR DESCRIPTION
Closes #1053
This can already be merged but will only start having an effect with https://github.com/getsentry/sentry-dotnet/pull/2050

* Unity 2019 - won't work - PDBs are not available - at least not the right ones, there are some but they don't match the final built app.
* [Windows Unity 2021](https://sentry.io/organizations/sentry-sdks/issues/3300403573/events/c6e25dc2530a45fc9d4a609a3a12c0b4/?project=5439417)
* [Linux Unity 2020](https://sentry.io/organizations/sentry-sdks/issues/3261854748/events/f28c26c23f59401da15a5f4112f5e460/?project=5439417)
* Android not working at the moment, see https://github.com/getsentry/sentry-dotnet/pull/2050#pullrequestreview-1208105473
* [MacOS Unity 2021](https://sentry.io/organizations/sentry-sdks/issues/3261854748/events/3fca11198f5a4584b0519cfbd93b2839/?project=5439417)
* iOS - not applicable
* WebGL - not applicable