### PR TITLE
fix: IL2CPP line number processing for dedicated server builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- The SDK no longer fails to resolve the debug symbol type on dedicated server builds ([#1522](https://github.com/getsentry/sentry-unity/pull/1522))
 - Fixed screenshots not being attached to iOS native crashes ([#1517](https://github.com/getsentry/sentry-unity/pull/1517))
 
 ### Dependencies

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -328,38 +328,38 @@ namespace Sentry.Unity
                 default:
                     return false;
             }
+        }
 
-            public bool IsSupportedBySentryNative(RuntimePlatform platform)
-            {
-                return platform ==
-                       RuntimePlatform.Android
-                       || RuntimePlatform.LinuxPlayer
-                       || RuntimePlatform.WindowsPlayer
-#if UNITY_2021_3_OR_NEWER
-                        || RuntimePlatform.WindowsServer
-                        || RuntimePlatform.OSXServer
-                        || RuntimePlatform.LinuxServer
-#endif
-                    ;
-            }
 
-            public string GetDebugImageType(RuntimePlatform platform)
-            {
-                platform switch
-                {
-                    RuntimePlatform.Android => "elf",
-                    RuntimePlatform.IPhonePlayer => "macho",
-                    RuntimePlatform.OSXPlayer => "macho",
-                    RuntimePlatform.LinuxPlayer => "elf",
-                    RuntimePlatform.WindowsPlayer => "pe",
+        public bool IsSupportedBySentryNative(RuntimePlatform platform)
+        {
+            return platform == RuntimePlatform.Android
+                   || platform == RuntimePlatform.LinuxPlayer
+                   || platform == RuntimePlatform.WindowsPlayer
 #if UNITY_2021_3_OR_NEWER
-                    RuntimePlatform.WindowsServer => "pe",
-                    RuntimePlatform.OSXServer => "macho",
-                    RuntimePlatform.LinuxServer => "elf",
+                   || platform == RuntimePlatform.WindowsServer
+                   || platform == RuntimePlatform.OSXServer
+                   || platform == RuntimePlatform.LinuxServer
 #endif
-                    _ => "unknown"
-                };
-            }
+                ;
+        }
+
+        public string GetDebugImageType(RuntimePlatform platform)
+        {
+            return platform switch
+            {
+                RuntimePlatform.Android => "elf",
+                RuntimePlatform.IPhonePlayer => "macho",
+                RuntimePlatform.OSXPlayer => "macho",
+                RuntimePlatform.LinuxPlayer => "elf",
+                RuntimePlatform.WindowsPlayer => "pe",
+#if UNITY_2021_3_OR_NEWER
+                RuntimePlatform.WindowsServer => "pe",
+                RuntimePlatform.OSXServer => "macho",
+                RuntimePlatform.LinuxServer => "elf",
+#endif
+                _ => "unknown"
+            };
         }
     }
 }

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -346,20 +346,29 @@ namespace Sentry.Unity
 
         public string GetDebugImageType(RuntimePlatform platform)
         {
-            return platform switch
+            switch (platform)
             {
-                RuntimePlatform.Android => "elf",
-                RuntimePlatform.IPhonePlayer => "macho",
-                RuntimePlatform.OSXPlayer => "macho",
-                RuntimePlatform.LinuxPlayer => "elf",
-                RuntimePlatform.WindowsPlayer => "pe",
+                case RuntimePlatform.Android:
+                    return "elf";
+                case RuntimePlatform.IPhonePlayer:
+                    return "macho";
+                case RuntimePlatform.OSXPlayer:
+                    return "macho";
+                case RuntimePlatform.LinuxPlayer:
+                    return "elf";
+                case RuntimePlatform.WindowsPlayer:
+                    return "pe";
 #if UNITY_2021_3_OR_NEWER
-                RuntimePlatform.WindowsServer => "pe",
-                RuntimePlatform.OSXServer => "macho",
-                RuntimePlatform.LinuxServer => "elf",
+                case RuntimePlatform.WindowsServer:
+                    return "pe";
+                case RuntimePlatform.OSXServer:
+                    return "macho";
+                case RuntimePlatform.LinuxServer:
+                    return "elf";
 #endif
-                _ => "unknown"
-            };
+                default:
+                    return "unknown";
+            }
         }
     }
 }

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -328,6 +328,38 @@ namespace Sentry.Unity
                 default:
                     return false;
             }
