### PR TITLE
fix: WebRequests breaking on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- On iOS, UnityWebRequests no longer break due to the native SDK appending the request URL a second time ([#1699](https://github.com/getsentry/sentry-unity/pull/1699))
 - The SDKs loglevel now also applies to sentry-cli logging ([#1693](https://github.com/getsentry/sentry-unity/pull/1693))
 - When targeting Android, sentry-cli will now log to the editor console ([#1693](https://github.com/getsentry/sentry-unity/pull/1691))
 

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -37,7 +37,8 @@ static SentryOptions* getSentryOptions()
         @""sendDefaultPii"" : @{ToObjCString(options.SendDefaultPii)},
         @""attachScreenshot"" : @{ToObjCString(options.AttachScreenshot)},
         @""release"" : @""{options.Release}"",
-        @""environment"" : @""{options.Environment}""
+        @""environment"" : @""{options.Environment}"",
+        @""enableNetworkBreadcrumbs"" : @NO
     }};
 
     NSError *error = nil;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1658

It seems like there is some incompatibility with UnityWebReqest and the swizzling the Cocoa SDK is doing for it's network breadcrumb integration. Disabling this for now to stop breaking webrequests.