### PR TITLE
fix: Screenshot smoketest

### DIFF
--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -31,6 +31,13 @@ namespace Sentry.Unity
                 return Stream.Null;
             }
 
+            if (Screen.width == 0 || Screen.height == 0)
+            {
+                _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on a screen with a resolution of '{0}x{1}'.",Screen.width, Screen.height);
+                // Returning an empty memory stream here so we can smoke-test the attempt to capture a screenshot in CI
+                return new MemoryStream();
+            }
+
             return new MemoryStream(CaptureScreenshot(Screen.width, Screen.height));
         }
 

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -33,7 +33,7 @@ namespace Sentry.Unity
 
             if (Screen.width == 0 || Screen.height == 0)
             {
-                _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on a screen with a resolution of '{0}x{1}'.",Screen.width, Screen.height);
+                _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on a screen with a resolution of '{0}x{1}'.", Screen.width, Screen.height);
                 // Returning a memory stream with a capacity of 1 so we can smoke-test the attempt to capture a screenshot in CI
                 return new MemoryStream(1);
             }

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -34,7 +34,7 @@ namespace Sentry.Unity
             if (Screen.width == 0 || Screen.height == 0)
             {
                 _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on a screen with a resolution of '{0}x{1}'.",Screen.width, Screen.height);
-                // Returning an empty memory stream here so we can smoke-test the attempt to capture a screenshot in CI
+                // Returning a memory stream with a capacity of 1 so we can smoke-test the attempt to capture a screenshot in CI
                 return new MemoryStream(1);
             }
 

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -35,7 +35,7 @@ namespace Sentry.Unity
             {
                 _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on a screen with a resolution of '{0}x{1}'.",Screen.width, Screen.height);
                 // Returning an empty memory stream here so we can smoke-test the attempt to capture a screenshot in CI
-                return new MemoryStream();
+                return new MemoryStream(1);
             }
 
             return new MemoryStream(CaptureScreenshot(Screen.width, Screen.height));


### PR DESCRIPTION
Relevant for 2021 and 2022 LTS.
On macOS CI, Unity doesn't accept RenderTextures with size 0 anymore. But because there is no screen in CI, width and height are 0.

```
Sentry: (Error) Failed to add attachment: screenshot.jpg. System.ArgumentException: RenderTextureDesc width must be greater than zero.
```

#skip-changelog