-		}
+
+            public bool IsSupportedBySentryNative(RuntimePlatform platform)
+            {
+                return platform ==
+                       RuntimePlatform.Android
+                       || RuntimePlatform.LinuxPlayer
+                       || RuntimePlatform.WindowsPlayer
+#if UNITY_2021_3_OR_NEWER
+                        || RuntimePlatform.WindowsServer
+                        || RuntimePlatform.OSXServer
+                        || RuntimePlatform.LinuxServer
+#endif
+                    ;
+            }
+
+            public string GetDebugImageType(RuntimePlatform platform)
+            {
+                platform switch
+                {
+                    RuntimePlatform.Android => "elf",
+                    RuntimePlatform.IPhonePlayer => "macho",
+                    RuntimePlatform.OSXPlayer => "macho",
+                    RuntimePlatform.LinuxPlayer => "elf",
+                    RuntimePlatform.WindowsPlayer => "pe",
+#if UNITY_2021_3_OR_NEWER
+                    RuntimePlatform.WindowsServer => "pe",
+                    RuntimePlatform.OSXServer => "macho",
+                    RuntimePlatform.LinuxServer => "elf",
+#endif
+                    _ => "unknown"
+                };
+            }
+        }
     }
 }

--- a/src/Sentry.Unity/ISentryUnityInfo.cs
+++ b/src/Sentry.Unity/ISentryUnityInfo.cs
@@ -10,6 +10,8 @@ namespace Sentry.Unity
         public bool IsKnownPlatform();
         public bool IsLinux();
         public bool IsNativeSupportEnabled(SentryUnityOptions options, RuntimePlatform platform);
+        public bool IsSupportedBySentryNative(RuntimePlatform platform);
+        public string GetDebugImageType(RuntimePlatform platform);
     }
 
     public class Il2CppMethods

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -223,37 +223,35 @@ namespace Sentry.Unity
             var result = new List<DebugImageInfo>();
 
             // Only on platforms where we actually use sentry-native.
