### PR TITLE
fix: Disable tracing on unknown platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- The SDK no longer causes games to crash out of the box on platforms that have disk access restrictions (i.e. Nintendo Switch) ([#1728](https://github.com/getsentry/sentry-unity/pull/1728))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.30.1 to v8.31.1 ([#1726](https://github.com/getsentry/sentry-unity/pull/1726))

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -259,6 +259,13 @@ public class ScriptableSentryUnityOptions : ScriptableObject
                 options.DiagnosticLogger?.LogDebug("Platform support for automatic session tracking is unknown: disabling.");
                 options.AutoSessionTracking = false;
             }
+
+            // Requires file access
+            if (options.TracesSampleRate > 0.0f)
+            {
+                options.DiagnosticLogger?.LogDebug("Platform support for tracing is unknown: disabling.");
+                options.TracesSampleRate = null;
+            }
         }
     }
 


### PR DESCRIPTION
Tracing requires file access which is not permitted on i.e. Nintendo Switch.