### PR TITLE
chore: Renamed `OptionsConfig` to `RuntimeOptionsConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Removed `Override Sentry URL` from editor window ([#1188](https://github.com/getsentry/sentry-unity/pull/1188))
   - The option is still available from within the `SentryBuildTimeOptionsConfiguration`
+- Renamed `OptionsConfiguration` to `RuntimeOptionsConfiguration` on the ScriptableSentryOptions ([#1196](https://github.com/getsentry/sentry-unity/pull/1196))
+  - If you make use programmatic runtime options configuration, you will need to reassign the scriptable object in the configuration tab
 
 ### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Removed `Override Sentry URL` from editor window ([#1188](https://github.com/getsentry/sentry-unity/pull/1188))
   - The option is still available from within the `SentryBuildTimeOptionsConfiguration`
 - Renamed `OptionsConfiguration` to `RuntimeOptionsConfiguration` on the ScriptableSentryOptions ([#1196](https://github.com/getsentry/sentry-unity/pull/1196))
-  - If you make use programmatic runtime options configuration, you will need to reassign the scriptable object in the configuration tab
+  - If you make use of programmatic runtime options configuration, you will need to reassign the scriptable object in the configuration tab
 
 ### Feature
 

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/OptionsConfigurationTab.cs
@@ -32,8 +32,8 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
 
             EditorGUILayout.Space();
 
-            options.OptionsConfiguration = OptionsConfigurationItem.Display(
-                options.OptionsConfiguration,
+            options.RuntimeOptionsConfiguration = OptionsConfigurationItem.Display(
+                options.RuntimeOptionsConfiguration,
                 "Runtime Options Script",
                 "RuntimeOptionsConfiguration"
             );
@@ -153,7 +153,7 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
             else
             {
                 // Don't overwrite already set OptionsConfiguration
-                options.OptionsConfiguration ??= optionsConfigurationObject as SentryRuntimeOptionsConfiguration;
+                options.RuntimeOptionsConfiguration ??= optionsConfigurationObject as SentryRuntimeOptionsConfiguration;
             }
         }
     }

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -79,7 +79,7 @@ namespace Sentry.Unity.Editor
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Options Configuration", EditorStyles.boldLabel);
-            EditorGUILayout.ObjectField("Runtime Configuration", options.OptionsConfiguration,
+            EditorGUILayout.ObjectField("Runtime Configuration", options.RuntimeOptionsConfiguration,
                 typeof(SentryRuntimeOptionsConfiguration), false);
             EditorGUILayout.ObjectField("Buildtime Configuration", options.BuildtimeOptionsConfiguration,
                 typeof(SentryBuildtimeOptionsConfiguration), false);

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -81,7 +81,7 @@ namespace Sentry.Unity
 
         [field: SerializeField] public bool Il2CppLineNumberSupportEnabled { get; set; } = true;
 
-        [field: SerializeField] public SentryRuntimeOptionsConfiguration? OptionsConfiguration { get; set; }
+        [field: SerializeField] public SentryRuntimeOptionsConfiguration? RuntimeOptionsConfiguration { get; set; }
         [field: SerializeField] public SentryBuildtimeOptionsConfiguration? BuildtimeOptionsConfiguration { get; set; }
 
         [field: SerializeField] public bool Debug { get; set; } = true;
@@ -193,9 +193,9 @@ namespace Sentry.Unity
 
             if (!isBuilding)
             {
-                if (OptionsConfiguration != null)
+                if (RuntimeOptionsConfiguration != null)
                 {
-                    OptionsConfiguration.Configure(options);
+                    RuntimeOptionsConfiguration.Configure(options);
                 }
 
                 // Doing this after the configure callback to allow users to programmatically opt out

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -114,7 +114,7 @@ namespace Sentry.Unity.Tests
         {
             var optionsConfiguration = ScriptableObject.CreateInstance<TestOptionsConfiguration>();
             var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
-            scriptableOptions.OptionsConfiguration = optionsConfiguration;
+            scriptableOptions.RuntimeOptionsConfiguration = optionsConfiguration;
 
             scriptableOptions.ToSentryUnityOptions(isBuilding);
 


### PR DESCRIPTION
Already put breaking changes around the programmatic configuration.
Progress in the quest of being more explicit: `RuntimeOptionsConfig`