### PR TITLE
fix: WegGL smoketest

### DIFF
--- a/samples/unity-of-bugs/Assets/Scripts/Editor.meta
+++ b/samples/unity-of-bugs/Assets/Scripts/Editor.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 094322ed9aa243c68f9d1a1374c21efa
+timeCreated: 1702488552

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -85,7 +85,11 @@ public class Builder
         BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android);
     }
     public static void BuildIOSProject() => BuildIl2CPPPlayer(BuildTarget.iOS, BuildTargetGroup.iOS);
-    public static void BuildWebGLPlayer() => BuildIl2CPPPlayer(BuildTarget.WebGL, BuildTargetGroup.WebGL);
+    public static void BuildWebGLPlayer()
+    {
+        PlayerSettings.WebGL.compressionFormat = WebGLCompressionFormat.Brotli;
+        BuildIl2CPPPlayer(BuildTarget.WebGL, BuildTargetGroup.WebGL);
+    }
 
     public static Dictionary<string, string> ParseCommandLineArguments()
     {


### PR DESCRIPTION
For whatever reason we're suddenly stuck with `.gz` on WebGL builds but on 2021 only?

#skip-changelog