### PR TITLE
fix: CI selenium update

### DIFF
--- a/scripts/smoke-test-webgl.py
+++ b/scripts/smoke-test-webgl.py
@@ -145,10 +145,10 @@ class TestDriver:
         options = Options()
         options.add_experimental_option('excludeSwitches', ['enable-logging'])
         options.add_argument('--headless')
-        d = DesiredCapabilities.CHROME
+        d = {}
         d['goog:loggingPrefs'] = {'browser': 'ALL'}
-        self.driver = webdriver.Chrome(
-            options=options, desired_capabilities=d)
+        options.set_capability('cloud:options', d)
+        self.driver = webdriver.Chrome(options=options)
         self.driver.get('http://{}:{}?test=smoke'.format(host, port))
         self.messages = []
 

--- a/scripts/smoke-test-webgl.py
+++ b/scripts/smoke-test-webgl.py
@@ -15,7 +15,6 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from threading import Thread, Lock
 
 host = '127.0.0.1'
@@ -140,14 +139,13 @@ appServerThread = Thread(target=appServer.serve_forever)
 appServerThread.start()
 time.sleep(1)
 
+
 class TestDriver:
     def __init__(self):
         options = Options()
         options.add_experimental_option('excludeSwitches', ['enable-logging'])
         options.add_argument('--headless')
-        d = {}
-        d['goog:loggingPrefs'] = {'browser': 'ALL'}
-        options.set_capability('cloud:options', d)
+        options.set_capability('goog:loggingPrefs', {'browser': 'ALL'})
         self.driver = webdriver.Chrome(options=options)
         self.driver.get('http://{}:{}?test=smoke'.format(host, port))
         self.messages = []


### PR DESCRIPTION
The automatic bump to Selenium 4.10 leads to:
```
Traceback (most recent call last):
  File "/home/runner/work/sentry-unity/sentry-unity/scripts/smoke-test-webgl.py", line 180, in <module>
    driver = TestDriver()
  File "/home/runner/work/sentry-unity/sentry-unity/scripts/smoke-test-webgl.py", line 150, in __init__
    self.driver = webdriver.Chrome(
TypeError: WebDriver.__init__() got an unexpected keyword argument 'desired_capabilities'
```
Can be seen [here](https://github.com/getsentry/sentry-unity/actions/runs/5250781239/jobs/9485479485).
Trying to follow the [upgrade-docs](https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/#capabilities)

#skip-changelog