### PR TITLE
fix: Don't add `Sentry Android` with Android Native Support disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ package-dev/Plugins/*/Sentry/crashpad_handler*
 !package-dev/**/SentryNativeBridge.m.meta
 
 # Android SDK files
-package-dev/Plugins/Android/Sentry/*
+package-dev/Plugins/Android/Sentry~/*
 
 # CLI
 package-dev/Editor/sentry-cli

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,7 +17,7 @@
     <SentrymacOSArtifactsDestination>$(SentryArtifactsDestination)macOS/Sentry/</SentrymacOSArtifactsDestination>
     <!-- Android -->
     <SentryAndroidRoot>$(RepoRoot)modules/sentry-java/</SentryAndroidRoot>
-    <SentryAndroidArtifactsDestination>$(SentryArtifactsDestination)Android/Sentry/</SentryAndroidArtifactsDestination>
+    <SentryAndroidArtifactsDestination>$(SentryArtifactsDestination)Android/Sentry~/</SentryAndroidArtifactsDestination>
     <!-- Native -->
     <SentryNativeRoot>$(RepoRoot)modules/sentry-native/</SentryNativeRoot>
     <SentryLinuxArtifactsDestination>$(SentryArtifactsDestination)Linux/Sentry/</SentryLinuxArtifactsDestination>

--- a/samples/unity-of-bugs/Assets/Plugins/Sentry.meta
+++ b/samples/unity-of-bugs/Assets/Plugins/Sentry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64c0becb913584872b45232831bb29d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -229,7 +229,7 @@ namespace Sentry.Unity.Editor.Android
 
         internal void CopyAndroidSdkToGradleProject(string gradlePath)
         {
-            var sentrySdkPath = Path.Combine("Packages", SentryPackageInfo.GetName(), "Plugins", "Android", "Sentry");
+            var sentrySdkPath = Path.Combine("Packages", SentryPackageInfo.GetName(), "Plugins", "Android", "Sentry~");
             var targetPath = Path.Combine(gradlePath, "unityLibrary", "libs");
 
             if (_options is { Enabled: true, AndroidNativeSupportEnabled: true })

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -45,7 +45,9 @@ namespace Sentry.Unity.Editor.Android
                 else
                 {
                     text += "        println 'Uploading symbols to Sentry. You can find the full log in ./Logs/sentry-symbols-upload.log (the file content may not be strictly sequential because it\\'s a merge of two streams).'\n";
-                    text += $"        def sentryLogFile = new FileOutputStream('{ConvertSlashes(_unityProjectPath)}/Logs/sentry-symbols-upload.log')\n";
+                    text += $"        def logDirectory = file('{ConvertSlashes(_unityProjectPath)}/Logs/')\n";
+                    text += "        Files.createDirectories(logDirectory.toPath())\n";
+                    text += "        def sentryLogFile = new FileOutputStream(logDirectory.toPath() + '/sentry-symbols-upload.log')\n";
                 }
                 text += "        exec {{\n";
                 text += "            environment 'SENTRY_PROPERTIES', './sentry.properties'\n";

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -202,13 +202,9 @@ Plugins/Linux/Sentry/libsentry.so
 Plugins/Linux/Sentry/libsentry.so.meta
 Plugins/Android/proguard-sentry-unity.pro
 Plugins/Android/proguard-sentry-unity.pro.meta
-Plugins/Android/Sentry.meta
-Plugins/Android/Sentry/sentry-android-core-release.aar
-Plugins/Android/Sentry/sentry-android-core-release.aar.meta
-Plugins/Android/Sentry/sentry-android-ndk-release.aar
-Plugins/Android/Sentry/sentry-android-ndk-release.aar.meta
-Plugins/Android/Sentry/sentry.jar
-Plugins/Android/Sentry/sentry.jar.meta
+Plugins/Android/Sentry~/sentry-android-core-release.aar
+Plugins/Android/Sentry~/sentry-android-ndk-release.aar
+Plugins/Android/Sentry~/sentry.jar
 Plugins/Windows/Sentry.meta
 Plugins/Windows/Sentry/crashpad_handler.exe
 Plugins/Windows/Sentry/crashpad_handler.exe.meta


### PR DESCRIPTION
The base idea is to make unity games as a library work. For that, the SDK can't move any native SDK into the gradle output project.
That means
- The SDK no longer needs to set `self-init = false` in the manifest because there is no android SDK in the output project
- Manually copy/remove the Android SDK from the output project