### PR TITLE
Pass CLI logs to Unity in any case for Android build

### DIFF
--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -247,7 +247,7 @@ namespace Sentry.Unity.Editor.Android
         internal void SetupSymbolsUpload(string unityProjectPath, string gradleProjectPath)
         {
             var disableSymbolsUpload = false;
-            var symbolsUpload = new DebugSymbolUpload(_logger, _sentryCliOptions, unityProjectPath, gradleProjectPath, EditorUserBuildSettings.exportAsGoogleAndroidProject, ShouldUploadMapping());
+            var symbolsUpload = new DebugSymbolUpload(_logger, _sentryCliOptions, unityProjectPath, gradleProjectPath, EditorUserBuildSettings.exportAsGoogleAndroidProject, AndroidUtils.ShouldUploadMapping());
 
             if (_options is not { Enabled: true, AndroidNativeSupportEnabled: true })
             {
@@ -330,34 +330,7 @@ namespace Sentry.Unity.Editor.Android
                 .Append("AndroidManifest.xml")
                 .ToString();
 
-        private bool ShouldUploadMapping()
-        {
-            var isDebug = EditorUserBuildSettings.development;
-            var majorVersion = int.Parse(Application.unityVersion.Split('.')[0]);
-            if (majorVersion < 2020)
-            {
-                var buildSettingsType = typeof(EditorUserBuildSettings);
-                var propertyName = isDebug ? "androidDebugMinification" : "androidReleaseMinification";
-                var prop = buildSettingsType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static);
-                if (prop != null)
-                {
-                    var value = (int)prop.GetValue(null);
-                    return value > 0;
-                }
-            }
-            else
-            {
-                var type = typeof(PlayerSettings.Android);
-                var propertyName = isDebug ? "minifyDebug" : "minifyRelease";
-                var prop = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static);
-                if (prop != null)
-                {
-                    return (bool)prop.GetValue(null);
-                }
-            }
 
-            return false;
-        }
     }
 
     internal class AndroidXmlDocument : XmlDocument

--- a/src/Sentry.Unity.Editor/Android/AndroidUtils.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidUtils.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Sentry.Unity.Editor.Android
+{
+    internal static class AndroidUtils
+    {
+        internal static bool ShouldUploadMapping()
+        {
+            var isDebug = EditorUserBuildSettings.development;
+            var majorVersion = int.Parse(Application.unityVersion.Split('.')[0]);
+            if (majorVersion < 2020)
+            {
+                var buildSettingsType = typeof(EditorUserBuildSettings);
+                var propertyName = isDebug ? "androidDebugMinification" : "androidReleaseMinification";
+                var prop = buildSettingsType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static);
+                if (prop != null)
+                {
+                    var value = (int)prop.GetValue(null);
+                    return value > 0;
+                }
+            }
+            else
+            {
+                var type = typeof(PlayerSettings.Android);
+                var propertyName = isDebug ? "minifyDebug" : "minifyRelease";
+                var prop = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static);
+                if (prop != null)
+                {
+                    return (bool)prop.GetValue(null);
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The logs will be passed as warnings if the IgnoreCliErrors flag is set in the settings, and will be logged as info if the task was successful.

#skip-changelog