### PR TITLE
fix: IL2CPP in Unity 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 - The SDK no longer causes games to crash out of the box on platforms that have disk access restrictions (i.e. Nintendo Switch) ([#1728](https://github.com/getsentry/sentry-unity/pull/1728))
+- IL2CPP in Unity 6 ([#1735](https://github.com/getsentry/sentry-unity/pull/1735))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Fixes
 
 - The SDK no longer causes games to crash out of the box on platforms that have disk access restrictions (i.e. Nintendo Switch) ([#1728](https://github.com/getsentry/sentry-unity/pull/1728))
-- IL2CPP in Unity 6 ([#1735](https://github.com/getsentry/sentry-unity/pull/1735))
+- The SDK no longer causes crashes on Unity 6 in an attempt to provide line numbers ([#1735](https://github.com/getsentry/sentry-unity/pull/1735))
 
 ### Dependencies
 

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -200,7 +200,7 @@ namespace Sentry.Unity
             return Marshal.PtrToStringAnsi(debugIdPtr);
         }
 
-#if UNITY_2023
+#if UNITY_2023_1_OR_NEWER
         private static IntPtr Il2CppGcHandleGetTargetShim(IntPtr gchandle) => il2cpp_gchandle_get_target(gchandle);
 
         // Available in Unity `2013.3.12f1` (and later)


### PR DESCRIPTION
This PR fixes #1442 for Unity 6