### PR TITLE
fix: Attaching screenshots on native iOS crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed screenshots not being attached to iOS native crashes ([#1517](https://github.com/getsentry/sentry-unity/pull/1517))
+
 ### Dependencies
 
 - Bump CLI from v2.21.2 to v2.22.3 ([#1501](https://github.com/getsentry/sentry-unity/pull/1501), [#1502](https://github.com/getsentry/sentry-unity/pull/1502))

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -28,7 +28,7 @@ static SentryOptions* getSentryOptions()
         @""enableAutoSessionTracking"": @NO,
         @""enableAppHangTracking"": @NO,
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
-        @""attachScreenshot"" : @""{options.AttachScreenshot}"",
+        @""attachScreenshot"" : @{ToObjCString(options.AttachScreenshot)},
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}""
     }};


### PR DESCRIPTION
Fixed the setting of `attachScreenshot` on the native options.