### PR TITLE
chore: Removed unused meta in sample

### DIFF
--- a/samples/unity-of-bugs/Assets/Plugins/Sentry.meta
+++ b/samples/unity-of-bugs/Assets/Plugins/Sentry.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 02fcd6256f5944977b3bc22fe00a4bb1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
On the first opening of the sample, the meta without its directory creates a warning.
The cli options and the directory get created during the opening of the editor window.

#skip-changelog