### PR TITLE
fix: Made SDK pause event agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed an issue with the SDK failing to properly detect application pause and focus lost events and creating false positive ANR events (specifically on Android) ([#1484](https://github.com/getsentry/sentry-unity/pull/1484))
+
 ### Dependencies
 
 - Bump CLI from v2.21.2 to v2.21.5 ([#1485](https://github.com/getsentry/sentry-unity/pull/1485), [#1494](https://github.com/getsentry/sentry-unity/pull/1494), [#1495](https://github.com/getsentry/sentry-unity/pull/1495))

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -63,7 +63,7 @@ namespace Sentry.Unity
         public event Action? ApplicationPausing;
 
         // Keeping internal track of running state because OnApplicationPause and OnApplicationFocus get called during startup and would fire false resume events
-        private bool _isRunning = true;
+        internal bool _isRunning = true;
 
         private IApplication? _application;
         internal IApplication Application

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -91,34 +91,15 @@ namespace Sentry.Unity
         }
 
         /// <summary>
-        /// To receive Leaving/Resuming events on Android.
-        /// <remarks>
-        /// On Android, when the on-screen keyboard is enabled, it causes a OnApplicationFocus(false) event.
-        /// Additionally, if you press "Home" at the moment the keyboard is enabled, the OnApplicationFocus() event is
-        /// not called, but OnApplicationPause() is called instead.
-        /// </remarks>
-        /// <seealso href="https://docs.unity3d.com/2019.4/Documentation/ScriptReference/MonoBehaviour.OnApplicationPause.html"/>
+        /// To receive Pause events.
         /// </summary>
-        internal void OnApplicationPause(bool pauseStatus)
-        {
-            if (Application.Platform == RuntimePlatform.Android)
-            {
-                UpdatePauseStatus(pauseStatus);
-            }
-        }
+        internal void OnApplicationPause(bool pauseStatus) => UpdatePauseStatus(pauseStatus);
 
         /// <summary>
-        /// To receive Leaving/Resuming events on all platforms except Android.
+        /// To receive Focus events.
         /// </summary>
         /// <param name="hasFocus"></param>
-        internal void OnApplicationFocus(bool hasFocus)
-        {
-            // To avoid event duplication on Android since the pause event will be handled via OnApplicationPause
-            if (Application.Platform != RuntimePlatform.Android)
-            {
-                UpdatePauseStatus(!hasFocus);
-            }
-        }
+        internal void OnApplicationFocus(bool hasFocus) => UpdatePauseStatus(!hasFocus);
 
         // The GameObject has to destroy itself since it was created with HideFlags.HideAndDontSave
         private void OnApplicationQuit() => Destroy(gameObject);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1458
Am I missing something? Why did we need to special-case it? Worst case we're pausing twice but `UpdatePauseStatus` is reentrant and handles that anyway.