### PR TITLE
fix: Reinstall native backend 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The SDK no longer fails to capture native crashes on Windows. It now properly reinstalls the capturing backend during the initialization ([#1603](https://github.com/getsentry/sentry-unity/pull/1603))
+
 ### Dependencies
 
 - Bump CLI from v2.30.1 to v2.30.2 ([#1589](https://github.com/getsentry/sentry-unity/pull/1589))

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -69,7 +69,6 @@ namespace Sentry.Unity
 #elif SENTRY_NATIVE_ANDROID
                     SentryNativeAndroid.Configure(options, sentryUnityInfo);
 #elif SENTRY_NATIVE
-                    CrashReportHandler.enableCaptureExceptions = false;
                     SentryNative.Configure(options, sentryUnityInfo);
 #elif SENTRY_WEBGL
                     SentryWebGL.Configure(options);

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -69,6 +69,7 @@ namespace Sentry.Unity
 #elif SENTRY_NATIVE_ANDROID
                     SentryNativeAndroid.Configure(options, sentryUnityInfo);
 #elif SENTRY_NATIVE
+                    CrashReportHandler.enableCaptureExceptions = false;
                     SentryNative.Configure(options, sentryUnityInfo);
 #elif SENTRY_WEBGL
                     SentryWebGL.Configure(options);

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -69,6 +69,11 @@ namespace Sentry.Unity.Native
                 }
             }
             options.CrashedLastRun = () => crashedLastRun;
+
+            // At this point Unity has taken the signal handler and will not invoke our handler. So we register our
+            // backend once more to make sure user-defined data is available in the crash report and the SDK is able
+            // to capture the crash.
+            SentryNativeBridge.ReinstallBackend();
         }
     }
 }

--- a/src/Sentry.Unity.Native/SentryNativeBridge.cs
+++ b/src/Sentry.Unity.Native/SentryNativeBridge.cs
@@ -104,6 +104,8 @@ namespace Sentry.Unity.Native
             }
         }
 
+        internal static void ReinstallBackend() => sentry_reinstall_backend();
+
         // libsentry.so
         [DllImport("sentry")]
         private static extern IntPtr sentry_options_new();
@@ -276,5 +278,8 @@ namespace Sentry.Unity.Native
 
         [DllImport("sentry")]
         private static extern int sentry_clear_crashed_last_run();
+
+        [DllImport("sentry")]
+        private static extern void sentry_reinstall_backend();
     }
 }


### PR DESCRIPTION
I'm not sure (yet) when that happened but Unity is overwriting the signal handler in newer versions. This prevents `sentry-native` from capturing native crashes. 
We have a similar situation on Android where we reinstall the backend to take back control so I'm taking the same approach to resolve this.
An open TODO: We have checks in CI specifically to make sure that does not break. Why does CI pass?