### PR TITLE
feat: Added `ApplicationNotRespondingException` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added an `ApplicationNotRespondingException` type that allows filtering of ANR events ([#1800](https://github.com/getsentry/sentry-unity/pull/1800))
+
 ### Dependencies
 
 - Bump CLI from v2.34.1 to v2.36.1 ([#1788](https://github.com/getsentry/sentry-unity/pull/1788), [#1792](https://github.com/getsentry/sentry-unity/pull/1792), [#1796](https://github.com/getsentry/sentry-unity/pull/1796))

--- a/src/Sentry.Unity/Integrations/AnrIntegration.cs
+++ b/src/Sentry.Unity/Integrations/AnrIntegration.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading;
 using Sentry.Extensibility;
 using Sentry.Integrations;
+using Sentry.Unity.Integrations;
 using UnityEngine;
 
 namespace Sentry.Unity;
@@ -51,7 +52,7 @@ internal abstract class AnrWatchDog
     protected readonly int SleepIntervalMs;
     protected readonly IDiagnosticLogger? Logger;
     protected readonly SentryMonoBehaviour MonoBehaviour;
-    internal event EventHandler<ApplicationNotResponding> OnApplicationNotResponding = delegate { };
+    internal event EventHandler<ApplicationNotRespondingException> OnApplicationNotResponding = delegate { };
     protected bool Paused { get; private set; } = false;
 
     internal AnrWatchDog(IDiagnosticLogger? logger, SentryMonoBehaviour monoBehaviour, TimeSpan detectionTimeout)
@@ -77,7 +78,7 @@ internal abstract class AnrWatchDog
         {
             var message = $"Application not responding for at least {DetectionTimeoutMs} ms.";
             Logger?.LogInfo("Detected an ANR event: {0}", message);
-            OnApplicationNotResponding?.Invoke(this, new ApplicationNotResponding(message));
+            OnApplicationNotResponding?.Invoke(this, new ApplicationNotRespondingException(message));
         }
     }
 }
@@ -191,11 +192,4 @@ internal class AnrWatchDogSingleThreaded : AnrWatchDog
             yield return waitForSeconds;
         }
     }
-}
-
-internal class ApplicationNotResponding : Exception
-{
-    internal ApplicationNotResponding() : base() { }
-    internal ApplicationNotResponding(string message) : base(message) { }
-    internal ApplicationNotResponding(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/src/Sentry.Unity/Integrations/ApplicationNotRespondingException.cs
+++ b/src/Sentry.Unity/Integrations/ApplicationNotRespondingException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Sentry.Unity.Integrations;
+
+public class ApplicationNotRespondingException : Exception
+{
+    internal ApplicationNotRespondingException() : base() { }
+    internal ApplicationNotRespondingException(string message) : base(message) { }
+    internal ApplicationNotRespondingException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/test/Sentry.Unity.Tests/AnrDetectionTests.cs
+++ b/test/Sentry.Unity.Tests/AnrDetectionTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Sentry.Extensibility;
+using Sentry.Unity.Integrations;
 using Sentry.Unity.Tests.SharedClasses;
 
 namespace Sentry.Unity.Tests;
@@ -43,7 +44,7 @@ public class AnrDetectionTests
     [UnityTest]
     public IEnumerator DetectsStuckUI([ValueSource(nameof(MultiThreadingTestValues))] bool multiThreaded)
     {
-        ApplicationNotResponding? arn = null;
+        ApplicationNotRespondingException? arn = null;
         _sut = CreateWatchDog(multiThreaded);
         _sut.OnApplicationNotResponding += (_, e) => arn = e;
 
@@ -71,7 +72,7 @@ public class AnrDetectionTests
     [UnityTest]
     public IEnumerator DoesntReportWorkingUI([ValueSource(nameof(MultiThreadingTestValues))] bool multiThreaded)
     {
-        ApplicationNotResponding? arn = null;
+        ApplicationNotRespondingException? arn = null;
         _sut = CreateWatchDog(multiThreaded);
         _sut.OnApplicationNotResponding += (_, e) => arn = e;
 
@@ -90,7 +91,7 @@ public class AnrDetectionTests
     [TestCase(false)]
     public void DoesntReportShortlyStuckUI(bool multiThreaded)
     {
-        ApplicationNotResponding? arn = null;
+        ApplicationNotRespondingException? arn = null;
         _sut = CreateWatchDog(multiThreaded);
         _sut.OnApplicationNotResponding += (_, e) => arn = e;
 
@@ -103,7 +104,7 @@ public class AnrDetectionTests
     [UnityTest]
     public IEnumerator DoesntReportWhilePaused([ValueSource(nameof(MultiThreadingTestValues))] bool multiThreaded)
     {
-        ApplicationNotResponding? arn = null;
+        ApplicationNotRespondingException? arn = null;
         _sut = CreateWatchDog(multiThreaded);
         _sut.OnApplicationNotResponding += (_, e) => arn = e;
 
@@ -132,7 +133,7 @@ public class AnrDetectionTests
     [UnityTest]
     public IEnumerator IsNotAffectedByTimeScale()
     {
-        ApplicationNotResponding? anr = null;
+        ApplicationNotRespondingException? anr = null;
         _sut = CreateWatchDog(true);
         _sut.OnApplicationNotResponding += (_, e) => anr = e;
 


### PR DESCRIPTION
The `ApplicationNotResponding` exception was previously `internal`.

This can now be consumed i.e. in a `BeforeSend` callback to modify or filter
```
options.SetBeforeSend((sentryEvent, _) =>
{
    if (sentryEvent.Exception is ApplicationNotRespondingException)
    {
        return null;
    }

    return sentryEvent;
});
```