### PR TITLE
fix: Aliasing `Microsoft` Editor dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: docker exec unity dotnet tool install --global Alias --version 0.4.3
 
       - name: Alias editor assemblies
-        run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Mono.Cecil*"
+        run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"
 
       - name: Alias runtime assemblies
         run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- Resolved the `Microsoft.Extensions.FileSystemGlobbing.dll` dependency conflict ([#1253](https://github.com/getsentry/sentry-unity/pull/1253))
+
 ### Dependencies
 
 - Bump CLI from v2.14.4 to v2.15.2 ([#1231](https://github.com/getsentry/sentry-unity/pull/1231), [#1236](https://github.com/getsentry/sentry-unity/pull/1236))

--- a/scripts/repack.ps1
+++ b/scripts/repack.ps1
@@ -1,5 +1,5 @@
 assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
-assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Mono.Cecil*"
+assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"
 
 $unity_version = Get-Content ./samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt | grep m_EditorVersion -m 1 | cut -d ' ' -f 2
 

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -1,8 +1,8 @@
 Documentation~/index.md
 Editor/iOS.meta
-Editor/Microsoft.Extensions.FileSystemGlobbing.dll
-Editor/Microsoft.Extensions.FileSystemGlobbing.dll.meta
 Editor/sentry-cli.meta
+Editor/Sentry.Microsoft.Extensions.FileSystemGlobbing.dll
+Editor/Sentry.Microsoft.Extensions.FileSystemGlobbing.dll.meta
 Editor/Sentry.Mono.Cecil.dll
 Editor/Sentry.Mono.Cecil.dll.meta
 Editor/Sentry.Mono.Cecil.Mdb.dll


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1245