### PR TITLE
feat: Allow for manual application pause update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- The static `SentryMonoBehaviour` now has it's `UpdatePauseStatus` public, allowing users to manually update the SDK's internal pause status. This helps work around false positive ANR events when using plugins that take away control from the game i.e. ad frameworks like AppLovin or Ironsource ([#1529](https://github.com/getsentry/sentry-unity/pull/1529))
 - It's now possible enable to `CaptureFailedRequests` and the statuscode ranges via the editor. These also apply to the native SDK on `iOS` ([#1514](https://github.com/getsentry/sentry-unity/pull/1514))
 
 ### Fixes

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -48,17 +48,11 @@ namespace Sentry.Unity
     {
         /// <summary>
         /// Hook to receive an event when the application gains focus.
-        /// <remarks>
-        /// Listens to OnApplicationFocus for all platforms except Android, where we listen to OnApplicationPause.
-        /// </remarks>
         /// </summary>
         public event Action? ApplicationResuming;
 
         /// <summary>
         /// Hook to receive an event when the application loses focus.
-        /// <remarks>
-        /// Listens to OnApplicationFocus for all platforms except Android, where we listen to OnApplicationPause.
-        /// </remarks>
         /// </summary>
         public event Action? ApplicationPausing;
 
@@ -76,7 +70,10 @@ namespace Sentry.Unity
             set => _application = value;
         }
 
-        internal void UpdatePauseStatus(bool paused)
+        /// <summary>
+        /// Updates the SDK's internal pause status
+        /// </summary>
+        public void UpdatePauseStatus(bool paused)
         {
             if (paused && _isRunning)
             {


### PR DESCRIPTION
We continuously have issues regarding false positive ANR events coming in combination with Ad-SDKs from providers like AppLovin and Ironsource. These SDKs put the game in the background and or pause them. This seems to circumvent our `SentryMonoBehavious` hooks for pause/focus events.
Making the `UpdatePauseStatus` public allows users to manually unblock themselves by setting the SDK's pause status.