### PR TITLE
fix: Not adding the IL2CPP processor when in Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- No longer log warnings about missing IL2CPP methods when running in the Editor ([#1132](https://github.com/getsentry/sentry-unity/pull/1132))
+
 ### Features
 
 - Mono PDB files upload during build ([#1106](https://github.com/getsentry/sentry-unity/pull/1106))

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -191,7 +191,7 @@ namespace Sentry.Unity
                 OptionsConfiguration?.Configure(options);
 
                 // Doing this after the configure callback to allow users to programmatically opt out
-                if (options.Il2CppLineNumberSupportEnabled && unityInfo is not null)
+                if (!application.IsEditor && options.Il2CppLineNumberSupportEnabled && unityInfo is not null)
                 {
                     options.AddIl2CppExceptionProcessor(unityInfo);
                 }


### PR DESCRIPTION
We should not log a warning about not being able to find the IL2CPP methods when running in the Editor.