-            if (!UnityInfo.IsSupportedBySentryNative(Application.platform))
+            if (UnityInfo.IsSupportedBySentryNative(Application.platform))
             {
-                return result;
-            }
-
-            var nativeDebugImages = C.DebugImages.Value;
-            foreach (var image in nativeDebugImages)
-            {
-                if (image.ImageSize is null)
+                var nativeDebugImages = C.DebugImages.Value;
+                foreach (var image in nativeDebugImages)
                 {
-                    Logger?.Log(SentryLevel.Debug,
-                        "Skipping debug image '{0}' (CodeId {1} | DebugId: {2}) because its size is NULL",
-                        null, image.CodeFile, image.CodeId, image.DebugId);
-                    continue;
-                }
-
-                var info = new DebugImageInfo(image);
-                var i = 0;
-                for (; i < result.Count; i++)
-                {
-                    if (info.StartAddress < result[i].StartAddress)
+                    if (image.ImageSize is null)
                     {
-                        // insert at index `i`, all the rest have a larger start address
-                        break;
+                        Logger?.Log(SentryLevel.Debug,
+                            "Skipping debug image '{0}' (CodeId {1} | DebugId: {2}) because its size is NULL",
+                            null, image.CodeFile, image.CodeId, image.DebugId);
+                        continue;
                     }
-                }
-                result.Insert(i, info);
 
-                Logger?.Log(SentryLevel.Debug,
-                    "Found debug image '{0}' (CodeId {1} | DebugId: {2}) with addresses between {3:X8} and {4:X8}",
-                    null, image.CodeFile, image.CodeId, image.DebugId, info.StartAddress, info.EndAddress);
+                    var info = new DebugImageInfo(image);
+                    var i = 0;
+                    for (; i < result.Count; i++)
+                    {
+                        if (info.StartAddress < result[i].StartAddress)
+                        {
+                            // insert at index `i`, all the rest have a larger start address
+                            break;
+                        }
+                    }
+                    result.Insert(i, info);
+
+                    Logger?.Log(SentryLevel.Debug,
+                        "Found debug image '{0}' (CodeId {1} | DebugId: {2}) with addresses between {3:X8} and {4:X8}",
+                        null, image.CodeFile, image.CodeId, image.DebugId, info.StartAddress, info.EndAddress);
+                }
             }
             return result;
         });

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -13,12 +13,14 @@ namespace Sentry.Unity
     internal class UnityIl2CppEventExceptionProcessor : ISentryEventExceptionProcessor
     {
         private readonly SentryUnityOptions _options;
+        private static ISentryUnityInfo UnityInfo = null!; // private static will be initialized in the constructor
         private readonly Il2CppMethods _il2CppMethods;
 
-        public UnityIl2CppEventExceptionProcessor(SentryUnityOptions options, Il2CppMethods il2CppMethods)
+        public UnityIl2CppEventExceptionProcessor(SentryUnityOptions options, ISentryUnityInfo unityInfo)
         {
             _options = options;
-            _il2CppMethods = il2CppMethods;
+            UnityInfo = unityInfo;
+            _il2CppMethods = unityInfo.Il2CppMethods ?? throw new ArgumentNullException(nameof(unityInfo.Il2CppMethods), "Unity IL2CPP methods are not available.");
 
             _options.SdkIntegrationNames.Add("IL2CPPLineNumbers");
         }
@@ -94,7 +96,7 @@ namespace Sentry.Unity
                     var instructionAddress = (ulong)nativeFrame.ToInt64();
 
                     // We cannot determine whether this frame is a main library frame just from the address
-                    // because even relative address on the frame may correspond to an absolute addres of a loaded library.
+                    // because even relative address on the frame may correspond to an absolute address of a loaded library.
                     // Therefore, if the frame package matches known prefixes, we assume it's a GameAssembly frame.
                     var isMainLibFrame = frame.Package is not null && (
                         frame.Package.StartsWith("UnityEngine.", StringComparison.InvariantCultureIgnoreCase) ||
@@ -129,18 +131,10 @@ namespace Sentry.Unity
                         }
 
                         // First, try to find the image among the loaded ones, otherwise create a dummy one.
-                        mainLibImage ??= DebugImagesSorted.Value.Find((info) => string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
+                        mainLibImage ??= _debugImagesSorted.Value.Find((info) => string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
                         mainLibImage ??= new DebugImage
                         {
-                            Type = Application.platform switch
-                            {
-                                RuntimePlatform.Android => "elf",
-                                RuntimePlatform.IPhonePlayer => "macho",
-                                RuntimePlatform.OSXPlayer => "macho",
-                                RuntimePlatform.LinuxPlayer => "elf",
-                                RuntimePlatform.WindowsPlayer => "pe",
-                                _ => "unknown"
-                            },
+                            Type = UnityInfo.GetDebugImageType(Application.platform),
                             // NOTE: il2cpp in some circumstances does not return a correct `ImageName`.
                             // A null/missing `CodeFile` however would lead to a processing error in sentry.
                             // Since the code file is not strictly necessary for processing, we just fall back to
@@ -224,48 +218,49 @@ namespace Sentry.Unity
 
         private static IDiagnosticLogger? Logger;
 
-        private static readonly Lazy<List<DebugImageInfo>> DebugImagesSorted = new(() =>
+        private readonly Lazy<List<DebugImageInfo>> _debugImagesSorted = new(() =>
         {
             var result = new List<DebugImageInfo>();
 
             // Only on platforms where we actually use sentry-native.
-            if (ApplicationAdapter.Instance.Platform
-                is RuntimePlatform.WindowsPlayer or RuntimePlatform.Android or RuntimePlatform.LinuxPlayer)
+            if (!UnityInfo.IsSupportedBySentryNative(Application.platform))
             {
-                var nativeDebugImages = C.DebugImages.Value;
-                foreach (var image in nativeDebugImages)
+                return result;
+            }
+
+            var nativeDebugImages = C.DebugImages.Value;
+            foreach (var image in nativeDebugImages)
+            {
+                if (image.ImageSize is null)
                 {
-                    if (image.ImageSize is null)
-                    {
-                        Logger?.Log(SentryLevel.Debug,
-                            "Skipping debug image '{0}' (CodeId {1} | DebugId: {2}) because its size is NULL",
-                            null, image.CodeFile, image.CodeId, image.DebugId);
-                        continue;
-                    }
-
-                    var info = new DebugImageInfo(image);
-                    var i = 0;
-                    for (; i < result.Count; i++)
-                    {
-                        if (info.StartAddress < result[i].StartAddress)
-                        {
-                            // insert at index `i`, all the rest have a larger start address
-                            break;
-                        }
-                    }
-                    result.Insert(i, info);
-
                     Logger?.Log(SentryLevel.Debug,
-                        "Found debug image '{0}' (CodeId {1} | DebugId: {2}) with addresses between {3:X8} and {4:X8}",
-                        null, image.CodeFile, image.CodeId, image.DebugId, info.StartAddress, info.EndAddress);
+                        "Skipping debug image '{0}' (CodeId {1} | DebugId: {2}) because its size is NULL",
+                        null, image.CodeFile, image.CodeId, image.DebugId);
+                    continue;
                 }
+
+                var info = new DebugImageInfo(image);
+                var i = 0;
+                for (; i < result.Count; i++)
+                {
+                    if (info.StartAddress < result[i].StartAddress)
+                    {
+                        // insert at index `i`, all the rest have a larger start address
+                        break;
+                    }
+                }
+                result.Insert(i, info);
+
+                Logger?.Log(SentryLevel.Debug,
+                    "Found debug image '{0}' (CodeId {1} | DebugId: {2}) with addresses between {3:X8} and {4:X8}",
+                    null, image.CodeFile, image.CodeId, image.DebugId, info.StartAddress, info.EndAddress);
             }
             return result;
         });
 
-        private static DebugImage? FindDebugImageContainingAddress(ulong instructionAddress)
+        private DebugImage? FindDebugImageContainingAddress(ulong instructionAddress)
         {
-            var list = DebugImagesSorted.Value;
+            var list = _debugImagesSorted.Value;
 
             // Manual binary search implementation on "value in range".
             var lowerBound = 0;

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -131,7 +131,7 @@ namespace Sentry.Unity
                         }
 
                         // First, try to find the image among the loaded ones, otherwise create a dummy one.
-                        mainLibImage ??= _debugImagesSorted.Value.Find((info) => string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
+                        mainLibImage ??= DebugImagesSorted.Value.Find((info) => string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
                         mainLibImage ??= new DebugImage
                         {
                             Type = UnityInfo.GetDebugImageType(Application.platform),
@@ -218,7 +218,7 @@ namespace Sentry.Unity
 
         private static IDiagnosticLogger? Logger;
 
-        private readonly Lazy<List<DebugImageInfo>> _debugImagesSorted = new(() =>
+        private static readonly Lazy<List<DebugImageInfo>> DebugImagesSorted = new(() =>
         {
             var result = new List<DebugImageInfo>();
 
@@ -258,7 +258,7 @@ namespace Sentry.Unity
 
         private DebugImage? FindDebugImageContainingAddress(ulong instructionAddress)
         {
-            var list = _debugImagesSorted.Value;
+            var list = DebugImagesSorted.Value;
 
             // Manual binary search implementation on "value in range".
             var lowerBound = 0;

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -256,7 +256,7 @@ namespace Sentry.Unity
             return result;
         });
 
-        private DebugImage? FindDebugImageContainingAddress(ulong instructionAddress)
+        private static DebugImage? FindDebugImageContainingAddress(ulong instructionAddress)
         {
             var list = DebugImagesSorted.Value;
 

--- a/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
+++ b/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
@@ -67,7 +67,7 @@ namespace Sentry.Unity
         {
             if (unityInfo.Il2CppMethods is not null)
             {
-                options.AddExceptionProcessor(new UnityIl2CppEventExceptionProcessor(options, unityInfo.Il2CppMethods));
+                options.AddExceptionProcessor(new UnityIl2CppEventExceptionProcessor(options, unityInfo));
             }
             else
             {

--- a/test/SharedClasses/TestUnityInfo.cs
+++ b/test/SharedClasses/TestUnityInfo.cs
@@ -6,20 +6,25 @@ public class TestUnityInfo : ISentryUnityInfo
     private readonly bool _isKnownPlatform;
     private readonly bool _isLinux;
     private readonly bool _isNativeSupportEnabled;
+    private readonly bool _isSupportedBySentryNative;
 
     public bool IL2CPP { get; set; }
     public string? Platform { get; }
     public Il2CppMethods? Il2CppMethods { get; }
 
-    public TestUnityInfo(bool isKnownPlatform = true, bool isLinux = false, bool isNativeSupportEnabled = true)
+    public TestUnityInfo(bool isKnownPlatform = true, bool isLinux = false, bool isNativeSupportEnabled = true, bool isSupportedBySentryNative = true)
     {
         _isKnownPlatform = isKnownPlatform;
         _isLinux = isLinux;
         _isNativeSupportEnabled = isNativeSupportEnabled;
+        _isSupportedBySentryNative = isSupportedBySentryNative;
     }
 
     public bool IsKnownPlatform() => _isKnownPlatform;
     public bool IsLinux() => _isLinux;
 
     public bool IsNativeSupportEnabled(SentryUnityOptions options, RuntimePlatform platform) => _isNativeSupportEnabled;
+    public bool IsSupportedBySentryNative(RuntimePlatform platform) => _isSupportedBySentryNative;
+
+    public string GetDebugImageType(RuntimePlatform platform) => "debug";
 }


### PR DESCRIPTION
Fixed the checks for `RuntimePlatform` in the IL2CPP exception processor. Those need to be conditionally compiled with the game.