### PR TITLE
fix: Image UUID normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fixed debug image UUID normalization ([#1361](https://github.com/getsentry/sentry-unity/pull/1361))
+- Fixed an issue where the debug image UUID normalization would malform the UUID leading to a failed symbolication ([#1361](https://github.com/getsentry/sentry-unity/pull/1361))
 
 ## 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed debug image UUID normalization ([#1361](https://github.com/getsentry/sentry-unity/pull/1361))
+
 ## 1.4.1
 
 ### Fixes 

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -87,7 +87,7 @@ namespace Sentry.Unity
                     // whereas the native stack trace is sorted from callee to caller.
                     var frame = sentryStacktrace.Frames[i];
                     var nativeFrame = nativeStackTrace.Frames[nativeLen - 1 - i];
-                    var mainImageUUID = NormalizeUUID(nativeStackTrace.ImageUuid);
+                    var mainImageUUID = NormalizeUuid(nativeStackTrace.ImageUuid);
 
                     // TODO should we do this for all addresses or only relative ones?
                     //      If the former, we should also update `frame.InstructionAddress` down below.
@@ -129,7 +129,7 @@ namespace Sentry.Unity
                         }
 
                         // First, try to find the image among the loaded ones, otherwise create a dummy one.
-                        mainLibImage ??= DebugImagesSorted.Value.Find((info) => string.Equals(NormalizeUUID(info.Image.DebugId), mainImageUUID))?.Image;
+                        mainLibImage ??= DebugImagesSorted.Value.Find((info) => string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
                         mainLibImage ??= new DebugImage
                         {
                             Type = Application.platform switch
@@ -194,8 +194,21 @@ namespace Sentry.Unity
         // native (contains dashes, all lower-case) & what Unity gives us (no dashes, uppercase).
         // On Linux, the image also has shorter UUID coming from Unity, e.g. 3028cb80b0712541,
         // while native image UUID we get is 3028cb80-b071-2541-0000-000000000000.
-        private static string? NormalizeUUID(string? value) =>
-            value?.ToLowerInvariant().Replace("-", "").TrimEnd(new char[] { '0' });
+        private static string? NormalizeUuid(string? value)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            var normalizedUuid = value.ToLowerInvariant().Replace("-", "");
+            if (normalizedUuid.Length > 32)
+            {
+                normalizedUuid.Remove(32);
+            }
+
+            return normalizedUuid;
+        }
 
         private class DebugImageInfo
         {

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -194,13 +194,18 @@ namespace Sentry.Unity
         // native (contains dashes, all lower-case) & what Unity gives us (no dashes, uppercase).
         // On Linux, the image also has shorter UUID coming from Unity, e.g. 3028cb80b0712541,
         // while native image UUID we get is 3028cb80-b071-2541-0000-000000000000.
+<<<<<<< Updated upstream
         private static string? NormalizeUuid(string? value)
+=======
+        private static string? NormalizeUUID(string? value)
+>>>>>>> Stashed changes
         {
             if (value is null)
             {
                 return null;
             }
 
+<<<<<<< Updated upstream
             var normalizedUuid = value.ToLowerInvariant().Replace("-", "");
             if (normalizedUuid.Length > 32)
             {
@@ -208,6 +213,11 @@ namespace Sentry.Unity
             }
 
             return normalizedUuid;
+=======
+            value = value.ToLowerInvariant();
+            value = value.Replace("-0000-000000000000", "");
+            return value.Replace("-", "");
+>>>>>>> Stashed changes
         }
 
         private class DebugImageInfo

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -194,30 +194,16 @@ namespace Sentry.Unity
         // native (contains dashes, all lower-case) & what Unity gives us (no dashes, uppercase).
         // On Linux, the image also has shorter UUID coming from Unity, e.g. 3028cb80b0712541,
         // while native image UUID we get is 3028cb80-b071-2541-0000-000000000000.
-<<<<<<< Updated upstream
         private static string? NormalizeUuid(string? value)
-=======
-        private static string? NormalizeUUID(string? value)
->>>>>>> Stashed changes
         {
             if (value is null)
             {
                 return null;
             }
 
-<<<<<<< Updated upstream
-            var normalizedUuid = value.ToLowerInvariant().Replace("-", "");
-            if (normalizedUuid.Length > 32)
-            {
-                normalizedUuid.Remove(32);
-            }
-
-            return normalizedUuid;
-=======
             value = value.ToLowerInvariant();
             value = value.Replace("-0000-000000000000", "");
             return value.Replace("-", "");
->>>>>>> Stashed changes
         }
 
         private class DebugImageInfo

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -194,7 +194,7 @@ namespace Sentry.Unity
         // native (contains dashes, all lower-case) & what Unity gives us (no dashes, uppercase).
         // On Linux, the image also has shorter UUID coming from Unity, e.g. 3028cb80b0712541,
         // while native image UUID we get is 3028cb80-b071-2541-0000-000000000000.
-        private static string? NormalizeUuid(string? value)
+        internal static string? NormalizeUuid(string? value)
         {
             if (value is null)
             {

--- a/test/Sentry.Unity.Tests/UnityIl2CppEventExceptionProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityIl2CppEventExceptionProcessorTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+
+namespace Sentry.Unity.Tests
+{
+    public class UnityIl2CppEventExceptionProcessorTests
+    {
+        [Test]
+        [TestCase("f30fef22-d93e-7f60-0000-000000000000", "f30fef22d93e7f60")]
+        [TestCase("0c9249e5-e223-8bd5-0000-000000000000", "0c9249e5e2238bd5")]
+        [TestCase("6f42afa0-45c8-86e6-2372-a02513d55560", "6f42afa045c886e62372a02513d55560")]
+        [TestCase("ff25f952-44c9-4c78-b54f-f8403f185b50-b9a5f714", "ff25f95244c94c78b54ff8403f185b50b9a5f714")]
+        [TestCase("94552647-48dc-4fe4-ba75-7ccd3c43c44d-917f8072", "9455264748dc4fe4ba757ccd3c43c44d917f8072")]
+        public void NormalizeUuid_MatchesExpected(string input, string expected)
+        {
+            var actual = UnityIl2CppEventExceptionProcessor.NormalizeUuid(input);
+
+            Assert.AreEqual(actual, expected);
+        }
+    }
+}

--- a/test/Sentry.Unity.Tests/UnityIl2CppEventExceptionProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/UnityIl2CppEventExceptionProcessorTests.cs
@@ -5,12 +5,13 @@ namespace Sentry.Unity.Tests
     public class UnityIl2CppEventExceptionProcessorTests
     {
         [Test]
+        [TestCase(null, null)]
         [TestCase("f30fef22-d93e-7f60-0000-000000000000", "f30fef22d93e7f60")]
         [TestCase("0c9249e5-e223-8bd5-0000-000000000000", "0c9249e5e2238bd5")]
         [TestCase("6f42afa0-45c8-86e6-2372-a02513d55560", "6f42afa045c886e62372a02513d55560")]
         [TestCase("ff25f952-44c9-4c78-b54f-f8403f185b50-b9a5f714", "ff25f95244c94c78b54ff8403f185b50b9a5f714")]
         [TestCase("94552647-48dc-4fe4-ba75-7ccd3c43c44d-917f8072", "9455264748dc4fe4ba757ccd3c43c44d917f8072")]
-        public void NormalizeUuid_MatchesExpected(string input, string expected)
+        public void NormalizeUuid_ReturnValueMatchesExpected(string input, string expected)
         {
             var actual = UnityIl2CppEventExceptionProcessor.NormalizeUuid(input);
 


### PR DESCRIPTION
Trimming `0` on UUIDs with a trailing `0` leads to a malformed UUID and failure to symbolicate.