### PR TITLE
ref: Removed redundant integration registry logs

### DIFF
--- a/src/Sentry.Unity/Integrations/SceneManagerIntegration.cs
+++ b/src/Sentry.Unity/Integrations/SceneManagerIntegration.cs
@@ -1,7 +1,7 @@
 using Sentry.Integrations;
 using UnityEngine.SceneManagement;
 
-namespace Sentry.Unity
+namespace Sentry.Unity.Integrations
 {
     internal class SceneManagerIntegration : ISdkIntegration
     {
@@ -15,8 +15,6 @@ namespace Sentry.Unity
 
         public void Register(IHub hub, SentryOptions options)
         {
-            options.DiagnosticLogger?.Log(SentryLevel.Debug, "Registering SceneManager integration.");
-
             _sceneManager.SceneLoaded += OnSceneManagerOnSceneLoaded;
             _sceneManager.SceneUnloaded += SceneManagerOnSceneUnloaded;
             _sceneManager.ActiveSceneChanged += SceneManagerOnActiveSceneChanged;

--- a/src/Sentry.Unity/Integrations/UnityBeforeSceneLoadIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityBeforeSceneLoadIntegration.cs
@@ -17,8 +17,6 @@ namespace Sentry.Unity.Integrations
                 : null;
 
             hub.AddBreadcrumb(message: "BeforeSceneLoad", category: "scene.beforeload", data: data);
-
-            options.DiagnosticLogger?.Log(SentryLevel.Debug, "Registered BeforeSceneLoad integration.");
         }
     }
 }

--- a/test/Sentry.Unity.Tests/SceneManagerIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/SceneManagerIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using Sentry.Unity.Integrations;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine.SceneManagement;
 


### PR DESCRIPTION
Integration registration already DebugLogs `Registering integration: '{0}'.`

#skip-changelog