### PR TITLE
Fix symbol upload during .aab build from Unity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - The SDKs loglevel now also applies to sentry-cli logging ([#1693](https://github.com/getsentry/sentry-unity/pull/1693))
 - When targeting Android, sentry-cli will now log to the editor console ([#1693](https://github.com/getsentry/sentry-unity/pull/1691))
-- Fix symbol upload during .aab build from Unity ([#1698](https://github.com/getsentry/sentry-unity/pull/1698))
+- Fixed an issue with the SDK failing to automatically uploading debug symbols when exporting an `.aab` when targeting Android ([#1698](https://github.com/getsentry/sentry-unity/pull/1698))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The SDKs loglevel now also applies to sentry-cli logging ([#1693](https://github.com/getsentry/sentry-unity/pull/1693))
 - When targeting Android, sentry-cli will now log to the editor console ([#1693](https://github.com/getsentry/sentry-unity/pull/1691))
+- Fix symbol upload during .aab build from Unity ([#1698](https://github.com/getsentry/sentry-unity/pull/1698))
 
 ### Features
 

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -87,12 +87,8 @@ namespace Sentry.Unity.Editor.Android
                 stringBuilder.AppendLine(string.Empty);
                 stringBuilder.AppendLine("tasks.assembleDebug.finalizedBy sentryUploadSymbols");
                 stringBuilder.AppendLine("tasks.assembleRelease.finalizedBy sentryUploadSymbols");
-
-                if (_isExporting)
-                {
-                    stringBuilder.AppendLine("tasks.bundleDebug.finalizedBy sentryUploadSymbols");
-                    stringBuilder.AppendLine("tasks.bundleRelease.finalizedBy sentryUploadSymbols");
-                }
+                stringBuilder.AppendLine("tasks.bundleDebug.finalizedBy sentryUploadSymbols");
+                stringBuilder.AppendLine("tasks.bundleRelease.finalizedBy sentryUploadSymbols");
 
                 stringBuilder.AppendLine("}");
                 return stringBuilder.ToString();

--- a/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/DebugSymbolUploadTests.cs
@@ -148,17 +148,14 @@ namespace Sentry.Unity.Editor.Tests.Android
                 "sentry.properties",
                 "args = ['debug-files', 'upload', '--il2cpp-mapping', '--include-sources'",
                 "tasks.assembleDebug.finalizedBy sentryUploadSymbols",
-                "tasks.assembleRelease.finalizedBy sentryUploadSymbols"
+                "tasks.assembleRelease.finalizedBy sentryUploadSymbols",
+                "tasks.bundleDebug.finalizedBy sentryUploadSymbols",
+                "tasks.bundleRelease.finalizedBy sentryUploadSymbols"
             };
 
             if (!isExporting)
             {
                 keywords.Add("logFilePath");
-            }
-            else
-            {
-                keywords.Add("tasks.bundleDebug.finalizedBy sentryUploadSymbols");
-                keywords.Add("tasks.bundleRelease.finalizedBy sentryUploadSymbols");
             }
 
             if (!isExporting && ignoreCliErrors)


### PR DESCRIPTION
Fixes #1696 