### PR TITLE
fix: Make ANR detection unaffected by `Time.timescale`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The ANR detection is now unaffected by changes to `Time.timescale` ([#1225](https://github.com/getsentry/sentry-unity/pull/1225))
+
 ### Features
 
 - Added `View Hierarchy` as an opt-in attachment. This will capture the scene hierarchy at the moment an event occurs and send it to Sentry ([#1169](https://github.com/getsentry/sentry-unity/pull/1169))

--- a/src/Sentry.Unity/Integrations/AnrIntegration.cs
+++ b/src/Sentry.Unity/Integrations/AnrIntegration.cs
@@ -115,7 +115,7 @@ namespace Sentry.Unity
 
         private IEnumerator UpdateUiStatus()
         {
-            var waitForSeconds = new WaitForSeconds((float)SleepIntervalMs / 1000);
+            var waitForSeconds = new WaitForSecondsRealtime((float)SleepIntervalMs / 1000);
 
             yield return waitForSeconds;
             while (!_stop)
@@ -180,7 +180,7 @@ namespace Sentry.Unity
 
         private IEnumerator UpdateUiStatus()
         {
-            var waitForSeconds = new WaitForSeconds((float)SleepIntervalMs / 1000);
+            var waitForSeconds = new WaitForSecondsRealtime((float)SleepIntervalMs / 1000);
             while (!_stop)
             {
                 if (_watch.ElapsedMilliseconds >= DetectionTimeoutMs)

--- a/test/Sentry.Unity.Tests/AnrDetectionTests.cs
+++ b/test/Sentry.Unity.Tests/AnrDetectionTests.cs
@@ -128,5 +128,19 @@ namespace Sentry.Unity.Tests
 
             Assert.IsNull(arn);
         }
+
+        [UnityTest]
+        public IEnumerator IsNotAffectedByTimeScale()
+        {
+            ApplicationNotResponding? anr = null;
+            _sut = CreateWatchDog(true);
+            _sut.OnApplicationNotResponding += (_, e) => anr = e;
+
+            Time.timeScale = 0.0f;
+            yield return new WaitForSecondsRealtime((float)_timeout.TotalSeconds * 2);
+            Time.timeScale = 1.0f;
+
+            Assert.IsNull(anr);
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1214