### PR TITLE
chore: Disable `macOS` smoke test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,14 +381,15 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2020", "2021", "2022"]
-        os: ["windows", "macos"]
+        # os: ["windows", "macos"]
+        os: ["windows"]
         include:
           - os: windows
             unity-modules: windows-il2cpp
             unity-config-path: C:/ProgramData/Unity/config/
-          - os: macos
-            unity-modules: mac-il2cpp
-            unity-config-path: /Library/Application Support/Unity/config/
+          # - os: macos
+          #   unity-modules: mac-il2cpp
+          #   unity-config-path: /Library/Application Support/Unity/config/
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We're installing Unity via `getsentry/setup-unity`. It's basically a wrapper around the Unity hub.
For some reason, the Unity installation for macOS changed with 2022 leading to 
```
Could not find Unity Package Manager local server application at [/Applications/Unity/Hub/Editor/{{insert-unity-version}}/Unity.app/Contents/Resources/PackageManager/Server/UnityPackageManager]
```
which itself seems to be regression of https://discussions.unity.com/t/could-not-find-upm-executable-at-path/809716/5 going back to the 2019 version. Also see see https://discussions.unity.com/t/failed-to-start-the-unity-package-manager/930285/14

Game CI now also provides Windows docker images. So that might be the way to move forward as well.

#skip-changelog