### PR TITLE
chore: remove @vaind from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-*       @bitsandfoxes @vaind
-
-# Automatic dependency updates
-/scripts/ci-env.ps1   @bitsandfoxes
-/modules              @bitsandfoxes
+*       @bitsandfoxes


### PR DESCRIPTION
The previous change to whitelist the interesting bits doesn't work and I'm still getting spammed. Let's remove completely.

Still feel free to request review manually, I just don't want all the spam coming from the automatic  subscription to all PRs

#skip-changelog