### PR TITLE
fix: System.DllNotFoundException during Sentry initialization in Unity Headless Linux Server build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           - target: iOS
             host: macos-13
           - target: Linux
+            # Build using older Linux version to preserve sdk compatibility with old GLIBC
+            # See discussion in https://github.com/getsentry/sentry-unity/issues/1730 for more details
             host: ubuntu-20.04
           - target: macOS
             host: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - target: iOS
             host: macos-13
           - target: Linux
-            host: ubuntu-latest
+            host: ubuntu-20.04
           - target: macOS
             host: macos-13
           - target: Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## Unreleased
 
-- System.DllNotFoundException during Sentry initialization in Unity Headless Linux Server build ([#1748](https://github.com/getsentry/sentry-unity/pull/1748))
-
-## 2.1.2
 ### Fixes
 
+- The SDK no longer throws `System.DllNotFoundException` during initialization when running a headless Linux server build ([#1748](https://github.com/getsentry/sentry-unity/pull/1748))
 - The SDK now correctly uses forward slashes when modifying the gradle project when setting up debug symbol and mapping upload ([#1747](https://github.com/getsentry/sentry-unity/pull/1747))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- System.DllNotFoundException during Sentry initialization in Unity Headless Linux Server build ([#1748](https://github.com/getsentry/sentry-unity/pull/1748))
+
 ## 2.1.2
 
 ### Various fixes & improvements


### PR DESCRIPTION
This PR fixes the issue with loading `libsentry.so` on older Linux versions during Sentry initialization.

Switching to using Ubuntu 20.04 for building `sentry-native` in CI allows to preserve its compatibility with `GLIBC` libs that are available on older Linux versions.

Closes #1730 , #1719