### PR TITLE
feat: Filter Unity telemetry `BadGatewayException` on iOS native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated sample configure callback to use the new `BeforeSend`methods that allow the use of `Hints` ([#1341](https://github.com/getsentry/sentry-unity/pull/1341))
 
+### Feature
+
+- Added automatic filtering of `BadGatewayExceptions` originating from Unity telemetry on the native iOS layer ([#1345](https://github.com/getsentry/sentry-unity/pull/1345))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.7.2 to v8.7.3 ([#1342](https://github.com/getsentry/sentry-unity/pull/1342))

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -41,6 +41,11 @@ static SentryOptions* getSentryOptions()
         return nil;
     }}
 
+    {(options.FilterBadGatewayExceptions ? @"options.beforeSend = ^SentryEvent * _Nullable(SentryEvent * _Nonnull event) {
+        if ([event.request.url containsString:@""operate-sdk-telemetry.unity3d.com""]) return nil;
+        return event;
+    };" : "")}
+
     return options;
 }}";
 

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -140,6 +140,11 @@ namespace Sentry.Unity
         public TimeSpan AnrTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
+        /// Whether the SDK should automatically filter `Bad Gateway Exceptions` caused by Unity.
+        /// </summary>
+        public bool FilterBadGatewayExceptions { get; set; } = true;
+
+        /// <summary>
         /// Whether the SDK should add native support for iOS
         /// </summary>
         public bool IosNativeSupportEnabled { get; set; } = true;

--- a/test/Sentry.Unity.Editor.iOS.Tests/NativeOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/NativeOptionsTests.cs
@@ -60,5 +60,35 @@ namespace Sentry.Unity.Editor.iOS.Tests
 
             File.Delete(testOptionsFileName);
         }
+
+        [Test]
+        public void CreateOptionsFile_FilterBadGatewayEnabled_AddsFiltering()
+        {
+            const string testOptionsFileName = "testOptions.m";
+
+            NativeOptions.CreateFile(testOptionsFileName, new SentryUnityOptions { FilterBadGatewayExceptions = true });
+
+            Assert.IsTrue(File.Exists(testOptionsFileName)); // Sanity check
+
+            var nativeOptions = File.ReadAllText(testOptionsFileName);
+            StringAssert.Contains("event.request.url containsString:@\"operate-sdk-telemetry.unity3d.com\"", nativeOptions);
+
+            File.Delete(testOptionsFileName);
+        }
+
+        [Test]
+        public void CreateOptionsFile_FilterBadGatewayDisabled_DoesNotAddFiltering()
+        {
+            const string testOptionsFileName = "testOptions.m";
+
+            NativeOptions.CreateFile(testOptionsFileName, new SentryUnityOptions { FilterBadGatewayExceptions = false });
+
+            Assert.IsTrue(File.Exists(testOptionsFileName)); // Sanity check
+
+            var nativeOptions = File.ReadAllText(testOptionsFileName);
+            StringAssert.DoesNotContain("event.request.url containsString:@\"operate-sdk-telemetry.unity3d.com\"", nativeOptions);
+
+            File.Delete(testOptionsFileName);
+        }
     }
 }


### PR DESCRIPTION
We had filtering of `BadGatewayExceptions` on the C# layer. If enabled, these need to be propagated down to the native layer as well.