### PR TITLE
feat: Remove bitcode check from iOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Suspending Android native support for Mono builds to prevent C# exceptions form causing crashes ([#1362](https://github.com/getsentry/sentry-unity/pull/1362))
 - Fixed an issue where the debug image UUID normalization would malform the UUID leading to a failed symbolication ([#1361](https://github.com/getsentry/sentry-unity/pull/1361))
 
+### Feature
+
+- When building for iOS, the debug symbol upload now works irrespective of whether `Bitcode` is enabled or not ([#1381](https://github.com/getsentry/sentry-unity/pull/1381))
+
 ### Dependencies
 
 - Bump .NET SDK from v3.33.0 to v3.33.1 ([#1370](https://github.com/getsentry/sentry-unity/pull/1370))

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -28,17 +28,11 @@ process_upload_symbols() {{
 }}
 
 export SENTRY_PROPERTIES=sentry.properties
-if [ ""$ENABLE_BITCODE"" = ""NO"" ] ; then
-    echo ""Uploading debug symbols (Bitcode disabled).""
+if [ ""$ACTION"" = ""install"" ] ; then
+    echo ""Uploading debug symbols and bcsymbolmaps.""
     process_upload_symbols
 else
-    echo ""Bitcode is enabled""
-    if [ ""$ACTION"" = ""install"" ] ; then
-        echo ""Uploading debug symbols and bcsymbolmaps (Bitcode enabled).""
-        process_upload_symbols
-    else
-        echo ""Skipping debug symbol upload because Bitcode is enabled and this is a non-install build.""
-    fi
+    echo ""Skipping debug symbol upload because this is a non-install build.""
 fi
 ";
 


### PR DESCRIPTION
It's been deprecated and removed from all kinds of places.