### PR TITLE
feat: replay

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -187,15 +187,19 @@ Expected to exist:
     <Error Condition="!Exists('$(SentryAndroidRoot)')" Text="Couldn't find the Android root at $(SentryAndroidRoot)." />
     <Message Importance="High" Text="Building Sentry Android SDK." />
 
-    <Exec WorkingDirectory="$(SentryAndroidRoot)" EnvironmentVariables="JAVA_HOME=$(JAVA_HOME_17_X64)" Command="./gradlew -PsentryAndroidSdkName=sentry.native.android.unity :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none" />
+    <Exec WorkingDirectory="$(SentryAndroidRoot)" EnvironmentVariables="JAVA_HOME=$(JAVA_HOME_17_X64)" Command="./gradlew -PsentryAndroidSdkName=sentry.native.android.unity :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease  :sentry-android-replay:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none" />
 
     <ItemGroup>
       <AndroidSdkArtifacts Include="$(SentryAndroidRoot)sentry-android-ndk/build/outputs/aar/sentry-android-ndk-release.aar" />
       <AndroidSdkArtifacts Include="$(SentryAndroidRoot)sentry-android-core/build/outputs/aar/sentry-android-core-release.aar" />
+      <AndroidSdkArtifacts Include="$(SentryAndroidRoot)sentry-android-replay/build/outputs/aar/sentry-android-replay-release.aar" />
     </ItemGroup>
-
     <Copy SourceFiles="@(AndroidSdkArtifacts)" DestinationFiles="@(AndroidSdkArtifacts->'$(SentryAndroidArtifactsDestination)%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Exec WorkingDirectory="$(SentryAndroidRoot)" Command="cp sentry/build/libs/sentry*.jar $(SentryAndroidArtifactsDestination)sentry.jar" />
+
+    <ItemGroup>
+      <SentryJarArtifact Include="$(SentryAndroidRoot)/sentry/build/libs/sentry*.jar" />
+    </ItemGroup>
+    <Copy SourceFiles="@(SentryJarArtifact)" DestinationFiles="@(SentryJarArtifact->'$(SentryAndroidArtifactsDestination)sentry.jar')" />
 
     <Error Condition="!Exists('$(SentryAndroidArtifactsDestination)')" Text="Failed to build the Android SDK." />
   </Target>

--- a/package-dev/Plugins/Android/proguard-sentry-unity.pro
+++ b/package-dev/Plugins/Android/proguard-sentry-unity.pro
@@ -7,3 +7,6 @@
 -keep class io.sentry.Scope { *; }
 -keep class io.sentry.ScopeCallback { *; }
 -keep class io.sentry.protocol.** { *; }
+
+# TODO Copy proguard rules from sentry-android-* in msbuild
+-keep class io.sentry.** { *; }

--- a/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
+++ b/src/Sentry.Unity.Editor.iOS/NativeOptions.cs
@@ -37,7 +37,14 @@ static SentryOptions* getSentryOptions()
         @""attachScreenshot"" : @{ToObjCString(options.AttachScreenshot)},
         @""release"" : @""{options.Release}"",
         @""environment"" : @""{options.Environment}"",
-        @""enableNetworkBreadcrumbs"" : @NO
+        @""enableNetworkBreadcrumbs"" : @NO,
+        // TODO temp code, implement this properly
+        @""experimental"" : @{{
+            @""sessionReplay"" : @{{
+                @""sessionSampleRate"" : @1.0,
+                @""errorSampleRate"" : @1.0
+            }}
+        }}
     }};
 
     NSError *error = nil;

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -179,6 +179,7 @@ public class AndroidManifestConfiguration
         androidManifest.SetAutoAppLifecycleBreadcrumbs(false);
         androidManifest.SetAnr(false);
         androidManifest.SetPersistentScopeObserver(false);
+        androidManifest.SetReplay(1.0, 1.0);
 
         // TODO: All SentryOptions and create specific Android options
 
@@ -443,6 +444,21 @@ internal class AndroidManifest : AndroidXmlDocument
         => SetMetaData($"{SentryPrefix}.ndk.scope-sync.enable", enableNdkScopeSync.ToString());
 
     internal void SetDebug(bool debug) => SetMetaData($"{SentryPrefix}.debug", debug ? "true" : "false");
