### PR TITLE
fix: UnityViewHierarchy tests

### DIFF
--- a/test/Sentry.Unity.Tests/UnityViewHierarchyAttachmentTests.cs
+++ b/test/Sentry.Unity.Tests/UnityViewHierarchyAttachmentTests.cs
@@ -6,7 +6,7 @@ using UnityEngine.SceneManagement;
 
 namespace Sentry.Unity.Tests
 {
-    public class UnityViewHierarchyAttachmentTests : DisabledSelfInitializationTests
+    public class UnityViewHierarchyAttachmentTests
     {
         private class Fixture
         {


### PR DESCRIPTION
A mishap with having a dependency on the submodule and then bumping and merging it.
#skip-changelog