### PR TITLE
fix: SDK name reporting on iOS

### DIFF
--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -30,7 +30,7 @@ static SentryOptions* getSentryOptions()
         @""enableAutoSessionTracking"": @NO,
         @""enableAppHangTracking"": @NO,
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
-        @""attachScreenshot"" : @""{{options.AttachScreenshot}}"",
+        @""attachScreenshot"" : @""{options.AttachScreenshot}"",
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}""
     }};

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -22,7 +22,6 @@ static SentryOptions* getSentryOptions()
     [PrivateSentrySDKOnly setSdkName:@""sentry.cocoa.unity""];
 
     NSDictionary* optionsDictionary = @{{
-        @""sdk"" : @{{ @""name"": @""sentry.cocoa.unity"" }},
         @""dsn"" : @""{options.Dsn}"",
         @""debug"" : @{ToObjCString(options.Debug)},
         @""diagnosticLevel"" : @""{ToNativeDiagnosticLevel(options.DiagnosticLevel)}"",

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -30,7 +30,7 @@ static SentryOptions* getSentryOptions()
         @""enableAutoSessionTracking"": @NO,
         @""enableAppHangTracking"": @NO,
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
-        @""attachScreenshot"" : @{ToObjCString(options.AttachScreenshot)},
+        @""attachScreenshot"" : @""{{options.AttachScreenshot}}"",
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}""
     }};

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -10,6 +10,7 @@ namespace Sentry.Unity.Editor.iOS
         {
             var nativeOptions = $@"#import <Foundation/Foundation.h>
 #import <Sentry/SentryOptions+HybridSDKs.h>
+#import <Sentry/PrivateSentrySDKOnly.h>
 
 // IMPORTANT: Changes to this file will be lost!
 // This file is generated during the Xcode project creation.
@@ -18,6 +19,8 @@ namespace Sentry.Unity.Editor.iOS
 
 static SentryOptions* getSentryOptions()
 {{
+    [PrivateSentrySDKOnly setSdkName:@""sentry.cocoa.unity""];
+
     NSDictionary* optionsDictionary = @{{
         @""sdk"" : @{{ @""name"": @""sentry.cocoa.unity"" }},
         @""dsn"" : @""{options.Dsn}"",
@@ -28,7 +31,7 @@ static SentryOptions* getSentryOptions()
         @""enableAutoSessionTracking"": @NO,
         @""enableAppHangTracking"": @NO,
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
-        @""attachScreenshot"" : @""{options.AttachScreenshot}"",
+        @""attachScreenshot"" : @{ToObjCString(options.AttachScreenshot)},
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}""
     }};


### PR DESCRIPTION
Setting the SKD name has to happen through `PrivateSentrySDKOnly`. The SDK name no longer gets picked up through the options.

#skip-changelog