### PR TITLE
feat: Log multiple SDK inits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Preventing `LoggingIntegration` from registering multiple times ([#1178](https://github.com/getsentry/sentry-unity/pull/1178))
 - Fixed the logging integration only capturing tags and missing the message ([#1150](https://github.com/getsentry/sentry-unity/pull/1150))
 
 ### Dependencies

--- a/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs
@@ -28,6 +28,18 @@ namespace Sentry.Unity.Integrations
         {
             _hub = hub;
             _sentryOptions = sentryOptions as SentryUnityOptions;
+            if (_sentryOptions is null)
+            {
+                return;
+            }
+
+            // If called twice (i.e. init with the same options object) the integration will reference itself as the
+            // original handler loghandler and endlessly forward to itself
+            if (Debug.unityLogger.logHandler == this)
+            {
+                _sentryOptions.DiagnosticLogger?.LogWarning("UnityLogHandlerIntegration has already been registered.");
+                return;
+            }
 
             _unityLogHandler = Debug.unityLogger.logHandler;
             Debug.unityLogger.logHandler = this;

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -1,12 +1,6 @@
 using System;
-using System.IO;
 using System.ComponentModel;
-using System.Diagnostics.Tracing;
-using System.Threading.Tasks;
-using System.Xml;
 using Sentry.Extensibility;
-using Sentry.Unity.Integrations;
-using UnityEngine;
 
 namespace Sentry.Unity
 {
@@ -36,6 +30,11 @@ namespace Sentry.Unity
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Init(SentryUnityOptions options)
         {
+            if(UnitySdk is not null)
+            {
+                options.DiagnosticLogger?.LogWarning("The SDK has already been initialized.");
+            }
+
             UnitySdk = SentryUnitySdk.Init(options);
         }
 

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -30,7 +30,7 @@ namespace Sentry.Unity
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Init(SentryUnityOptions options)
         {
-            if(UnitySdk is not null)
+            if (UnitySdk is not null)
             {
                 options.DiagnosticLogger?.LogWarning("The SDK has already been initialized.");
             }

--- a/test/Sentry.Unity.Tests/SentryUnityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityTests.cs
@@ -1,9 +1,12 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Debug = UnityEngine.Debug;
 using Sentry.Extensibility;
+using Sentry.Unity.Tests.SharedClasses;
+using UnityEditor.PackageManager;
 
 namespace Sentry.Unity.Tests
 {
@@ -14,7 +17,7 @@ namespace Sentry.Unity.Tests
         {
             if (SentrySdk.IsEnabled)
             {
-                SentrySdk.Close();
+                SentryUnity.Close();
             }
         }
 
@@ -82,6 +85,25 @@ namespace Sentry.Unity.Tests
             SentryUnity.Init(options);
 
             Assert.IsFalse(SentrySdk.IsEnabled);
+        }
+
+        [Test]
+        public void Init_MultipleTimes_LogsWarning()
+        {
+            var testLogger = new TestLogger();
+            var options = new SentryUnityOptions
+            {
+                Debug = true,
+                Dsn = "https://94677106febe46b88b9b9ae5efd18a00@o447951.ingest.sentry.io/5439417",
+                DiagnosticLogger = testLogger,
+            };
+
+            SentryUnity.Init(options);
+            SentryUnity.Init(options);
+
+            Assert.IsTrue(testLogger.Logs.Any(log =>
+                log.logLevel == SentryLevel.Warning &&
+                log.message.Contains("The SDK has already been initialized.")));
         }
     }
 }

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -15,7 +15,7 @@ using Object = UnityEngine.Object;
 // TODO do we need a real (working) DSN in these tests?
 namespace Sentry.Unity.Tests
 {
-    public sealed class UnityEventProcessorThreadingTests
+    public sealed class UnityEventProcessorThreadingTests : DisabledSelfInitializationTests
     {
         private GameObject _gameObject = null!;
         private TestLogger _testLogger = null!;

--- a/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 using Sentry.Protocol;
 using Sentry.Unity.Integrations;
+using Sentry.Unity.Tests.SharedClasses;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
 
@@ -228,6 +229,22 @@ namespace Sentry.Unity.Tests
             Assert.AreEqual(exception.GetType() + ": " + message, breadcrumb.Message);
             Assert.AreEqual("unity.logger", breadcrumb.Category);
             Assert.AreEqual(BreadcrumbLevel.Error, breadcrumb.Level);
+        }
+
+        [Test]
+        public void Register_RegisteredASecondTime_LogsWarningAndReturns()
+        {
+            var testLogger = new TestLogger();
+            _fixture.SentryOptions.DiagnosticLogger = testLogger;
+            _fixture.SentryOptions.Debug = true;
+            var sut = _fixture.GetSut();
+
+            // Edge-case of initializing the SDK twice with the same options object.
+            sut.Register(_fixture.Hub, _fixture.SentryOptions);
+
+            Assert.IsTrue(testLogger.Logs.Any(log =>
+                log.logLevel == SentryLevel.Warning &&
+                log.message.Contains("UnityLogHandlerIntegration has already been registered.")));
         }
     }
 }


### PR DESCRIPTION
Especially since the SDK is self-initializing it should log in case of multiple inits.

#skip-changelog