### PR TITLE
fix: Don't run instrumentation with the SDK disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- The SDK no longer runs performance auto instrumentation with the SDK disabled ([#1314](https://github.com/getsentry/sentry-unity/pull/1314))
 - Fixed an issue where the SDK would throw a `NullReferenceException` when trying to capture a log message ([#1309](https://github.com/getsentry/sentry-unity/pull/1309))
 - Fixed the `BreadcrumbsForErrors` checkbox on the config window ([#1306](https://github.com/getsentry/sentry-unity/pull/1306))
 - The SDK filters `Bad Gateway` Exceptions of type `Exception` by default ([#1293](https://github.com/getsentry/sentry-unity/pull/1293))

--- a/src/Sentry.Unity.Editor/AutoInstrumentation/SentryPerformanceAutoInstrumentation.cs
+++ b/src/Sentry.Unity.Editor/AutoInstrumentation/SentryPerformanceAutoInstrumentation.cs
@@ -22,6 +22,13 @@ namespace Sentry.Unity.Editor
             }
 
             var logger = options.DiagnosticLogger ?? new UnityLogger(options);
+
+            if (!options.IsValid())
+            {
+                logger.LogDebug("Performance Auto Instrumentation disabled.");
+                return;
+            }
+
             if (options.TracesSampleRate <= 0.0f || !options.PerformanceAutoInstrumentationEnabled)
             {
                 logger.LogInfo("Performance Auto Instrumentation has been disabled.");


### PR DESCRIPTION
The SDK no longer instruments performance with the SDK disabled.