### PR TITLE
fix: Destroy screenshot texture

### DIFF
--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Sentry.Unity
 {
@@ -102,6 +103,8 @@ namespace Sentry.Unity
             RenderTexture.ReleaseTemporary(renderTextureResized);
 
             var bytes = screenshot.EncodeToJPG(_options.ScreenshotCompression);
+            Object.Destroy(screenshot);
+
             _options.DiagnosticLogger?.Log(SentryLevel.Debug,
                     "Screenshot captured at {0}x{1}: {2} bytes", null, width, height, bytes.Length);
             return bytes;

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -1,7 +1,5 @@
-using System;
 using System.IO;
 using Sentry.Extensibility;
-using Sentry.Unity.Integrations;
 using UnityEngine;
 using Object = UnityEngine.Object;
 

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using Sentry.Extensibility;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace Sentry.Unity
 {


### PR DESCRIPTION
This fixes a potential memory leak as `Texture2D` is a Unity object. Those are not garbage collected as readily.
Ideally, I would like to just cache the texture object instead of creating a `new` one every time. Let's see if we can make that work when we're refactoring this to make use of `hints`.