### PR TITLE
fix: Removed `Overrride Sentry URL` from editor window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Removed `Override Sentry URL` from editor window ([#1188](https://github.com/getsentry/sentry-unity/pull/1188))
+  - The option is still available from within the `SentryBuildTimeOptionsConfiguration`
+
 ### Feature
 
 - Much improved line numbers for IL2CPP builds by setting the `instruction_addr_adjustment` appropriately ([#1165](https://github.com/getsentry/sentry-unity/pull/1165))

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
@@ -43,11 +43,6 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                     cliOptions.UploadSymbols && string.IsNullOrWhiteSpace(cliOptions.Project) ? SentryWindow.ErrorIcon : null,
                     "The project name in Sentry"),
                 cliOptions.Project);
-
-            cliOptions.UrlOverride = EditorGUILayout.TextField(
-                new GUIContent("Override Sentry URL", "Fully qualified URL to the Sentry server (defaults to " +
-                                                      "the server configured in DSN, e.g. https://sentry.io)"),
-                cliOptions.UrlOverride);
         }
     }
 }


### PR DESCRIPTION
We didn't intend to put this on the editor window and it caused some confusion as to `what to put there`. Since it's a very specific edge case and it's accessible from the `BuildTimeOptionsConfig` I think it can be removed from the editor window.