### PR TITLE
Hook to bundle tasks during Android export for symbols upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Fix symbol upload task hook for exported projects ([#1692](https://github.com/getsentry/sentry-unity/pull/1692))
+- When exporting Android projects, the SDK will now correctly add the symbol upload at the end of bundling ([#1692](https://github.com/getsentry/sentry-unity/pull/1692))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an `IgnoreCliErrors` to the Sentry-CLI options, allowing you to ignore errors during symbol and mapping upload ([#1687](https://github.com/getsentry/sentry-unity/pull/1687))
 
+### Fixes
+
+- Fix symbol upload task hook for exported projects ([#1692](https://github.com/getsentry/sentry-unity/pull/1692))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.27.0 to v8.29.0 ([#1685](https://github.com/getsentry/sentry-unity/pull/1685), [#1690](https://github.com/getsentry/sentry-unity/pull/1690))

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -87,6 +87,13 @@ namespace Sentry.Unity.Editor.Android
                 stringBuilder.AppendLine(string.Empty);
                 stringBuilder.AppendLine("tasks.assembleDebug.finalizedBy sentryUploadSymbols");
                 stringBuilder.AppendLine("tasks.assembleRelease.finalizedBy sentryUploadSymbols");
+
+                if (_isExporting)
+                {
+                    stringBuilder.AppendLine("tasks.bundleDebug.finalizedBy sentryUploadSymbols");
+                    stringBuilder.AppendLine("tasks.bundleRelease.finalizedBy sentryUploadSymbols");
+                }
+
                 stringBuilder.AppendLine("}");
                 return stringBuilder.ToString();
             }

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -155,6 +155,11 @@ namespace Sentry.Unity.Editor.Tests.Android
             {
                 keywords.Add("logFilePath");
             }
+            else
+            {
+                keywords.Add("tasks.bundleDebug.finalizedBy sentryUploadSymbols");
+                keywords.Add("tasks.bundleRelease.finalizedBy sentryUploadSymbols");
+            }
 
             if (!isExporting && ignoreCliErrors)
             {


### PR DESCRIPTION
Fixes #1673 

Previously, we were binding to the assemble tasks that get executed during Unity build (regardless of whether it is apk or abb).

But for the exported projects .aab artifacts are only created using the bundle task, during which the upload symbol task was not executed.