### PR TITLE
fix: CI `pwsh: Command not found.`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
           android: false
           dotnet: false
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: false
           swap-storage: true      
 


### PR DESCRIPTION
GH images for all OSes updated Powershell to 7.4: https://github.com/actions/runner-images/issues/9115
The action `free-disk-space` removes `powershell` as part of [`large-packages`](https://github.com/jlumbroso/free-disk-space/blob/54081f138730dfa15788a46383842cd2f914a1be/action.yml#L181). What I don't get is why it was working before and why it's not working anymore.
Leaving `large-packages` changes from:
- Previously: 11 GB saved
- Now: 4 GB saved

which is still enough space. And we save 2 minutes.

#skip-changelog
 