### PR TITLE
fix: IL2CPP Exception processor now checks for native support being enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The IL2CPP exception processor no longer fails when the native support has been disabled ([#1708](https://github.com/getsentry/sentry-unity/pull/1708))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.29.1 to v8.30.0 ([#1702](https://github.com/getsentry/sentry-unity/pull/1702))

--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -29,8 +29,7 @@ namespace Sentry.Unity
 
         public void Process(Exception incomingException, SentryEvent sentryEvent)
         {
-            Options.DiagnosticLogger?.LogDebug("Running Unity IL2CPP event exception processor on: Event {0}",
-                sentryEvent.EventId);
+            Options.DiagnosticLogger?.LogDebug("Running Unity IL2CPP event exception processor on: Event {0}", sentryEvent.EventId);
 
             var sentryExceptions = sentryEvent.SentryExceptions;
             if (sentryExceptions == null)
@@ -62,8 +61,7 @@ namespace Sentry.Unity
 
                 var nativeStackTrace = GetNativeStackTrace(exception);
 
-                Options.DiagnosticLogger?.LogDebug("NativeStackTrace Image: '{0}' (UUID: {1})",
-                    nativeStackTrace.ImageName, nativeStackTrace.ImageUuid);
+                Options.DiagnosticLogger?.LogDebug("NativeStackTrace Image: '{0}' (UUID: {1})", nativeStackTrace.ImageName, nativeStackTrace.ImageUuid);
 
                 // Unity by definition only builds a single library which we add once to our list of debug images.
                 // We use this when we encounter stack frames with relative addresses.
@@ -129,14 +127,12 @@ namespace Sentry.Unity
                     {
                         if (mainImageUUID is null)
                         {
-                            Options.DiagnosticLogger?.LogWarning(
-                                "Couldn't process stack trace - main image UUID reported as NULL by Unity");
+                            Options.DiagnosticLogger?.LogWarning("Couldn't process stack trace - main image UUID reported as NULL by Unity");
                             continue;
                         }
 
                         // First, try to find the image among the loaded ones, otherwise create a dummy one.
-                        mainLibImage ??= DebugImagesSorted.Value.Find((info) =>
-                            string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
+                        mainLibImage ??= DebugImagesSorted.Value.Find((info) => string.Equals(NormalizeUuid(info.Image.DebugId), mainImageUUID))?.Image;
                         mainLibImage ??= new DebugImage
                         {
                             Type = UnityInfo.GetDebugImageType(Application.platform),
@@ -144,9 +140,7 @@ namespace Sentry.Unity
                             // A null/missing `CodeFile` however would lead to a processing error in sentry.
                             // Since the code file is not strictly necessary for processing, we just fall back to
                             // a sentinel value here.
-                            CodeFile = string.IsNullOrEmpty(nativeStackTrace.ImageName)
-                                ? "GameAssembly.fallback"
-                                : nativeStackTrace.ImageName,
+                            CodeFile = string.IsNullOrEmpty(nativeStackTrace.ImageName) ? "GameAssembly.fallback" : nativeStackTrace.ImageName,
                             DebugId = mainImageUUID,
                             ImageAddress = mainLibOffset,
                         };
@@ -180,8 +174,7 @@ namespace Sentry.Unity
                         }
                     }
 
-                    Options.DiagnosticLogger?.Log(logLevel,
-                        "Stack frame '{0}' at {1:X8} (originally {2:X8}) belongs to {3} {4}",
+                    Options.DiagnosticLogger?.Log(logLevel, "Stack frame '{0}' at {1:X8} (originally {2:X8}) belongs to {3} {4}",
                         null, frame.Function, instructionAddress, nativeFrame.ToInt64(), image.CodeFile, notes ?? "");
 
                     _ = usedImages.Add(image);
@@ -253,7 +246,6 @@ namespace Sentry.Unity
                             break;
                         }
                     }
-
                     result.Insert(i, info);
 
                     Options.DiagnosticLogger?.Log(SentryLevel.Debug,
@@ -261,7 +253,6 @@ namespace Sentry.Unity
                         null, image.CodeFile, image.CodeId, image.DebugId, info.StartAddress, info.EndAddress);
                 }
             }
-
             return result;
         });
 


### PR DESCRIPTION
The IL2CPP exception processor relies on some sentry-native functionality to read from debug images. On i.e. Android, with Android native support disabled, sentry-native is not present, causing a DLL not found exception, breaking the processor.