### PR TITLE
feat: Surface options to opt out of the Android `NDK integration`

### DIFF
--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -163,11 +163,11 @@ namespace Sentry.Unity.Editor.Android
             androidManifest.SetAttachScreenshot(false);
 
             // Disabling the native in favor of the C# layer for now
+            androidManifest.SetNdkEnabled(_options.NdkIntegrationEnabled);
+            androidManifest.SetNdkScopeSync(_options.NdkScopeSyncEnabled);
             androidManifest.SetAutoSessionTracking(false);
             androidManifest.SetAutoAppLifecycleBreadcrumbs(false);
             androidManifest.SetAnr(false);
-            // TODO: We need an opt-out for this:
-            androidManifest.SetNdkScopeSync(true);
 
             // TODO: All SentryOptions and create specific Android options
 
@@ -438,6 +438,9 @@ namespace Sentry.Unity.Editor.Android
 
         internal void SetAnr(bool enableAnr)
             => SetMetaData($"{SentryPrefix}.anr.enable", enableAnr.ToString());
+
+        internal void SetNdkEnabled(bool enableNdk)
+            => SetMetaData($"{SentryPrefix}.ndk.enable", enableNdk.ToString());
 
         internal void SetNdkScopeSync(bool enableNdkScopeSync)
             => SetMetaData($"{SentryPrefix}.ndk.scope-sync.enable", enableNdkScopeSync.ToString());

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -90,6 +90,20 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                     EditorGUILayout.HelpBox("Android native support requires IL2CPP scripting backend and is currently unsupported on Mono.", MessageType.Warning);
                 }
 
+                EditorGUI.BeginDisabledGroup(!options.AndroidNativeSupportEnabled);
+                EditorGUI.indentLevel++;
+                options.NdkIntegrationEnabled = EditorGUILayout.Toggle(
+                    new GUIContent("NDK Integration", "Whether to enable NDK Integration to capture" +
+                                                              "errors written in languages such C and C++."),
+                    options.NdkIntegrationEnabled);
+                EditorGUI.BeginDisabledGroup(!options.NdkIntegrationEnabled);
+                options.NdkScopeSyncEnabled = EditorGUILayout.Toggle(
+                    new GUIContent("NDK Scope Sync", "Whether the SDK should sync the scope to the NDK layer."),
+                    options.NdkScopeSyncEnabled);
+                EditorGUI.EndDisabledGroup();
+                EditorGUI.indentLevel--;
+                EditorGUI.EndDisabledGroup();
+
                 options.WindowsNativeSupportEnabled = EditorGUILayout.Toggle(
                     new GUIContent("Windows Native Support", "Whether to enable native crashes support on Windows."),
                     options.WindowsNativeSupportEnabled);

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -90,8 +90,8 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                     EditorGUILayout.HelpBox("Android native support requires IL2CPP scripting backend and is currently unsupported on Mono.", MessageType.Warning);
                 }
 
-                EditorGUI.BeginDisabledGroup(!options.AndroidNativeSupportEnabled);
                 EditorGUI.indentLevel++;
+                EditorGUI.BeginDisabledGroup(!options.AndroidNativeSupportEnabled);
                 options.NdkIntegrationEnabled = EditorGUILayout.Toggle(
                     new GUIContent("NDK Integration", "Whether to enable NDK Integration to capture" +
                                                               "errors written in languages such C and C++."),
@@ -101,8 +101,8 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                     new GUIContent("NDK Scope Sync", "Whether the SDK should sync the scope to the NDK layer."),
                     options.NdkScopeSyncEnabled);
                 EditorGUI.EndDisabledGroup();
-                EditorGUI.indentLevel--;
                 EditorGUI.EndDisabledGroup();
+                EditorGUI.indentLevel--;
 
                 options.WindowsNativeSupportEnabled = EditorGUILayout.Toggle(
                     new GUIContent("Windows Native Support", "Whether to enable native crashes support on Windows."),

--- a/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/ScriptableSentryUnityOptionsEditor.cs
@@ -78,6 +78,10 @@ namespace Sentry.Unity.Editor
 
             EditorGUILayout.Toggle("iOS Native Support", options.IosNativeSupportEnabled);
             EditorGUILayout.Toggle("Android Native Support", options.AndroidNativeSupportEnabled);
+            EditorGUI.indentLevel++;
+            EditorGUILayout.Toggle("NDK Integration", options.NdkIntegrationEnabled);
+            EditorGUILayout.Toggle("NDK Scope Sync", options.NdkScopeSyncEnabled);
+            EditorGUI.indentLevel--;
             EditorGUILayout.Toggle("Windows Native Support", options.WindowsNativeSupportEnabled);
             EditorGUILayout.Toggle("macOS Native Support", options.MacosNativeSupportEnabled);
             EditorGUILayout.Toggle("Linux Native Support", options.LinuxNativeSupportEnabled);

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -89,6 +89,8 @@ namespace Sentry.Unity
 
         [field: SerializeField] public bool IosNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool AndroidNativeSupportEnabled { get; set; } = true;
+        [field: SerializeField] public bool NdkIntegrationEnabled { get; set; } = true;
+        [field: SerializeField] public bool NdkScopeSyncEnabled { get; set; } = true;
         [field: SerializeField] public bool WindowsNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool MacosNativeSupportEnabled { get; set; } = true;
         [field: SerializeField] public bool LinuxNativeSupportEnabled { get; set; } = true;
@@ -163,6 +165,7 @@ namespace Sentry.Unity
                 FilterBadGatewayExceptions = FilterBadGatewayExceptions,
                 IosNativeSupportEnabled = IosNativeSupportEnabled,
                 AndroidNativeSupportEnabled = AndroidNativeSupportEnabled,
+                NdkIntegrationEnabled = NdkIntegrationEnabled,
                 WindowsNativeSupportEnabled = WindowsNativeSupportEnabled,
                 MacosNativeSupportEnabled = MacosNativeSupportEnabled,
                 LinuxNativeSupportEnabled = LinuxNativeSupportEnabled,

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -155,6 +155,16 @@ namespace Sentry.Unity
         public bool AndroidNativeSupportEnabled { get; set; } = true;
 
         /// <summary>
+        /// Whether the SDK should add the NDK integration for Android
+        /// </summary>
+        public bool NdkIntegrationEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Whether the SDK should sync the scope to the NDK layer for Android
+        /// </summary>
+        public bool NdkScopeSyncEnabled { get; set; } = true;
+
+        /// <summary>
         /// Whether the SDK should add native support for Windows
         /// </summary>
         public bool WindowsNativeSupportEnabled { get; set; } = true;


### PR DESCRIPTION
Relates to: https://github.com/getsentry/sentry-unity/issues/1444
Gives more granular control over the Android native support by allowing to disable the NDK integration.
Added an opt-out for scope sync while at it.