### PR TITLE
chore: Downgrading iOS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
         # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
         # Also make sure to match the versions available here:
         #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-        ios: ['15.5', latest] # last updated May 2023
+        ios: ['15.4', latest] # last updated May 2023
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Someone is lying here.
Based on :https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md there should be `15.5` for macOS-12. But based on CI there isn't.

#skip-changelog