### PR TITLE
chore: New Sentry project

### DIFF
--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: SentryOptions
   m_EditorClassIdentifier: 
   <Enabled>k__BackingField: 1
-  <Dsn>k__BackingField: https://94677106febe46b88b9b9ae5efd18a00@o447951.ingest.sentry.io/5439417
+  <Dsn>k__BackingField: https://e9ee299dbf554dfd930bc5f3c90d5d4b@o447951.ingest.sentry.io/4504604988538880
   <CaptureInEditor>k__BackingField: 1
   <EnableLogDebouncing>k__BackingField: 0
   <TracesSampleRate>k__BackingField: 0
@@ -47,7 +47,7 @@ MonoBehaviour:
   <MacosNativeSupportEnabled>k__BackingField: 1
   <LinuxNativeSupportEnabled>k__BackingField: 1
   <Il2CppLineNumberSupportEnabled>k__BackingField: 1
-  <RuntimeOptionsConfiguration>k__BackingField: {fileID: 11400000, guid: 407b4d5f2fef2c845bf2a3dcdf6b00fb,
+  <OptionsConfiguration>k__BackingField: {fileID: 11400000, guid: 407b4d5f2fef2c845bf2a3dcdf6b00fb,
     type: 2}
   <BuildtimeOptionsConfiguration>k__BackingField: {fileID: 11400000, guid: 6bcc81a646c08ce439ab03805d477458,
     type: 2}


### PR DESCRIPTION
The wizard returns only 50 projects per org, sorted by creation date. And since we're power users here and sentry-unity is kinda old the wizard doesn't work anymore.
New project - same name. 

And I fixed the missing reference that fell through the renaming PR.

#skip-changelog