### PR TITLE
fix: Uploading all `.pdb` at `Temp/ManagedSymbols` for Mono on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fixed missing debug file upload for assembly definitions for Mono builds ([#1226](https://github.com/getsentry/sentry-unity/pull/1226))
 - The ANR detection is now unaffected by changes to `Time.timescale` ([#1225](https://github.com/getsentry/sentry-unity/pull/1225))
 
 ### Features

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -178,7 +178,7 @@ namespace Sentry.Unity.Editor.Native
 
             if (isMono)
             {
-                addFilesMatching($"{projectDir}/Temp", new[] { "**/UnityEngine.*.pdb", "**/Assembly-CSharp.pdb" });
+                addFilesMatching($"{projectDir}/Temp/ManagedSymbols", new[] { "*.pdb" });
             }
 
             var cliArgs = "upload-dif ";

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -141,44 +141,67 @@ namespace Sentry.Unity.Editor.Native
             };
 
             addPath(executableName);
-            if (!isMono)
-            {
-                addPath(Path.GetFileNameWithoutExtension(executableName) + "_BackUpThisFolder_ButDontShipItWithYourGame");
-            }
-            if (target is BuildTarget.StandaloneWindows64)
-            {
-                addPath("UnityPlayer.dll");
-                addPath(Path.GetFileNameWithoutExtension(executableName) + "_Data/Plugins/x86_64/sentry.dll");
-                addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/Windows/Sentry/sentry.pdb"));
-                if (isMono)
-                {
-                    addPath("MonoBleedingEdge/EmbedRuntime");
-                    addFilesMatching(buildOutputDir, new[] { "*.pdb" });
-                }
-                else
-                {
-                    addPath("GameAssembly.dll");
-                }
-            }
-            else if (target is BuildTarget.StandaloneLinux64)
-            {
-                addPath("GameAssembly.so");
-                addPath("UnityPlayer.so");
-                addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/Linux/Sentry/libsentry.dbg.so"));
-                if (isMono)
-                {
-                    addPath(Path.GetFileNameWithoutExtension(executableName) + "_Data/MonoBleedingEdge/x86_64");
-                    addFilesMatching(buildOutputDir, new[] { "*.debug" });
-                }
-            }
-            else if (target is BuildTarget.StandaloneOSX)
-            {
-                addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/macOS/Sentry/Sentry.dylib.dSYM"));
-            }
 
-            if (isMono)
+            switch (target)
             {
-                addFilesMatching($"{projectDir}/Temp/ManagedSymbols", new[] { "*.pdb" });
+                case BuildTarget.StandaloneWindows64:
+                    addPath("UnityPlayer.dll");
+                    addPath(Path.GetFileNameWithoutExtension(executableName) + "_Data/Plugins/x86_64/sentry.dll");
+                    addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/Windows/Sentry/sentry.pdb"));
+
+                    if (isMono)
+                    {
+                        addPath("MonoBleedingEdge/EmbedRuntime");
+                        addFilesMatching(buildOutputDir, new[] { "*.pdb" });
+
+                        // Unity stores the .pdb files in './Library/ScriptAssemblies/' and starting with 2020 in
+                        // './Temp/ManagedSymbols/'. We want the one in 'Temp/ManagedSymbols/' specifically.
+                        var managedSymbolsDirectory = $"{projectDir}/Temp/ManagedSymbols";
+                        if (Directory.Exists(managedSymbolsDirectory))
+                        {
+                            addFilesMatching(managedSymbolsDirectory, new[] { "*.pdb" });
+                        }
+                    }
+                    else // IL2CPP
+                    {
+                        addPath(Path.GetFileNameWithoutExtension(executableName) + "_BackUpThisFolder_ButDontShipItWithYourGame");
+                        addPath("GameAssembly.dll");
+                    }
+                    break;
+                case BuildTarget.StandaloneLinux64:
+                    addPath("GameAssembly.so");
+                    addPath("UnityPlayer.so");
+                    addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/Linux/Sentry/libsentry.dbg.so"));
+
+                    if (isMono)
+                    {
+                        addPath(Path.GetFileNameWithoutExtension(executableName) + "_Data/MonoBleedingEdge/x86_64");
+                        addFilesMatching(buildOutputDir, new[] { "*.debug" });
+
+                        var managedSymbolsDirectory = $"{projectDir}/Temp/ManagedSymbols";
+                        if (Directory.Exists(managedSymbolsDirectory))
+                        {
+                            addFilesMatching(managedSymbolsDirectory, new[] { "*.pdb" });
+                        }
+                    }
+                    else // IL2CPP
+                    {
+                        addPath(Path.GetFileNameWithoutExtension(executableName) + "_BackUpThisFolder_ButDontShipItWithYourGame");
+                    }
+                    break;
+                case BuildTarget.StandaloneOSX:
+                    addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/macOS/Sentry/Sentry.dylib.dSYM"));
+
+                    if (isMono)
+                    { }
+                    else // IL2CPP
+                    {
+                        addPath(Path.GetFileNameWithoutExtension(executableName) + "_BackUpThisFolder_ButDontShipItWithYourGame");
+                    }
+                    break;
+                default:
+                    logger.LogError($"Symbol upload for '{target}' is currently not supported.");
+                    break;
             }
 
             var cliArgs = "upload-dif ";


### PR DESCRIPTION
Unity allows for the use of [Assembly Definitions](https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html) which leads to the creation of separate `.dll` and `.pdb` files. Currently, those get skipped due to the naming restriction.