### PR TITLE
fix: Add more logging to iOS `BuildPostProcess`

### DIFF
--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -75,6 +75,11 @@ namespace Sentry.Unity.Editor.iOS
 
         internal static void CopyFramework(string sourcePath, string targetPath, IDiagnosticLogger? logger)
         {
+            if (!Directory.Exists(sourcePath))
+            {
+                throw new DirectoryNotFoundException($"Failed to find '{sourcePath}'");
+            }
+
             if (Directory.Exists(targetPath))
             {
                 logger?.LogDebug("'{0}' has already been copied to '{1}'", Path.GetFileName(targetPath), targetPath);
@@ -97,6 +102,11 @@ namespace Sentry.Unity.Editor.iOS
 
         internal static void CopyFile(string sourcePath, string targetPath, IDiagnosticLogger? logger)
         {
+            if (!File.Exists(sourcePath))
+            {
+                throw new DirectoryNotFoundException($"Failed to find '{sourcePath}'");
+            }
+
             if (File.Exists(targetPath))
             {
                 logger?.LogDebug("'{0}' has already been copied to '{1}'", Path.GetFileName(targetPath), targetPath);

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -104,7 +104,7 @@ namespace Sentry.Unity.Editor.iOS
         {
             if (!File.Exists(sourcePath))
             {
-                throw new DirectoryNotFoundException($"Failed to find '{sourcePath}'");
+                throw new FileNotFoundException($"Failed to find '{sourcePath}'");
             }
 
             if (File.Exists(targetPath))

--- a/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
@@ -55,6 +55,12 @@ namespace Sentry.Unity.Editor.iOS.Tests
         }
 
         [Test]
+        public void CopyFramework_SourceMissing_ThrowsDirectoryNotFoundException() =>
+            Assert.Throws<DirectoryNotFoundException>(() =>
+                BuildPostProcess.CopyFramework("non-existent-path.framework",
+                    Path.Combine(_xcodeProjectPath, "SomeDirectory", "Test.framework"), new TestLogger()));
+
+        [Test]
         public void CopyFramework_FailedToCopy_ThrowsDirectoryNotFoundException() =>
             Assert.Throws<DirectoryNotFoundException>(() =>
                 BuildPostProcess.CopyFramework("non-existent-path.framework",
@@ -84,6 +90,12 @@ namespace Sentry.Unity.Editor.iOS.Tests
                 log.logLevel == SentryLevel.Debug &&
                 log.message.Contains("has already been copied to")));
         }
+
+        [Test]
+        public void CopyFile_SourceMissing_ThrowsFileNotFoundException() =>
+            Assert.Throws<FileNotFoundException>(() =>
+                BuildPostProcess.CopyFile("non-existent-path.m",
+                    Path.Combine(_xcodeProjectPath, "NewDirectory", "Test.m"), new TestLogger()));
 
         [Test]
         public void CopyFile_FailedToCopyFile_ThrowsFileNotFoundException() =>


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1176

#skip-changelog