### PR TITLE
fix: Prevent `LoggingIntegration` from registering multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Preventing `LoggingIntegration` from registering multiple times ([#1178](https://github.com/getsentry/sentry-unity/pull/1178))
 - Fixed the logging integration only capturing tags and missing the message ([#1150](https://github.com/getsentry/sentry-unity/pull/1150))
 
 ### Dependencies

--- a/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs
@@ -28,6 +28,18 @@ namespace Sentry.Unity.Integrations
         {
             _hub = hub;
             _sentryOptions = sentryOptions as SentryUnityOptions;
+            if (_sentryOptions is null)
+            {
+                return;
+            }
+
+            // If called twice (i.e. init with the same options object) the integration will reference itself as the
+            // original handler loghandler and endlessly forward to itself
+            if (Debug.unityLogger.logHandler == this)
+            {
+                _sentryOptions.DiagnosticLogger?.LogWarning("UnityLogHandlerIntegration has already been registered.");
+                return;
+            }
 
             _unityLogHandler = Debug.unityLogger.logHandler;
             Debug.unityLogger.logHandler = this;

--- a/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 using Sentry.Protocol;
 using Sentry.Unity.Integrations;
+using Sentry.Unity.Tests.SharedClasses;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
 
@@ -228,6 +229,22 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(exception.GetType() + ": " + message, breadcrumb.Message);
             Assert.AreEqual("unity.logger", breadcrumb.Category);
             Assert.AreEqual(BreadcrumbLevel.Error, breadcrumb.Level);
+        }
+
+        [Test]
+        public void Register_RegisteredASecondTime_LogsWarningAndReturns()
+        {
+            var testLogger = new TestLogger();
+            _fixture.SentryOptions.DiagnosticLogger = testLogger;
+            _fixture.SentryOptions.Debug = true;
+            var sut = _fixture.GetSut();
+
+            // Edge-case of initializing the SDK twice with the same options object.
+            sut.Register(_fixture.Hub, _fixture.SentryOptions);
+
+            Assert.IsTrue(testLogger.Logs.Any(log =>
+                log.logLevel == SentryLevel.Warning &&
+                log.message.Contains("UnityLogHandlerIntegration has already been registered.")));
         }
     }
 }


### PR DESCRIPTION
Edge-case: If the SDK initializes with the same options object multiple times the integration starts forwarding the logs to itself.