### PR TITLE
fix: lockfile check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- The SDK no longer logs a warning due to a missing log file on non-windows player platforms ([#1195](https://github.com/getsentry/sentry-unity/pull/1195))
 - Preventing `LoggingIntegration` from registering multiple times ([#1178](https://github.com/getsentry/sentry-unity/pull/1178))
 - Fixed the logging integration only capturing tags and missing the message ([#1150](https://github.com/getsentry/sentry-unity/pull/1150))
 

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -11,7 +11,7 @@ namespace Sentry.Unity
     {
         private readonly SentryUnityOptions _options;
         private IDisposable _dotnetSdk = null!;
-        private FileStream _lockFile = null!;
+        private FileStream? _lockFile;
 
         private SentryUnitySdk(SentryUnityOptions options)
         {
@@ -96,7 +96,7 @@ namespace Sentry.Unity
             try
             {
                 // We don't really need to close, Windows would release the lock anyway, but let's be nice.
-                _lockFile.Close();
+                _lockFile?.Close();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Closing the SDK results in a warning on non-windows player platforms. (especially prominent in the editor) because the lock was never set.