+
+    internal void SetReplay(double? sessionSampleRate, double? errorSampleRate)
+    {
+        if (sessionSampleRate != null)
+        {
+            // https://github.com/getsentry/sentry-java/issues/3603
+            // SetMetaData($"{SentryPrefix}.session-replay.session-sample-rate", sessionSampleRate.ToString());
+            SetMetaData($"{SentryPrefix}.session-replay.session-sample-rate", "1.0");
+        }
+        if (errorSampleRate != null)
+        {
+            // SetMetaData($"{SentryPrefix}.session-replay.error-sample-rate", errorSampleRate.ToString());
+            SetMetaData($"{SentryPrefix}.session-replay.error-sample-rate", "1.0");
+        }
+    }
 
     // https://github.com/getsentry/sentry-java/blob/db4dfc92f202b1cefc48d019fdabe24d487db923/sentry/src/main/java/io/sentry/SentryLevel.java#L4-L9
     internal void SetLevel(SentryLevel level) =>

--- a/src/Sentry.Unity.Editor/Android/GradleSetup.cs
+++ b/src/Sentry.Unity.Editor/Android/GradleSetup.cs
@@ -13,7 +13,8 @@ internal class GradleSetup
 
     public const string SdkDependencies = @"dependencies {
     implementation(name: 'sentry-android-ndk-release', ext:'aar')
-    implementation(name: 'sentry-android-core-release', ext:'aar')";
+    implementation(name: 'sentry-android-core-release', ext:'aar')
+    implementation(name: 'sentry-android-replay-release', ext:'aar')";
     public const string DependenciesAddedMessage = "The Sentry Gradle dependencies have already been added.";
     private readonly string _unityLibraryGradle;
 

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -220,6 +220,7 @@ Plugins/Android/proguard-sentry-unity.pro
 Plugins/Android/proguard-sentry-unity.pro.meta
 Plugins/Android/Sentry~/sentry-android-core-release.aar
 Plugins/Android/Sentry~/sentry-android-ndk-release.aar
+Plugins/Android/Sentry~/sentry-android-replay-release.aar
 Plugins/Android/Sentry~/sentry.jar
 Plugins/Windows/Sentry.meta
 Plugins/Windows/Sentry/crashpad_handler.exe


### PR DESCRIPTION
A small experiment if we can get native replay working on mobile. Currently facing some issues:

## Android
1. proguard settings are not copied from android packages during build
2. Unity 2019 has old kotlin version (we need 1.8.0), seems to work on Unity 2022
3. The replay is sent but is just black screen, although, there are some breadcrumbs at least) - we'll either need to provide custom window/view to Android (not sure if that's possible) or implement a custom screenshot recorder, same as in [Flutter](https://github.com/getsentry/sentry-dart/pull/2032/files#diff-cd61578f20b29db49fc80018b11c17cc056d93099388900ac1b85981f30d353eR554)
4. There are native exceptions; maybe something to do with proguard
   ```
    2024/07/24 13:23:12.290 4984 5011 Error Sentry An exception occurred while processing replay event by processor: io.sentry.android.core.PerformanceAndroidEventProcessor
    2024/07/24 13:23:12.290 4984 5011 Error Sentry java.lang.AbstractMethodError: abstract method "io.sentry.SentryReplayEvent io.sentry.EventProcessor.process(io.sentry.SentryReplayEvent, io.sentry.Hint)"
    2024/07/24 13:23:12.290 4984 5011 Error Sentry 	at io.sentry.SentryClient.processReplayEvent(SentryClient.java:547)
    2024/07/24 13:23:12.290 4984 5011 Error Sentry 	at io.sentry.SentryClient.captureReplayEvent(SentryClient.java:300)
    2024/07/24 13:23:12.290 4984 5011 Error Sentry 	at io.sentry.Hub.captureReplay(Hub.java:965)
    2024/07/24 13:23:12.290 4984 5011 Error Sentry 	at io.sentry.HubAdapter.captureReplay(HubAdapter.java:274)
    ```

## iOS

Currently can't test because I don't have a physical iPhone and [Unity doesn't build for arm64 simulator](https://issuetracker.unity3d.com/issues/ios-simulator-sdk-is-missing-arm64-architecture-support). I've tried running on mac as if it was an iPad but replay didn't work - the integration got installed but there were no replays coming through.