### PR TITLE
Fix `SentryMonoBehavior` instance being removed on scene switch in WebGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix `SentryMonoBehavior` instance being removed on scene switch in WebGL ([#1754](https://github.com/getsentry/sentry-unity/pull/1754))
+
 ## 2.1.3
 
 ### Fixes

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -122,12 +122,12 @@ public partial class SentryMonoBehaviour
     // We want to do it this way instead of a StartCoroutine() so that we have the context info ASAP.
     private void Awake()
     {
-        CollectData();
-
         // This prevents object from being destroyed when unloading the scene since using HideFlags.HideAndDontSave
         // doesn't guarantee its persistence on all platforms i.e. WebGL
         // (see https://github.com/getsentry/sentry-unity/issues/1678 for more details)
         DontDestroyOnLoad(gameObject);
+        
+        CollectData();
     }
 
     internal void CollectData()

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -120,7 +120,15 @@ public partial class SentryMonoBehaviour
 
     // Note: Awake is called only once and synchronously while the object is built.
     // We want to do it this way instead of a StartCoroutine() so that we have the context info ASAP.
-    private void Awake() => CollectData();
+    private void Awake()
+    {
+        CollectData();
+
+        // This prevents object from being destroyed when unloading the scene since using HideFlags.HideAndDontSave
+        // doesn't guarantee its persistence on all platforms i.e. WebGL
+        // (see https://github.com/getsentry/sentry-unity/issues/1678 for more details)
+        DontDestroyOnLoad(gameObject);
+    }
 
     internal void CollectData()
     {


### PR DESCRIPTION
This PR adds `DontDestroyOnLoad` call to `SentryMonoBehavior.Awake` to ensure its instance won't be destroyed during the scene switch in WebGL builds.

Closes #1678