### PR TITLE
fix: Smoketester timeouts

### DIFF
--- a/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
@@ -11,6 +11,10 @@ using Sentry;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
+#if UNITY_WEBGL
+using System.Web;
+#endif
+
 public class SmokeTester : MonoBehaviour
 {
     private void Awake()


### PR DESCRIPTION
I came across a few odd timeouts in the Smoketester and after consulting @mattjohnsonpint we suspect possible deadlocks due to multi-locking to be the reason for those. 

#skip-changelog