### PR TITLE
chore: Ignore `Plugins/Sentry.meta`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ package-dev/Editor/sentry-cli
 
 # Build output of Sentry.Unity
 sentry-unity/Assets/Plugins/Sentry/
+sentry-unity/Assets/Plugins/Sentry.meta
 sentry-unity/Assets/Editor/Sentry/
 
 # Native SDK files


### PR DESCRIPTION
Follow-up of https://github.com/getsentry/sentry-unity/pull/1192
Don't track `meta` of ignored directory.

#skip-changelog