### PR TITLE
Improve C++ exceptions stacktrace on iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ package-dev/Plugins/*/Sentry/crashpad_handler*
 # required to be excluded on all platforms because we don't want Unity to copy it during build
 !package-dev/**/SentryNativeBridge.m.meta
 !package-dev/**/SentryNativeBridgeNoOp.m.meta
+!package-dev/**/SentryCxaThrowHook.cpp.meta
 
 # Android SDK files
 package-dev/Plugins/Android/Sentry~/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improve C++ exceptions stacktrace on iOS ([#1655](https://github.com/getsentry/sentry-unity/pull/1655))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.25.2 to v8.26.0 ([#1648](https://github.com/getsentry/sentry-unity/pull/1648))

--- a/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
+++ b/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
@@ -1,5 +1,6 @@
 #include <dlfcn.h>
 #include <typeinfo>
+#include <pthread.h>
 
 extern "C"
 {

--- a/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
+++ b/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
@@ -1,0 +1,51 @@
+#include <dlfcn.h>
+
+extern "C"
+{
+    // Function type __cxa_throw
+    typedef void(*cxa_throw_type)(void*, std::type_info*, void(*)(void*));
+    // Function type __cxa_rethrow
+    typedef void(*cxa_rethrow_type)(void);
+
+    static pthread_mutex_t guard = PTHREAD_MUTEX_INITIALIZER;
+    static cxa_throw_type orig_cxa_throw = NULL;
+    static cxa_rethrow_type orig_cxa_rethrow = NULL;
+
+    void __cxa_throw(void *thrown_exception, std::type_info *tinfo, void (*dest)(void *)) __attribute__((weak));
+
+    void __cxa_throw(void *thrown_exception, std::type_info *tinfo, void (*dest)(void *))
+    {
+        pthread_mutex_lock(&guard);
+        if (!orig_cxa_throw) // Try to load the sentry cocoa hook
+            orig_cxa_throw = (cxa_throw_type)dlsym(RTLD_DEFAULT, "__sentry_cxa_throw");
+        if (!orig_cxa_throw) // Try to load the default __cxa_throw method
+            orig_cxa_throw = (cxa_throw_type)dlsym(RTLD_NEXT, "__cxa_throw");
+        pthread_mutex_unlock(&guard);
+        
+        if (orig_cxa_throw)
+            orig_cxa_throw(thrown_exception, tinfo, dest);
+        else
+            std::terminate();
+        
+        __builtin_unreachable();
+    }
+
+    void __cxa_rethrow() __attribute__((weak));
+
+    void __cxa_rethrow()
+    {
+        pthread_mutex_lock(&guard);
+        if (!orig_cxa_throw) // Try to load the sentry cocoa hook
+            orig_cxa_rethrow = (cxa_rethrow_type)dlsym(RTLD_DEFAULT, "__sentry_cxa_rethrow");
+        if (!orig_cxa_throw) // Try to load the default __cxa_throw method
+            orig_cxa_rethrow = (cxa_rethrow_type)dlsym(RTLD_NEXT, "__cxa_rethrow");
+        pthread_mutex_unlock(&guard);
+        
+        if (orig_cxa_rethrow)
+            orig_cxa_rethrow();
+        else
+            std::terminate();
+        
+        __builtin_unreachable();
+    }
+}

--- a/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
+++ b/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
@@ -35,9 +35,9 @@ extern "C"
     void __cxa_rethrow()
     {
         pthread_mutex_lock(&guard);
-        if (!orig_cxa_throw) // Try to load the sentry cocoa hook
+        if (!orig_cxa_rethrow) // Try to load the sentry cocoa hook
             orig_cxa_rethrow = (cxa_rethrow_type)dlsym(RTLD_DEFAULT, "__sentry_cxa_rethrow");
-        if (!orig_cxa_throw) // Try to load the default __cxa_throw method
+        if (!orig_cxa_rethrow) // Try to load the default __cxa_rethrow method
             orig_cxa_rethrow = (cxa_rethrow_type)dlsym(RTLD_NEXT, "__cxa_rethrow");
         pthread_mutex_unlock(&guard);
         
@@ -49,3 +49,4 @@ extern "C"
         __builtin_unreachable();
     }
 }
+

--- a/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
+++ b/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
@@ -1,5 +1,6 @@
 #include <dlfcn.h>
 #include <typeinfo>
+#include <exception>
 #include <pthread.h>
 
 extern "C"

--- a/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
+++ b/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp
@@ -1,4 +1,5 @@
 #include <dlfcn.h>
+#include <typeinfo>
 
 extern "C"
 {

--- a/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp.meta
+++ b/package-dev/Plugins/iOS/SentryCxaThrowHook.cpp.meta
@@ -1,0 +1,81 @@
+fileFormatVersion: 2
+guid: 2e4535b4e7b654ab4a9ff2d3d333c015
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/samples/unity-of-bugs/Assets/Scripts/NativeSupport/CppPlugin.cpp
+++ b/samples/unity-of-bugs/Assets/Scripts/NativeSupport/CppPlugin.cpp
@@ -14,8 +14,7 @@ extern "C" {
 void throw_cpp()
 {
     try {
-        // throws std::length_error
-        std::string("1").substr(2);
+        throw std::runtime_error("test");
     } catch (const std::exception &e) {
         std::cout << e.what() << '\n';
         throw;

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -10,7 +10,7 @@ namespace Sentry.Unity.Android
     public static class SentryNativeAndroid
     {
         private static JniExecutor? JniExecutor;
-        
+
         /// <summary>
         /// Configures the native Android support.
         /// </summary>

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -33,6 +33,8 @@ Plugins/macOS/Sentry/Sentry.dylib
 Plugins/macOS/Sentry/Sentry.dylib.dSYM
 Plugins/macOS/Sentry/Sentry.dylib.dSYM.meta
 Plugins/macOS/Sentry/Sentry.dylib.meta
+Plugins/iOS/SentryCxaThrowHook.cpp
+Plugins/iOS/SentryCxaThrowHook.cpp.meta
 Plugins/iOS/SentryNativeBridge.m
 Plugins/iOS/SentryNativeBridge.m.meta
 Plugins/iOS/SentryNativeBridgeNoOp.m


### PR DESCRIPTION
Fixes #1628 

There are still some cases that are not covered by this fix.
If the exception is thrown not from UnityFramework, but from another library, the hook will not be called.

The details can be found in the conversation of the issue.