### PR TITLE
fix: remove ios embed framework build phase duplication (#1558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- remove ios embed framework build phase duplication (#1558) ([#1595](https://github.com/getsentry/sentry-unity/pull/1595))
+
 ### Dependencies
 
 - Bump CLI from v2.30.1 to v2.30.2 ([#1589](https://github.com/getsentry/sentry-unity/pull/1589))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- remove ios embed framework build phase duplication (#1558) ([#1595](https://github.com/getsentry/sentry-unity/pull/1595))
+- When building for iOS, the SDK no longer adds its dependencies multiple times (#1558) ([#1595](https://github.com/getsentry/sentry-unity/pull/1595))
 
 ### Dependencies
 


### PR DESCRIPTION
<img width="1224" alt="image" src="https://github.com/getsentry/sentry-unity/assets/41358286/3f3dff6b-7fdf-404b-96a3-fb9c611dabbf">

The linking phase is still added multiple times, but I could not find a way to check if it is already added.
But this does not break the build.