### PR TITLE
fix: CaptureLogFormat throws when `args` contain `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fixed an issue where the SDK would throw a `NullReferenceException` when trying to capture a log message ([#1309](https://github.com/getsentry/sentry-unity/pull/1309))
 - Fixed the `BreadcrumbsForErrors` checkbox on the config window ([#1306](https://github.com/getsentry/sentry-unity/pull/1306))
 - The SDK filters `Bad Gateway` Exceptions of type `Exception` by default ([#1293](https://github.com/getsentry/sentry-unity/pull/1293))
 

--- a/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityLogHandlerIntegration.cs
@@ -104,7 +104,7 @@ namespace Sentry.Unity.Integrations
             }
 
             // The SDK sets "Sentry" as tag when logging and we're not capturing SDK internal logs. Expected format: "{0}: {1}"
-            if (args.Length > 1 && args[0].Equals("Sentry"))
+            if (args.Length > 1 && "Sentry".Equals(args[0])) // Checking it this way around because `args[0]` could be null
             {
                 return;
             }

--- a/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLogHandlerIntegrationTests.cs
@@ -38,6 +38,16 @@ namespace Sentry.Unity.Tests
         }
 
         [Test]
+        public void CaptureLogFormat_ParamArgsContainNull_CaptureEvent()
+        {
+            var sut = _fixture.GetSut();
+
+            sut.CaptureLogFormat(LogType.Error, null, "{0}: {1}", new object[] { null!, null! });
+
+            Assert.AreEqual(1, _fixture.Hub.CapturedEvents.Count);
+        }
+
+        [Test]
         public void CaptureLogFormat_LogContainsSentryTag_NotCaptured()
         {
             var sut = _fixture.GetSut();


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1262