### PR TITLE
fix: Fixed `Failed to find repositories` on `2022.3.0f1` builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixes Android native integration in the gradle output project for builds with Unity 2022.3 and newer ([#1354](https://github.com/getsentry/sentry-unity/pull/1354))
+
 ### Dependencies
 
 - Bump Native SDK from v0.6.2 to v0.6.3 ([#1349](https://github.com/getsentry/sentry-unity/pull/1349))

--- a/src/Sentry.Unity.Editor/Android/GradleSetup.cs
+++ b/src/Sentry.Unity.Editor/Android/GradleSetup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Sentry.Extensibility;
 using UnityEditor.Build;
 
@@ -14,25 +15,37 @@ namespace Sentry.Unity.Editor.Android
         public const string RepositoryScopeName = "repositories";
         public const string SdkDependencies = "implementation ('io.sentry:sentry-android:+') { exclude group: 'androidx.core' exclude group: 'androidx.lifecycle' }";
         public const string DependencyScopeName = "dependencies";
+        public static readonly List<string> ScopesToSkip = new() { "buildscript", "pluginManagement" };
 
         private readonly string _rootGradle;
+        private readonly string _settingsGradle;
         private readonly string _unityLibraryGradle;
 
         public GradleSetup(IDiagnosticLogger logger, string gradleProjectPath)
         {
             _logger = logger;
             _rootGradle = Path.Combine(gradleProjectPath, "build.gradle");
+            _settingsGradle = Path.Combine(gradleProjectPath, "settings.gradle");
             _unityLibraryGradle = Path.Combine(gradleProjectPath, "unityLibrary", "build.gradle");
         }
 
         public void UpdateGradleProject()
         {
-            _logger.LogInfo("Modifying the 'build.gradle' file at {0}", _rootGradle);
-            var rootGradleContent = LoadGradleScript(_rootGradle);
-            rootGradleContent = InsertIntoScope(rootGradleContent, RepositoryScopeName, LocalRepository);
-            File.WriteAllText(_rootGradle, rootGradleContent);
+            _logger.LogInfo("Adding Sentry to the gradle project.");
 
-            _logger.LogInfo("Modifying the 'build.gradle' file at {0}", _unityLibraryGradle);
+            // Starting with 2022.3.0f1 the root build.gradle updated to use the "new" way of importing plugins via `id`
+            // Instead, dependency repositories get handled in the `settings.gradle` at the root
+            var gradleFilePath = SentryUnityVersion.IsNewerOrEqualThan("2022.3")
+                ? _settingsGradle
+                : _rootGradle;
+
+            _logger.LogDebug("Updating the gradle file at '{0}'", gradleFilePath);
+
+            var gradleContent = LoadGradleScript(gradleFilePath);
+            gradleContent = InsertIntoScope(gradleContent, RepositoryScopeName, LocalRepository);
+            File.WriteAllText(gradleFilePath, gradleContent);
+
+            _logger.LogDebug("Updating the gradle file at '{0}'", _unityLibraryGradle);
             var unityLibraryGradleContent = LoadGradleScript(_unityLibraryGradle);
             unityLibraryGradleContent = InsertIntoScope(unityLibraryGradleContent, DependencyScopeName, SdkDependencies);
             File.WriteAllText(_unityLibraryGradle, unityLibraryGradleContent);
@@ -40,12 +53,14 @@ namespace Sentry.Unity.Editor.Android
 
         public void ClearGradleProject()
         {
-            _logger.LogInfo("Removing modifications from the 'build.gradle' file at {0}", _rootGradle);
+            _logger.LogInfo("Removing Sentry from the gradle project.");
+
+            _logger.LogDebug("Removing modifications from the 'build.gradle' file at {0}", _rootGradle);
             var rootGradleContent = LoadGradleScript(_rootGradle);
             rootGradleContent = RemoveFromGradleContent(rootGradleContent, LocalRepository);
             File.WriteAllText(_rootGradle, rootGradleContent);
 
-            _logger.LogInfo("Removing modifications from the 'build.gradle' file at {0}", _unityLibraryGradle);
+            _logger.LogDebug("Removing modifications from the 'build.gradle' file at {0}", _unityLibraryGradle);
             var unityLibraryGradleContent = LoadGradleScript(_unityLibraryGradle);
             unityLibraryGradleContent = RemoveFromGradleContent(unityLibraryGradleContent, SdkDependencies);
             File.WriteAllText(_unityLibraryGradle, unityLibraryGradleContent);
@@ -66,7 +81,7 @@ namespace Sentry.Unity.Editor.Android
             {
                 var line = lines[i];
                 // There are potentially multiple, nested scopes. We cannot add ourselves to the ones within 'buildscript'
-                if (line.Contains("buildscript"))
+                if(ScopesToSkip.Any(line.Contains))
                 {
                     var startIndex = i;
 

--- a/test/Sentry.Unity.Editor.Tests/Android/GradleSetupTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/GradleSetupTests.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using Sentry.Unity.Editor.Android;
+using Sentry.Unity.Integrations;
 using Sentry.Unity.Tests.SharedClasses;
+using Sentry.Unity.Tests.Stubs;
 
 namespace Sentry.Unity.Editor.Tests.Android
 {
@@ -42,13 +44,17 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
-        public void UpdateGradleProject_ModifiesGradleFiles()
+        [TestCase("2019.3", "build.gradle")]
+        [TestCase("2020.3", "build.gradle")]
+        [TestCase("2021.3", "build.gradle")]
+        [TestCase("2022.3", "settings.gradle")]
+        public void UpdateGradleProject_ModifiesGradleFiles(string unityVersion, string rootGradleFileName)
         {
             var sut = new GradleSetup(Logger, GradleProjectPath);
 
-            sut.UpdateGradleProject();
+            sut.UpdateGradleProject(new TestApplication(unityVersion: unityVersion));
 
-            var rootGradleFilePath = Path.Combine(GradleProjectPath, "build.gradle");
+            var rootGradleFilePath = Path.Combine(GradleProjectPath, rootGradleFileName);
             var rootGradleContent = File.ReadAllText(rootGradleFilePath);
             StringAssert.Contains(GradleSetup.LocalRepository, rootGradleContent);
 
@@ -58,14 +64,18 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
-        public void UpdateGradleProject_GradleAlreadyModified_LogsAndReturns()
+        [TestCase("2019.3", "build.gradle")]
+        [TestCase("2020.3", "build.gradle")]
+        [TestCase("2021.3", "build.gradle")]
+        [TestCase("2022.3", "settings.gradle")]
+        public void UpdateGradleProject_GradleAlreadyModified_LogsAndReturns(string unityVersion, string rootGradleFileName)
         {
             var sut = new GradleSetup(Logger, GradleProjectPath);
-            sut.UpdateGradleProject();
+            sut.UpdateGradleProject(new TestApplication(unityVersion: unityVersion));
 
-            sut.UpdateGradleProject();
+            sut.UpdateGradleProject(new TestApplication(unityVersion: unityVersion));
 
-            var rootGradleFilePath = Path.Combine(GradleProjectPath, "build.gradle");
+            var rootGradleFilePath = Path.Combine(GradleProjectPath, rootGradleFileName);
             var rootGradleContent = File.ReadAllText(rootGradleFilePath);
             StringAssert.Contains(GradleSetup.LocalRepository, rootGradleContent); // Sanity check
 
@@ -79,12 +89,16 @@ namespace Sentry.Unity.Editor.Tests.Android
         }
 
         [Test]
-        public void ClearGradleProject_GradleFilesModified_RemovesModification()
+        [TestCase("2019.3", "build.gradle")]
+        [TestCase("2020.3", "build.gradle")]
+        [TestCase("2021.3", "build.gradle")]
+        [TestCase("2022.3", "settings.gradle")]
+        public void ClearGradleProject_GradleFilesModified_RemovesModification(string unityVersion, string rootGradleFileName)
         {
             var sut = new GradleSetup(Logger, GradleProjectPath);
-            sut.UpdateGradleProject();
+            sut.UpdateGradleProject(new TestApplication(unityVersion: unityVersion));
 
-            var rootGradleFilePath = Path.Combine(GradleProjectPath, "build.gradle");
+            var rootGradleFilePath = Path.Combine(GradleProjectPath, rootGradleFileName);
             var rootGradleContent = File.ReadAllText(rootGradleFilePath);
             StringAssert.Contains(GradleSetup.LocalRepository, rootGradleContent); // Sanity check
 
@@ -92,7 +106,7 @@ namespace Sentry.Unity.Editor.Tests.Android
             var unityLibraryGradleContent = File.ReadAllText(unityLibraryGradleFilePath);
             StringAssert.Contains(GradleSetup.SdkDependencies, unityLibraryGradleContent); // Sanity check
 
-            sut.ClearGradleProject();
+            sut.ClearGradleProject(new TestApplication(unityVersion: unityVersion));
 
             rootGradleContent = File.ReadAllText(rootGradleFilePath);
             StringAssert.DoesNotContain(GradleSetup.LocalRepository, rootGradleContent); // Sanity check

--- a/test/Sentry.Unity.Editor.Tests/TestFiles/SymbolsUploadProject/GradleProject/settings.gradle
+++ b/test/Sentry.Unity.Editor.Tests/TestFiles/SymbolsUploadProject/GradleProject/settings.gradle
@@ -1,0 +1,7 @@
+repositories {
+    google()
+    jcenter()
+    flatDir {
+        dirs "${project(':unityLibrary').projectDir}/libs"
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1355
With `2022.3.0f1` and forward the base gradle template has been updated. The SDK needs to add the local repository to the `settings.gradle` instead of the `build.gradle`.