### PR TITLE
fix: macOS bridge - inlined helpers are static too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixes
 
-- Made inlined helpers on the macOS bridge static ([#148](https://github.com/getsentry/sentry-unity/pull/1148))
 - Fixed conflicting default name for scriptable options configuration scripts ([#1146](https://github.com/getsentry/sentry-unity/pull/1146))
 - Made inlined helpers on the macOS bridge static ([#1148](https://github.com/getsentry/sentry-unity/pull/1148))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Made inlined helpers on the macOS bridge static ([#148](https://github.com/getsentry/sentry-unity/pull/1148))
+
 ### Dependencies
 
 - Bump Java SDK from v6.11.0 to v6.12.1 ([#1143](https://github.com/getsentry/sentry-unity/pull/1143))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ dotnet tool install --global PowerShell
 ### Setup for building the Java SDK
 
 * Install Git and ensure is accessible from the PATH
-* Install Java 11
-  * [Using sdkman](https://sdkman.io/) which manage versions for you. (i.e. `sdk install java 11.0.15-ms`)
+* Install Java 17
+  * [Using sdkman](https://sdkman.io/) which manage versions for you. (i.e. `sdk install java 17.0.5-ms`)
   * Or [download the OpenJDK](https://openjdk.java.net/install/) directly.
 * Add JAVA_HOME to your environment variables (if not using sdkman):
-  * Windows: `setx JAVA_HOME "C:\Program Files\Java\jdk-11.0.11"`
+  * Windows: `setx JAVA_HOME "C:\Program Files\Java\jdk-17.0.5"`
 * Install [Android Studio](https://developer.android.com/studio)
   * Open Android Studio and go to Customize -> All settings...
   * Search for "SDK" in the Seachbar
@@ -39,10 +39,10 @@ dotnet tool install --global PowerShell
   * Install the Android SDK
   * Swap tab to SDK Tools
   * Check "Show Package Details"
-  * Under Android SDK Build-Tools check "30.0.2"
+  * Under Android SDK Build-Tools check "30.0.3"
   * Apply
-* Add ANDROID_SDK_ROOT to your environment variables
-  * macOS zsh: `export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"`
+* Add ANDROID_HOME to your environment variables
+  * macOS zsh: `export ANDROID_HOME="$HOME/Library/Android/sdk"`
   * Windows: `setx ANDROID_HOME "C:\Program Files (x86)\Android\android-sdk"` for a machine wide install, `setx ANDROID_HOME "%localappdata%\Android\Sdk"` for a user level install.
 
 ### Setup for building the Cocoa SDK

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -242,14 +242,17 @@ char *SentryNativeBridgeGetInstallationId()
     return cString;
 }
 
-inline NSString *_NSStringOrNil(const char *value)
+static inline NSString *_NSStringOrNil(const char *value)
 {
     return value ? [NSString stringWithUTF8String:value] : nil;
 }
 
-inline NSString *_NSNumberOrNil(int32_t value) { return value == 0 ? nil : @(value); }
+static inline NSString *_NSNumberOrNil(int32_t value)
+{
+    return value == 0 ? nil : @(value);
+}
 
-inline NSNumber *_NSBoolOrNil(int8_t value)
+static inline NSNumber *_NSBoolOrNil(int8_t value)
 {
     if (value == 0) {
         return @NO;


### PR DESCRIPTION
Aligned the `NS_X_OrNil` methods with the ones from the iOS bridge from [here](https://github.com/getsentry/sentry-unity/pull/932).