### PR TITLE
fix changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## Feature
+### Feature
 
 - Added the dedicated server platforms to the known platforms to prevent the SDK from interpreting them as restricted platforms (i.e. disabling offline caching, session tracking) ([#1468](https://github.com/getsentry/sentry-unity/pull/1468))
 


### PR DESCRIPTION
Otherwise auto kicks in and adds all commits:

![image](https://github.com/getsentry/sentry-unity/assets/1633368/7dbad17a-af72-4c16-9441-ff1ac40f5820)

#skip-changelog