### PR TITLE
fix: CI for Desktop

### DIFF
--- a/.github/workflows/android-smoke-test-wrapper.yml
+++ b/.github/workflows/android-smoke-test-wrapper.yml
@@ -18,7 +18,7 @@ jobs:
 
   try-2:
     needs: [try-1]
-    if: ${{ needs.try-1.outputs.outcome == 'failure' }}
+    if: ${{ needs.try-1.result == 'failure' }}
     uses: ./.github/workflows/android-smoke-test.yml
     with:
       unity-version: ${{ inputs.unity-version }}
@@ -27,7 +27,7 @@ jobs:
 
   try-3:
     needs: [try-2]
-    if: ${{ needs.try-2.outputs.outcome == 'failure' }}
+    if: ${{ needs.try-2.result == 'failure' }}
     uses: ./.github/workflows/android-smoke-test.yml
     with:
       unity-version: ${{ inputs.unity-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
         run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
 
       - name: Setup Unity
-        uses: getsentry/setup-unity@808f50b583a0b64714af332862e406d3ed459d07
+        uses: getsentry/setup-unity@52de01ae128f9fab48aa4e32ddd0a1b2e867d44a
         with:
           unity-version: ${{ steps.env.outputs.unityVersion }}
           unity-modules: ${{ matrix.unity-modules }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,11 +223,6 @@ jobs:
       - name: Create new Project
         run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
-      - name: Build without Sentry SDK
-        # This hasn't broken for a long time, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
       - name: Download UPM package
         if: ${{ github.ref_name != 'main' }}
         uses: actions/download-artifact@v3
@@ -392,8 +387,6 @@ jobs:
           - os: macos
             unity-modules: mac-il2cpp
             unity-config-path: /Library/Application Support/Unity/config/
-    env:
-      UNITY_PATH: docker exec unity unity-editor
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -402,11 +395,18 @@ jobs:
         id: env
         run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
 
+      - name: Setup Unity
+        uses: getsentry/setup-unity@808f50b583a0b64714af332862e406d3ed459d07
+        with:
+          unity-version: ${{ steps.env.outputs.unityVersion }}
+          unity-modules: ${{ matrix.unity-modules }}
+
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
-      - name: Start the Unity docker container
-        run: ./scripts/ci-docker.sh '${{ matrix.unity-version }}' 'base' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
-        shell: bash
+      - name: Create Unity license config
+        run: |
+          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
+          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
 
       - name: Download IntegrationTest project
         uses: actions/download-artifact@v3
@@ -415,6 +415,23 @@ jobs:
 
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
+
+      - name: Build without Sentry SDK
+        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
+        if: ${{ github.ref_name == 'main' }}
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
+      - name: Download UPM package
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.sha }}
+
+      - name: Extract UPM package
+        run: ./test/Scripts.Integration.Test/extract-package.ps1
+
+      - name: Add Sentry to the project
+        if: ${{ github.ref_name == 'main' }}
+        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry
         run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
         run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
 
       - name: Setup Unity
-        uses: getsentry/setup-unity@52de01ae128f9fab48aa4e32ddd0a1b2e867d44a
+        uses: getsentry/setup-unity@d84ad1d1fb3020e48883c3ac8e87d64baf1135c7
         with:
           unity-version: ${{ steps.env.outputs.unityVersion }}
           unity-modules: ${{ matrix.unity-modules }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,11 @@ jobs:
       - name: Create new Project
         run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
+      - name: Build without Sentry SDK
+        # This hasn't broken for a long time, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
+        if: ${{ github.ref_name == 'main' }}
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
       - name: Download UPM package
         if: ${{ github.ref_name != 'main' }}
         uses: actions/download-artifact@v3
@@ -387,6 +392,8 @@ jobs:
           - os: macos
             unity-modules: mac-il2cpp
             unity-config-path: /Library/Application Support/Unity/config/
+    env:
+      UNITY_PATH: docker exec unity unity-editor
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -395,18 +402,11 @@ jobs:
         id: env
         run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
 
-      - name: Setup Unity
-        uses: getsentry/setup-unity@46c2e082d98cc3a825a5b59038cb31705fe9ff56
-        with:
-          unity-version: ${{ steps.env.outputs.unityVersion }}
-          unity-modules: ${{ matrix.unity-modules }}
-
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
-      - name: Create Unity license config
-        run: |
-          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
-          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+      - name: Start the Unity docker container
+        run: ./scripts/ci-docker.sh '${{ matrix.unity-version }}' 'base' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        shell: bash
 
       - name: Download IntegrationTest project
         uses: actions/download-artifact@v3
@@ -415,23 +415,6 @@ jobs:
 
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
-
-      - name: Build without Sentry SDK
-        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
-      - name: Download UPM package
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ github.sha }}
-
-      - name: Extract UPM package
-        run: ./test/Scripts.Integration.Test/extract-package.ps1
-
-      - name: Add Sentry to the project
-        if: ${{ github.ref_name == 'main' }}
-        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry
         run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -18,6 +18,7 @@ public class Builder
         EditorUserBuildSettings.selectedBuildTargetGroup = group;
         PlayerSettings.SetScriptingBackend(group, ScriptingImplementation.IL2CPP);
         DisableUnityAudio();
+        DisableProgressiveLightMapper();
         EditorUserBuildSettings.allowDebugging = false;
 
         // This should make IL2CCPP builds faster, see https://forum.unity.com/threads/il2cpp-build-time-improvements-seeking-feedback.1064135/
@@ -140,6 +141,17 @@ public class Builder
         var prop = serializedManager.FindProperty("m_DisableAudio");
         prop.boolValue = true;
         serializedManager.ApplyModifiedProperties();
+    }
+
+    // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI
+    private static void DisableProgressiveLightMapper()
+    {
+#if UNITY_2021_3_OR_NEWER
+        Lightmapping.lightingSettings = new LightingSettings
+        {
+            bakedGI = false
+        };
+#endif
     }
 }
 

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -146,7 +146,7 @@ public class Builder
     // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI
     private static void DisableProgressiveLightMapper()
     {
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2021_OR_NEWER
         Lightmapping.lightingSettings = new LightingSettings
         {
             bakedGI = false


### PR DESCRIPTION
~~Looks like we never updated the Desktop runs to use Unity in the docker container.~~
So the reason is: Game CI does not provide docker container for macOS.

We're forking [github.com/kuler90/setup-unity](https://github.com/kuler90/setup-unity) to smoke test the package installation and editor setup the editor on Windows and macOS (because Game CI does not provide docker container for macOS). The GH action was "broken" since the version of the hub that is getting used is now aware of `intel` vs `silicone`.
Initially, I tried making it work opting into silicone where possible but hit some blockers with the progressive lightmapper. It requires a GPU, finds none in CI (duh), falls back to the CPU mapper but that's not supported on silicone. So, `intel` all the way it is!

#skip-changelog