### PR TITLE
fix: Log native init failure instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- The SDK no longer throws an exception when failing to initialize the native SDK ([#1693](https://github.com/getsentry/sentry-unity/pull/1695))
 - The SDKs loglevel now also applies to sentry-cli logging ([#1693](https://github.com/getsentry/sentry-unity/pull/1693))
 - When targeting Android, sentry-cli will now log to the editor console ([#1693](https://github.com/getsentry/sentry-unity/pull/1691))
 

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -1,3 +1,4 @@
+using System;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
 using System.Collections.Generic;
@@ -28,10 +29,19 @@ namespace Sentry.Unity.Native
                 return;
             }
 
-            if (!SentryNativeBridge.Init(options, sentryUnityInfo))
+            try
+            {
+                if (!SentryNativeBridge.Init(options, sentryUnityInfo))
+                {
+                    options.DiagnosticLogger?
+                        .LogWarning("Sentry native initialization failed - native crashes are not captured.");
+                    return;
+                }
+            }
+            catch (Exception e)
             {
                 options.DiagnosticLogger?
-                    .LogWarning("Sentry native initialization failed - native crashes are not captured.");
+                    .LogError(e, "Sentry native initialization failed - native crashes are not captured.");
                 return;
             }
 


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry-unity/issues/1440
We're not building the native SDK statically, but we can at least stop the exceptions from being thrown.