### PR TITLE
fix: Test fake

### DIFF
--- a/test/Sentry.Unity.Tests/IntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/IntegrationTests.cs
@@ -272,7 +272,7 @@ namespace Sentry.Unity.Tests
         }
 
         [UnityTest]
-        public IEnumerator DebugLogException_InTask_IsCapturedAndIsMainThreadIsTrue()
+        public IEnumerator DebugLogException_InTask_IsCapturedAndIsMainThreadIsFalse()
         {
             yield return SetupSceneCoroutine("1_BugFarm");
 

--- a/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs
+++ b/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs
@@ -12,7 +12,12 @@ namespace Sentry.Unity.Tests.TestBehaviours
     {
         public void ThrowException(string message) => throw new Exception(message);
         public void DebugLogError(string message) => Debug.LogError(message);
-        public void DebugLogErrorInTask(string message) => Task.Run(() => DebugLogError(message));
+        public void DebugLogErrorInTask(string message) => Task.Run(() =>
+        {
+            // Don't fail test if an error is logged via 'SendMessage'. We want to continue.
+            LogAssert.ignoreFailingMessages = true;
+            DebugLogError(message);
+        });
         public void DebugLogException(string message)
         {
             // Don't fail test if an exception is thrown via 'SendMessage'. We want to continue.

--- a/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs
+++ b/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs
@@ -18,13 +18,13 @@ namespace Sentry.Unity.Tests.TestBehaviours
             LogAssert.ignoreFailingMessages = true;
             DebugLogError(message);
         });
-        public void DebugLogException(string message)
+        public void DebugLogException(string message) => Debug.LogException(new Exception(message));
+
+        public void DebugLogExceptionInTask(string message) => Task.Run(() =>
         {
             // Don't fail test if an exception is thrown via 'SendMessage'. We want to continue.
             LogAssert.ignoreFailingMessages = true;
-            Debug.LogException(new Exception(message));
-        }
-
-        public void DebugLogExceptionInTask(string message) => Task.Run(() => DebugLogException(message));
+            DebugLogException(message);
+        });
     }
 }

--- a/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs
+++ b/test/Sentry.Unity.Tests/TestBehaviours/TestMonoBehaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Sentry.Unity.Tests.TestBehaviours
 {
@@ -12,7 +13,13 @@ namespace Sentry.Unity.Tests.TestBehaviours
         public void ThrowException(string message) => throw new Exception(message);
         public void DebugLogError(string message) => Debug.LogError(message);
         public void DebugLogErrorInTask(string message) => Task.Run(() => DebugLogError(message));
-        public void DebugLogException(string message) => Debug.LogException(new Exception(message));
+        public void DebugLogException(string message)
+        {
+            // Don't fail test if an exception is thrown via 'SendMessage'. We want to continue.
+            LogAssert.ignoreFailingMessages = true;
+            Debug.LogException(new Exception(message));
+        }
+
         public void DebugLogExceptionInTask(string message) => Task.Run(() => DebugLogException(message));
     }
 }


### PR DESCRIPTION
We keep running into flaky tests in combination with `DebugLogException` and
```
Test 1064: DebugLogException_***
Unhandled log message: '[Exception] Exception: f39f46e8-d13a-445b-b25b-4ce562514c67 Test Event'.
```
I suspect the `LogAssert` is not working properly when logging within a `Task.Run`.

#skip-changelog