### PR TITLE
fix: Removed build guid from `Release`

### DIFF
--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -211,11 +211,7 @@ namespace Sentry.Unity
             {
                 Release = application.Version;
             }
-            if (!string.IsNullOrWhiteSpace(application.BuildGUID))
-            {
-                Release += $"+{application.BuildGUID}";
-            }
-
+            
             Environment = application.IsEditor && !isBuilding
                 ? "editor"
                 : "production";

--- a/test/Sentry.Unity.Tests/SentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityOptionsTests.cs
@@ -44,9 +44,9 @@ namespace Sentry.Unity.Tests
         public void Ctor_IsGlobalModeEnabled_IsTrue() => Assert.IsTrue(_fixture.GetSut().IsGlobalModeEnabled);
 
         [Test]
-        public void Ctor_Release_IsProductNameAtVersionPlusBuild() =>
+        public void Ctor_Release_IsProductNameAtVersion() =>
             Assert.AreEqual(
-                $"{_fixture.Application.ProductName}@{_fixture.Application.Version}+{_fixture.Application.BuildGUID}",
+                $"{_fixture.Application.ProductName}@{_fixture.Application.Version}",
                 _fixture.GetSut().Release);
 
         [Test]


### PR DESCRIPTION
Problem statement:
The `build GUID` is not available during build. So the release we set in the native SDKs during build time does not match the release during runtime. 

I tried looking into retrieving the `build GUID` during the build process from `BuildReport.BuidSummary.guid` but that one does not seem to match `Application.buildGuid` of the app?