### PR TITLE
fix: Revert `Java SDK` bump to `6.14.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@
 - Bump Native SDK from v0.6.0 to v0.6.1 ([#1254](https://github.com/getsentry/sentry-unity/pull/1254))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#061)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.6.0...0.6.1)
-- Bump Java SDK from v6.14.0 to v6.17.0 ([#1264](https://github.com/getsentry/sentry-unity/pull/1264))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6170)
-  - [diff](https://github.com/getsentry/sentry-java/compare/6.14.0...6.17.0)
 
 ## 1.1.0
 


### PR DESCRIPTION
#skip-changelog