### PR TITLE
feat: Collect `MainThreadData` before initial scene load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Contexts, such as `device` and `gpu` that the SDK retrieves during the game's startup is now available even earlier and irrespective whether an error was captured on the main or on a background thread ([#1802](https://github.com/getsentry/sentry-unity/pull/1802))
+
 ### Dependencies
 
 - Bump CLI from v2.34.1 to v2.36.1 ([#1788](https://github.com/getsentry/sentry-unity/pull/1788), [#1792](https://github.com/getsentry/sentry-unity/pull/1792), [#1796](https://github.com/getsentry/sentry-unity/pull/1796))

--- a/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
@@ -16,18 +16,16 @@ internal static class UnitySdkInfo
 
 internal class UnityScopeIntegration : ISdkIntegration
 {
-    private readonly MainThreadData _mainThreadData;
     private readonly IApplication _application;
 
     public UnityScopeIntegration(SentryMonoBehaviour monoBehaviour, IApplication application)
     {
-        _mainThreadData = monoBehaviour.MainThreadData;
         _application = application;
     }
 
     public void Register(IHub hub, SentryOptions options)
     {
-        var scopeUpdater = new UnityScopeUpdater((SentryUnityOptions)options, _mainThreadData, _application);
+        var scopeUpdater = new UnityScopeUpdater((SentryUnityOptions)options, _application);
         hub.ConfigureScope(scopeUpdater.ConfigureScope);
     }
 }
@@ -35,13 +33,11 @@ internal class UnityScopeIntegration : ISdkIntegration
 internal class UnityScopeUpdater
 {
     private readonly SentryUnityOptions _options;
-    private readonly MainThreadData _mainThreadData;
     private readonly IApplication _application;
 
-    public UnityScopeUpdater(SentryUnityOptions options, MainThreadData mainThreadData, IApplication application)
+    public UnityScopeUpdater(SentryUnityOptions options, IApplication application)
     {
         _options = options;
-        _mainThreadData = mainThreadData;
         _application = application;
     }
 
@@ -70,57 +66,57 @@ internal class UnityScopeUpdater
 
     private void PopulateApp(App app)
     {
-        app.StartTime = _mainThreadData.StartTime;
-        var isDebugBuild = _mainThreadData.IsDebugBuild;
+        app.StartTime = MainThreadData.StartTime;
+        var isDebugBuild = MainThreadData.IsDebugBuild;
         app.BuildType = isDebugBuild is null ? null : (isDebugBuild.Value ? "debug" : "release");
     }
 
     private void PopulateOperatingSystem(OperatingSystem operatingSystem)
     {
-        operatingSystem.RawDescription = _mainThreadData.OperatingSystem;
+        operatingSystem.RawDescription = MainThreadData.OperatingSystem;
     }
 
     private void PopulateDevice(Device device)
     {
-        device.ProcessorCount = _mainThreadData.ProcessorCount;
-        device.CpuDescription = _mainThreadData.CpuDescription;
+        device.ProcessorCount = MainThreadData.ProcessorCount;
+        device.CpuDescription = MainThreadData.CpuDescription;
         device.Timezone = TimeZoneInfo.Local;
-        device.SupportsVibration = _mainThreadData.SupportsVibration;
-        device.Name = _mainThreadData.DeviceName;
+        device.SupportsVibration = MainThreadData.SupportsVibration;
+        device.Name = MainThreadData.DeviceName;
 
         // The app can be run in an iOS or Android emulator. We can't safely set a value for simulator.
         device.Simulator = _application.IsEditor ? true : null;
         device.DeviceUniqueIdentifier = _options.SendDefaultPii
-            ? _mainThreadData.DeviceUniqueIdentifier
+            ? MainThreadData.DeviceUniqueIdentifier
             : null;
-        device.DeviceType = _mainThreadData.DeviceType;
-        device.Model = _mainThreadData.DeviceModel;
+        device.DeviceType = MainThreadData.DeviceType;
+        device.Model = MainThreadData.DeviceModel;
 
         // This is the approximate amount of system memory in megabytes.
         // This function is not supported on Windows Store Apps and will always return 0.
-        if (_mainThreadData.SystemMemorySize > 0)
+        if (MainThreadData.SystemMemorySize > 0)
         {
-            device.MemorySize = _mainThreadData.SystemMemorySize * 1048576L; // Sentry device mem is in Bytes
+            device.MemorySize = MainThreadData.SystemMemorySize * 1048576L; // Sentry device mem is in Bytes
         }
     }
 
     private void PopulateGpu(Gpu gpu)
     {
-        gpu.Id = _mainThreadData.GraphicsDeviceId;
-        gpu.Name = _mainThreadData.GraphicsDeviceName;
-        gpu.VendorName = _mainThreadData.GraphicsDeviceVendor;
-        gpu.MemorySize = _mainThreadData.GraphicsMemorySize;
-        gpu.NpotSupport = _mainThreadData.NpotSupport;
-        gpu.Version = _mainThreadData.GraphicsDeviceVersion;
-        gpu.ApiType = _mainThreadData.GraphicsDeviceType;
-        gpu.MaxTextureSize = _mainThreadData.MaxTextureSize;
-        gpu.SupportsDrawCallInstancing = _mainThreadData.SupportsDrawCallInstancing;
-        gpu.SupportsRayTracing = _mainThreadData.SupportsRayTracing;
-        gpu.SupportsComputeShaders = _mainThreadData.SupportsComputeShaders;
-        gpu.SupportsGeometryShaders = _mainThreadData.SupportsGeometryShaders;
-        gpu.VendorId = _mainThreadData.GraphicsDeviceVendorId;
-        gpu.MultiThreadedRendering = _mainThreadData.GraphicsMultiThreaded;
-        gpu.GraphicsShaderLevel = _mainThreadData.GraphicsShaderLevel switch
+        gpu.Id = MainThreadData.GraphicsDeviceId;
+        gpu.Name = MainThreadData.GraphicsDeviceName;
+        gpu.VendorName = MainThreadData.GraphicsDeviceVendor;
+        gpu.MemorySize = MainThreadData.GraphicsMemorySize;
+        gpu.NpotSupport = MainThreadData.NpotSupport;
+        gpu.Version = MainThreadData.GraphicsDeviceVersion;
+        gpu.ApiType = MainThreadData.GraphicsDeviceType;
+        gpu.MaxTextureSize = MainThreadData.MaxTextureSize;
+        gpu.SupportsDrawCallInstancing = MainThreadData.SupportsDrawCallInstancing;
+        gpu.SupportsRayTracing = MainThreadData.SupportsRayTracing;
+        gpu.SupportsComputeShaders = MainThreadData.SupportsComputeShaders;
+        gpu.SupportsGeometryShaders = MainThreadData.SupportsGeometryShaders;
+        gpu.VendorId = MainThreadData.GraphicsDeviceVendorId;
+        gpu.MultiThreadedRendering = MainThreadData.GraphicsMultiThreaded;
+        gpu.GraphicsShaderLevel = MainThreadData.GraphicsShaderLevel switch
         {
             null => null,
             -1 => null,
@@ -132,38 +128,38 @@ internal class UnityScopeUpdater
             45 => "Metal / OpenGL ES 3.1",
             46 => "OpenGL 4.1",
             50 => "Shader Model 5.0",
-            _ => _mainThreadData.GraphicsShaderLevel.ToString()
+            _ => MainThreadData.GraphicsShaderLevel.ToString()
         };
     }
 
     private void PopulateUnity(Protocol.Unity unity)
     {
-        unity.EditorVersion = _mainThreadData.EditorVersion;
-        unity.InstallMode = _mainThreadData.InstallMode;
-        unity.TargetFrameRate = _mainThreadData.TargetFrameRate;
-        unity.CopyTextureSupport = _mainThreadData.CopyTextureSupport;
-        unity.RenderingThreadingMode = _mainThreadData.RenderingThreadingMode;
+        unity.EditorVersion = MainThreadData.EditorVersion;
+        unity.InstallMode = MainThreadData.InstallMode;
+        unity.TargetFrameRate = MainThreadData.TargetFrameRate;
+        unity.CopyTextureSupport = MainThreadData.CopyTextureSupport;
+        unity.RenderingThreadingMode = MainThreadData.RenderingThreadingMode;
     }
 
     private void PopulateTags(Action<string, string> setTag)
     {
         // TODO revisit which tags we should be adding by default
-        if (_mainThreadData.InstallMode is { } installMode)
+        if (MainThreadData.InstallMode is { } installMode)
         {
             setTag("unity.install_mode", installMode);
         }
 
-        if (_mainThreadData.SupportsDrawCallInstancing.HasValue)
+        if (MainThreadData.SupportsDrawCallInstancing.HasValue)
         {
-            setTag("unity.gpu.supports_instancing", _mainThreadData.SupportsDrawCallInstancing.Value.ToTagValue());
+            setTag("unity.gpu.supports_instancing", MainThreadData.SupportsDrawCallInstancing.Value.ToTagValue());
         }
 
-        if (_mainThreadData.DeviceType is { } deviceType)
+        if (MainThreadData.DeviceType is { } deviceType)
         {
             setTag("unity.device.device_type", deviceType);
         }
 
-        if (_options.SendDefaultPii && _mainThreadData.DeviceUniqueIdentifier is { } deviceUniqueIdentifier)
+        if (_options.SendDefaultPii && MainThreadData.DeviceUniqueIdentifier is { } deviceUniqueIdentifier)
         {
             setTag("unity.device.unique_identifier", deviceUniqueIdentifier);
         }

--- a/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
@@ -18,7 +18,7 @@ internal class UnityScopeIntegration : ISdkIntegration
 {
     private readonly IApplication _application;
 
-    public UnityScopeIntegration(SentryMonoBehaviour monoBehaviour, IApplication application)
+    public UnityScopeIntegration(IApplication application)
     {
         _application = application;
     }

--- a/src/Sentry.Unity/MainThreadData.cs
+++ b/src/Sentry.Unity/MainThreadData.cs
@@ -1,73 +1,113 @@
 using System;
 using System.Threading;
+using UnityEngine;
 
 namespace Sentry.Unity;
 
-internal sealed class MainThreadData
+internal static class MainThreadData
 {
-    internal int? MainThreadId { get; set; }
+    internal static int? MainThreadId { get; set; }
 
-    public string? OperatingSystem { get; set; }
+    public static string? OperatingSystem { get; set; }
 
-    public int? ProcessorCount { get; set; }
+    public static int? ProcessorCount { get; set; }
 
-    public bool? SupportsVibration { get; set; }
+    public static bool? SupportsVibration { get; set; }
 
-    public string? DeviceType { get; set; }
+    public static string? DeviceType { get; set; }
 
-    public string? CpuDescription { get; set; }
+    public static string? CpuDescription { get; set; }
 
-    public string? DeviceName { get; set; }
+    public static string? DeviceName { get; set; }
 
-    public string? DeviceUniqueIdentifier { get; set; }
+    public static string? DeviceUniqueIdentifier { get; set; }
 
-    public string? DeviceModel { get; set; }
+    public static string? DeviceModel { get; set; }
 
-    public int? SystemMemorySize { get; set; }
+    public static int? SystemMemorySize { get; set; }
 
-    public int? GraphicsDeviceId { get; set; }
+    public static int? GraphicsDeviceId { get; set; }
 
-    public string? GraphicsDeviceName { get; set; }
+    public static string? GraphicsDeviceName { get; set; }
 
-    public string? GraphicsDeviceVendorId { get; set; }
+    public static string? GraphicsDeviceVendorId { get; set; }
 
-    public string? GraphicsDeviceVendor { get; set; }
+    public static string? GraphicsDeviceVendor { get; set; }
 
-    public int? GraphicsMemorySize { get; set; }
+    public static int? GraphicsMemorySize { get; set; }
 
-    public bool? GraphicsMultiThreaded { get; set; }
+    public static bool? GraphicsMultiThreaded { get; set; }
 
-    public string? NpotSupport { get; set; }
+    public static string? NpotSupport { get; set; }
 
-    public string? GraphicsDeviceVersion { get; set; }
+    public static string? GraphicsDeviceVersion { get; set; }
 
-    public string? GraphicsDeviceType { get; set; }
+    public static string? GraphicsDeviceType { get; set; }
 
-    public int? MaxTextureSize { get; set; }
+    public static int? MaxTextureSize { get; set; }
 
-    public bool? SupportsDrawCallInstancing { get; set; }
+    public static bool? SupportsDrawCallInstancing { get; set; }
 
-    public bool? SupportsRayTracing { get; set; }
+    public static bool? SupportsRayTracing { get; set; }
 
-    public bool? SupportsComputeShaders { get; set; }
+    public static bool? SupportsComputeShaders { get; set; }
 
-    public bool? SupportsGeometryShaders { get; set; }
+    public static bool? SupportsGeometryShaders { get; set; }
 
-    public int? GraphicsShaderLevel { get; set; }
+    public static int? GraphicsShaderLevel { get; set; }
 
-    public bool? IsDebugBuild { get; set; }
+    public static bool? IsDebugBuild { get; set; }
 
-    public string? EditorVersion { get; set; }
-    public string? InstallMode { get; set; }
+    public static string? EditorVersion { get; set; }
+    public static string? InstallMode { get; set; }
 
-    public string? TargetFrameRate { get; set; }
+    public static string? TargetFrameRate { get; set; }
 
-    public string? CopyTextureSupport { get; set; }
+    public static string? CopyTextureSupport { get; set; }
 
-    public string? RenderingThreadingMode { get; set; }
+    public static string? RenderingThreadingMode { get; set; }
 
-    public DateTimeOffset? StartTime { get; set; }
+    public static DateTimeOffset? StartTime { get; set; }
 
-    public bool IsMainThread()
+    public static bool IsMainThread()
         => MainThreadId.HasValue && Thread.CurrentThread.ManagedThreadId == MainThreadId;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void CollectData() => CollectData(SentrySystemInfoAdapter.Instance);
+
+    internal static void CollectData(ISentrySystemInfo sentrySystemInfo)
+    {
+        MainThreadId = sentrySystemInfo.MainThreadId;
+        ProcessorCount = sentrySystemInfo.ProcessorCount;
+        OperatingSystem = sentrySystemInfo.OperatingSystem;
+        CpuDescription = sentrySystemInfo.CpuDescription;
+        SupportsVibration = sentrySystemInfo.SupportsVibration;
+        DeviceName = sentrySystemInfo.DeviceName;
+        SystemMemorySize = sentrySystemInfo.SystemMemorySize;
+        GraphicsDeviceId = sentrySystemInfo.GraphicsDeviceId;
+        GraphicsDeviceName = sentrySystemInfo.GraphicsDeviceName;
+        GraphicsDeviceVendor = sentrySystemInfo.GraphicsDeviceVendor;
+        GraphicsMemorySize = sentrySystemInfo.GraphicsMemorySize;
+        NpotSupport = sentrySystemInfo.NpotSupport;
+        GraphicsDeviceVersion = sentrySystemInfo.GraphicsDeviceVersion;
+        GraphicsDeviceType = sentrySystemInfo.GraphicsDeviceType;
+        MaxTextureSize = sentrySystemInfo.MaxTextureSize;
+        SupportsDrawCallInstancing = sentrySystemInfo.SupportsDrawCallInstancing;
+        SupportsRayTracing = sentrySystemInfo.SupportsRayTracing;
+        SupportsComputeShaders = sentrySystemInfo.SupportsComputeShaders;
+        SupportsGeometryShaders = sentrySystemInfo.SupportsGeometryShaders;
+        GraphicsShaderLevel = sentrySystemInfo.GraphicsShaderLevel;
+        EditorVersion = sentrySystemInfo.EditorVersion;
+        InstallMode = sentrySystemInfo.InstallMode;
+        DeviceType = sentrySystemInfo.DeviceType?.Value;
+        DeviceUniqueIdentifier = sentrySystemInfo.DeviceUniqueIdentifier?.Value;
+        DeviceModel = sentrySystemInfo.DeviceModel?.Value;
+        GraphicsDeviceVendorId = sentrySystemInfo.GraphicsDeviceVendorId?.Value;
+        GraphicsMultiThreaded = sentrySystemInfo.GraphicsMultiThreaded?.Value;
+        IsDebugBuild = sentrySystemInfo.IsDebugBuild?.Value;
+        TargetFrameRate = sentrySystemInfo.TargetFrameRate?.Value;
+        CopyTextureSupport = sentrySystemInfo.CopyTextureSupport?.Value;
+        RenderingThreadingMode = sentrySystemInfo.RenderingThreadingMode?.Value;
+        StartTime = sentrySystemInfo.StartTime?.Value;
+    }
 }

--- a/src/Sentry.Unity/ScreenshotAttachment.cs
+++ b/src/Sentry.Unity/ScreenshotAttachment.cs
@@ -12,12 +12,10 @@ internal class ScreenshotAttachment : SentryAttachment
 
 internal class ScreenshotAttachmentContent : IAttachmentContent
 {
-    private readonly SentryMonoBehaviour _behaviour;
     private readonly SentryUnityOptions _options;
 
-    public ScreenshotAttachmentContent(SentryUnityOptions options, SentryMonoBehaviour behaviour)
+    public ScreenshotAttachmentContent(SentryUnityOptions options)
     {
-        _behaviour = behaviour;
         _options = options;
     }
 
@@ -25,7 +23,7 @@ internal class ScreenshotAttachmentContent : IAttachmentContent
     {
         // Note: we need to check explicitly that we're on the same thread. While Unity would throw otherwise
         // when capturing the screenshot, it would only do so on development builds. On release, it just crashes...
-        if (!_behaviour.MainThreadData.IsMainThread())
+        if (!MainThreadData.IsMainThread())
         {
             _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on other than main (UI) thread.");
             return Stream.Null;

--- a/src/Sentry.Unity/SentryMonoBehaviour.cs
+++ b/src/Sentry.Unity/SentryMonoBehaviour.cs
@@ -98,90 +98,12 @@ public partial class SentryMonoBehaviour
 
     // The GameObject has to destroy itself since it was created with HideFlags.HideAndDontSave
     private void OnApplicationQuit() => Destroy(gameObject);
-}
 
-/// <summary>
-/// Main thread data collector.
-/// </summary>
-public partial class SentryMonoBehaviour
-{
-    internal readonly MainThreadData MainThreadData = new();
-
-    private ISentrySystemInfo? _sentrySystemInfo;
-    internal ISentrySystemInfo SentrySystemInfo
-    {
-        get
-        {
-            _sentrySystemInfo ??= SentrySystemInfoAdapter.Instance;
-            return _sentrySystemInfo;
-        }
-        set => _sentrySystemInfo = value;
-    }
-
-    // Note: Awake is called only once and synchronously while the object is built.
-    // We want to do it this way instead of a StartCoroutine() so that we have the context info ASAP.
     private void Awake()
     {
         // This prevents object from being destroyed when unloading the scene since using HideFlags.HideAndDontSave
         // doesn't guarantee its persistence on all platforms i.e. WebGL
         // (see https://github.com/getsentry/sentry-unity/issues/1678 for more details)
         DontDestroyOnLoad(gameObject);
-
-        CollectData();
-    }
-
-    internal void CollectData()
-    {
-        // Note: Awake() runs on the main thread. The following code just reads a couple of variables so there's no
-        // delay on the UI and we're safe to do it on the main thread.
-        MainThreadData.MainThreadId = SentrySystemInfo.MainThreadId;
-        MainThreadData.ProcessorCount = SentrySystemInfo.ProcessorCount;
-        MainThreadData.OperatingSystem = SentrySystemInfo.OperatingSystem;
-        MainThreadData.CpuDescription = SentrySystemInfo.CpuDescription;
-        MainThreadData.SupportsVibration = SentrySystemInfo.SupportsVibration;
-        MainThreadData.DeviceName = SentrySystemInfo.DeviceName;
-        MainThreadData.SystemMemorySize = SentrySystemInfo.SystemMemorySize;
-        MainThreadData.GraphicsDeviceId = SentrySystemInfo.GraphicsDeviceId;
-        MainThreadData.GraphicsDeviceName = SentrySystemInfo.GraphicsDeviceName;
-        MainThreadData.GraphicsDeviceVendor = SentrySystemInfo.GraphicsDeviceVendor;
-        MainThreadData.GraphicsMemorySize = SentrySystemInfo.GraphicsMemorySize;
-        MainThreadData.NpotSupport = SentrySystemInfo.NpotSupport;
-        MainThreadData.GraphicsDeviceVersion = SentrySystemInfo.GraphicsDeviceVersion;
-        MainThreadData.GraphicsDeviceType = SentrySystemInfo.GraphicsDeviceType;
-        MainThreadData.MaxTextureSize = SentrySystemInfo.MaxTextureSize;
-        MainThreadData.SupportsDrawCallInstancing = SentrySystemInfo.SupportsDrawCallInstancing;
-        MainThreadData.SupportsRayTracing = SentrySystemInfo.SupportsRayTracing;
-        MainThreadData.SupportsComputeShaders = SentrySystemInfo.SupportsComputeShaders;
-        MainThreadData.SupportsGeometryShaders = SentrySystemInfo.SupportsGeometryShaders;
-        MainThreadData.GraphicsShaderLevel = SentrySystemInfo.GraphicsShaderLevel;
-        MainThreadData.EditorVersion = SentrySystemInfo.EditorVersion;
-        MainThreadData.InstallMode = SentrySystemInfo.InstallMode;
-        if (MainThreadData.IsMainThread())
-        {
-            MainThreadData.DeviceType = SentrySystemInfo.DeviceType?.Value;
-            MainThreadData.DeviceUniqueIdentifier = SentrySystemInfo.DeviceUniqueIdentifier?.Value;
-            MainThreadData.DeviceModel = SentrySystemInfo.DeviceModel?.Value;
-            MainThreadData.GraphicsDeviceVendorId = SentrySystemInfo.GraphicsDeviceVendorId?.Value;
-            MainThreadData.GraphicsMultiThreaded = SentrySystemInfo.GraphicsMultiThreaded?.Value;
-            MainThreadData.IsDebugBuild = SentrySystemInfo.IsDebugBuild?.Value;
-            MainThreadData.TargetFrameRate = SentrySystemInfo.TargetFrameRate?.Value;
-            MainThreadData.CopyTextureSupport = SentrySystemInfo.CopyTextureSupport?.Value;
-            MainThreadData.RenderingThreadingMode = SentrySystemInfo.RenderingThreadingMode?.Value;
-            MainThreadData.StartTime = SentrySystemInfo.StartTime?.Value;
-        }
-        else
-        {
-            // Note: while this shouldn't ever occur, we want to make sure there are some values instead of UB.
-            MainThreadData.DeviceType = null;
-            MainThreadData.DeviceUniqueIdentifier = null;
-            MainThreadData.DeviceModel = null;
-            MainThreadData.GraphicsDeviceVendorId = null;
-            MainThreadData.GraphicsMultiThreaded = null;
-            MainThreadData.IsDebugBuild = null;
-            MainThreadData.TargetFrameRate = null;
-            MainThreadData.CopyTextureSupport = null;
-            MainThreadData.RenderingThreadingMode = null;
-            MainThreadData.StartTime = null;
-        }
     }
 }

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -250,7 +250,7 @@ public sealed class SentryUnityOptions : SentryOptions
 
         this.AddIntegration(new UnityLogHandlerIntegration(this));
         this.AddIntegration(new AnrIntegration(behaviour));
-        this.AddIntegration(new UnityScopeIntegration(behaviour, application));
+        this.AddIntegration(new UnityScopeIntegration(application));
         this.AddIntegration(new UnityBeforeSceneLoadIntegration());
         this.AddIntegration(new SceneManagerIntegration());
         this.AddIntegration(new SessionIntegration(behaviour));

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -244,7 +244,7 @@ public sealed class SentryUnityOptions : SentryOptions
 
         this.AddInAppExclude("UnityEngine");
         this.AddInAppExclude("UnityEditor");
-        var processor = new UnityEventProcessor(this, behaviour);
+        var processor = new UnityEventProcessor(this);
         this.AddEventProcessor(processor);
         this.AddTransactionProcessor(processor);
 

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -53,14 +53,14 @@ internal class SentryUnitySdk
         {
             SentrySdk.ConfigureScope(s =>
                 s.AddAttachment(new ScreenshotAttachment(
-                    new ScreenshotAttachmentContent(options, SentryMonoBehaviour.Instance))));
+                    new ScreenshotAttachmentContent(options))));
         }
 
         if (options.AttachViewHierarchy)
         {
             SentrySdk.ConfigureScope(s =>
                 s.AddAttachment(new ViewHierarchyAttachment(
-                    new UnityViewHierarchyAttachmentContent(options, SentryMonoBehaviour.Instance))));
+                    new UnityViewHierarchyAttachmentContent(options))));
         }
 
         if (options.NativeContextWriter is { } contextWriter)

--- a/src/Sentry.Unity/UnityEventProcessor.cs
+++ b/src/Sentry.Unity/UnityEventProcessor.cs
@@ -11,12 +11,10 @@ internal class UnityEventProcessor :
     ISentryTransactionProcessor
 {
     private readonly SentryUnityOptions _sentryOptions;
-    private readonly MainThreadData _mainThreadData;
 
-    public UnityEventProcessor(SentryUnityOptions sentryOptions, SentryMonoBehaviour sentryMonoBehaviour)
+    public UnityEventProcessor(SentryUnityOptions sentryOptions)
     {
         _sentryOptions = sentryOptions;
-        _mainThreadData = sentryMonoBehaviour.MainThreadData;
     }
 
     public SentryTransaction? Process(SentryTransaction transaction)
@@ -43,7 +41,7 @@ internal class UnityEventProcessor :
             // that it got added last or that there was not an integration added at a later point
             PopulateSdkIntegrations(sentryEvent.Sdk);
             // TODO revisit which tags we should be adding by default
-            sentryEvent.SetTag("unity.is_main_thread", _mainThreadData.IsMainThread().ToTagValue());
+            sentryEvent.SetTag("unity.is_main_thread", MainThreadData.IsMainThread().ToTagValue());
         }
         catch (Exception exception)
         {
@@ -53,7 +51,7 @@ internal class UnityEventProcessor :
 
     private void PopulateDevice(Device device)
     {
-        if (!_mainThreadData.IsMainThread())
+        if (!MainThreadData.IsMainThread())
         {
             return;
         }

--- a/src/Sentry.Unity/UnityViewHierarchyAttachmentContent.cs
+++ b/src/Sentry.Unity/UnityViewHierarchyAttachmentContent.cs
@@ -11,12 +11,10 @@ namespace Sentry.Unity;
 
 internal class UnityViewHierarchyAttachmentContent : IAttachmentContent
 {
-    private readonly SentryMonoBehaviour _behaviour;
     private readonly SentryUnityOptions _options;
 
-    public UnityViewHierarchyAttachmentContent(SentryUnityOptions options, SentryMonoBehaviour behaviour)
+    public UnityViewHierarchyAttachmentContent(SentryUnityOptions options)
     {
-        _behaviour = behaviour;
         _options = options;
     }
 
@@ -24,7 +22,7 @@ internal class UnityViewHierarchyAttachmentContent : IAttachmentContent
     {
         // Note: we need to check explicitly that we're on the same thread. While Unity would throw otherwise
         // when capturing the screenshot, it would only do so on development builds. On release, it just crashes...
-        if (!_behaviour.MainThreadData.IsMainThread())
+        if (!MainThreadData.IsMainThread())
         {
             _options.DiagnosticLogger?.LogDebug("Can't capture screenshots on other than main (UI) thread.");
             return Stream.Null;

--- a/test/Sentry.Unity.Tests/ContextWriterTests.cs
+++ b/test/Sentry.Unity.Tests/ContextWriterTests.cs
@@ -31,7 +31,7 @@ public sealed class ContextWriterTests
     public void Arguments()
     {
         // arrange
-        var sysInfo = _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var sysInfo = new TestSentrySystemInfo
         {
             OperatingSystem = "OperatingSystem",
             ProcessorCount = 1,
@@ -78,7 +78,7 @@ public sealed class ContextWriterTests
         };
 
         // act
-        _sentryMonoBehaviour.CollectData();
+        MainThreadData.CollectData(sysInfo);
         SentryUnity.Init(options);
         Assert.IsTrue(context.SyncFinished.WaitOne(TimeSpan.FromSeconds(10)));
 

--- a/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotAttachmentContentTests.cs
@@ -11,7 +11,7 @@ public class ScreenshotAttachmentTests
     {
         public SentryUnityOptions Options = new() { AttachScreenshot = true };
 
-        public ScreenshotAttachmentContent GetSut() => new(Options, SentryMonoBehaviour.Instance);
+        public ScreenshotAttachmentContent GetSut() => new(Options);
     }
 
     private Fixture _fixture = null!;

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -92,10 +92,10 @@ public sealed class UnityEventProcessorThreadingTests
     [Test]
     [TestCase(true)]
     [TestCase(false)]
-    public void SentrySdkCaptureEvent(bool collectOnUiThread)
+    public void SentrySdkCaptureEvent(bool captureOnUiThread)
     {
         // arrange
-        var sysInfo = _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var systemInfo = new TestSentrySystemInfo
         {
             GraphicsDeviceVendorId = new Lazy<string>(() => "VendorId"),
             GraphicsMultiThreaded = new Lazy<bool>(() => true),
@@ -118,83 +118,46 @@ public sealed class UnityEventProcessorThreadingTests
             DiagnosticLogger = _testLogger
         };
 
-        if (collectOnUiThread)
+        // In an actual build, the collection is automatically triggered by `RuntimeInitializeLoadType.BeforeSceneLoad`
+        MainThreadData.CollectData(systemInfo);
+
+        SentryUnity.Init(options);
+
+        // Act
+        var @event = new SentryEvent
         {
-            _sentryMonoBehaviour.CollectData();
+            Message = TestContext.CurrentContext.Test.Name
+        };
+
+        // Events should have the same context, regardless of the thread they were issued on.
+        if (captureOnUiThread)
+        {
+            SentrySdk.CaptureEvent(@event);
         }
         else
         {
-            // Note: Task.Run().Wait() may be executed on the main thread if it hasn't yet started when Wait() runs.
-            // We prevent it by explicitly sleeping on the main thread
-            var task = Task.Run(_sentryMonoBehaviour.CollectData);
+            var task = Task.Run(() => SentrySdk.CaptureEvent(@event));
             Thread.Sleep(10);
             task.Wait();
         }
 
-        SentryUnity.Init(options);
+        SentrySdk.FlushAsync(TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
 
-        // act & assert
-        for (int i = 0; i <= 1; i++)
-        {
-            var @event = new SentryEvent()
-            {
-                Message = NUnit.Framework.TestContext.CurrentContext.Test.Name
-            };
+        // Assert
+        Assert.AreEqual(systemInfo.GraphicsDeviceVendorId!.Value, @event.Contexts.Gpu.VendorId);
+        Assert.AreEqual(systemInfo.GraphicsMultiThreaded!.Value, @event.Contexts.Gpu.MultiThreadedRendering);
+        Assert.AreEqual(systemInfo.DeviceType!.Value, @event.Contexts.Device.DeviceType);
+        Assert.AreEqual(systemInfo.DeviceModel!.Value, @event.Contexts.Device.Model);
+        Assert.AreEqual(systemInfo.DeviceUniqueIdentifier!.Value, @event.Contexts.Device.DeviceUniqueIdentifier);
+        Assert.AreEqual(systemInfo.IsDebugBuild!.Value ? "debug" : "release", @event.Contexts.App.BuildType);
 
-            // Events should have the same context, regardless of the thread they were issued on.
-            // The context only depends on the thread the data has been collected in, see CollectData() above.
-            if (i == 0)
-            {
-                var task = Task.Run(() => SentrySdk.CaptureEvent(@event));
-                Thread.Sleep(10);
-                task.Wait();
-            }
-            else
-            {
-                SentrySdk.CaptureEvent(@event);
-            }
-            SentrySdk.FlushAsync(TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
-
-            if (collectOnUiThread)
-            {
-                Assert.AreEqual(sysInfo.GraphicsDeviceVendorId!.Value, @event.Contexts.Gpu.VendorId);
-                Assert.AreEqual(sysInfo.GraphicsMultiThreaded!.Value, @event.Contexts.Gpu.MultiThreadedRendering);
-                Assert.AreEqual(sysInfo.DeviceType!.Value, @event.Contexts.Device.DeviceType);
-                Assert.AreEqual(sysInfo.DeviceModel!.Value, @event.Contexts.Device.Model);
-                Assert.AreEqual(sysInfo.DeviceUniqueIdentifier!.Value, @event.Contexts.Device.DeviceUniqueIdentifier);
-                Assert.AreEqual(sysInfo.IsDebugBuild!.Value ? "debug" : "release", @event.Contexts.App.BuildType);
-
-                @event.Contexts.TryGetValue(Unity.Protocol.Unity.Type, out var unityProtocolObject);
-                var unityContext = unityProtocolObject as Unity.Protocol.Unity;
-                Assert.IsNotNull(unityContext);
-                Assert.AreEqual(sysInfo.TargetFrameRate!.Value, unityContext!.TargetFrameRate);
-                Assert.AreEqual(sysInfo.CopyTextureSupport!.Value, unityContext.CopyTextureSupport);
-                Assert.AreEqual(sysInfo.RenderingThreadingMode!.Value, unityContext.RenderingThreadingMode);
-            }
-            else
-            {
-                Assert.IsNull(@event.Contexts.Gpu.VendorId);
-                Assert.IsNull(@event.Contexts.Gpu.MultiThreadedRendering);
-                Assert.IsNull(@event.Contexts.Device.DeviceType);
-                Assert.IsNull(@event.Contexts.Device.Model);
-                Assert.IsNull(@event.Contexts.Device.DeviceUniqueIdentifier);
-                Assert.IsNull(@event.Contexts.App.BuildType);
-                // TODO Assert.IsNull( @event.Contexts.App.StartTime);
-
-
-                Unity.Protocol.Unity? unityContext;
-                if (!@event.Contexts.TryGetValue(Unity.Protocol.Unity.Type, out var contextValue) || (unityContext = contextValue as Unity.Protocol.Unity) == null)
-                {
-                    unityContext = new Unity.Protocol.Unity();
-                    @event.Contexts[Unity.Protocol.Unity.Type] = unityContext;
-                }
-
-                Assert.IsNull(unityContext.TargetFrameRate);
-                Assert.IsNull(unityContext.CopyTextureSupport);
-                Assert.IsNull(unityContext.RenderingThreadingMode);
-            }
-            Assert.IsNull(@event.ServerName);
-        }
+        @event.Contexts.TryGetValue(Unity.Protocol.Unity.Type, out var unityProtocolObject);
+        var unityContext = unityProtocolObject as Unity.Protocol.Unity;
+        Assert.IsNotNull(unityContext);
+        Assert.AreEqual(systemInfo.TargetFrameRate!.Value, unityContext!.TargetFrameRate);
+        Assert.AreEqual(systemInfo.CopyTextureSupport!.Value, unityContext.CopyTextureSupport);
+        Assert.AreEqual(systemInfo.RenderingThreadingMode!.Value, unityContext.RenderingThreadingMode);
+        Assert.IsNull(@event.ServerName);
     }
 }
 
@@ -202,7 +165,6 @@ public sealed class UnityEventProcessorTests
 {
     private GameObject _gameObject = null!;
     private SentryMonoBehaviour _sentryMonoBehaviour = null!;
-    private MainThreadData _mainThreadData => _sentryMonoBehaviour.MainThreadData;
     private SentryUnityOptions _sentryOptions = null!;
     private TestApplication _testApplication = null!;
 
@@ -229,7 +191,7 @@ public sealed class UnityEventProcessorTests
     public void SdkInfo_Correct()
     {
         // arrange
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
@@ -250,7 +212,7 @@ public sealed class UnityEventProcessorTests
     {
         // arrange
         var testApplication = new TestApplication(isEditor);
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, testApplication);
+        var sut = new UnityScopeUpdater(_sentryOptions, testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
@@ -270,12 +232,13 @@ public sealed class UnityEventProcessorTests
     public void DeviceUniqueIdentifierWithSendDefaultPii_IsNotNull()
     {
         // arrange
+        MainThreadData.CollectData(new TestSentrySystemInfo { DeviceUniqueIdentifier = new Lazy<string>(() => "83fdd6d4-50b1-4735-a4d1-d4f7de64aff0") });
+
         var sentryOptions = new SentryUnityOptions { SendDefaultPii = true };
-        var sut = new UnityScopeUpdater(sentryOptions, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(sentryOptions, _testApplication);
         var scope = new Scope(sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // act
@@ -288,11 +251,10 @@ public sealed class UnityEventProcessorTests
     public void AppProtocol_Assigned()
     {
         // arrange
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
@@ -305,11 +267,10 @@ public sealed class UnityEventProcessorTests
     {
         // arrange
         var options = new SentryUnityOptions { DefaultUserId = "foo" };
-        var sut = new UnityScopeUpdater(options, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(options, _testApplication);
         var scope = new Scope(options);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
@@ -321,12 +282,11 @@ public sealed class UnityEventProcessorTests
     {
         // arrange
         var options = new SentryUnityOptions { DefaultUserId = "foo" };
-        var sut = new UnityScopeUpdater(options, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(options, _testApplication);
         var scope = new Scope(options);
         scope.User.Id = "bar";
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
@@ -337,23 +297,23 @@ public sealed class UnityEventProcessorTests
     public void Tags_Set()
     {
         // arrange
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var systemInfo = new TestSentrySystemInfo
         {
             SupportsDrawCallInstancing = true,
             DeviceType = new(() => "test type"),
             DeviceUniqueIdentifier = new(() => "f810306c-68db-4ebe-89ba-13c457449339"),
             InstallMode = ApplicationInstallMode.Store.ToString()
         };
+        MainThreadData.CollectData(systemInfo);
 
         var sentryOptions = new SentryUnityOptions { SendDefaultPii = true };
-        var scopeUpdater = new UnityScopeUpdater(sentryOptions, _mainThreadData, _testApplication);
-        var unityEventProcessor = new UnityEventProcessor(sentryOptions, _sentryMonoBehaviour);
+        var scopeUpdater = new UnityScopeUpdater(sentryOptions, _testApplication);
+        var unityEventProcessor = new UnityEventProcessor(sentryOptions);
         var scope = new Scope(sentryOptions);
         var sentryEvent = new SentryEvent();
         var transaction = new SentryTransaction("name", "operation");
 
         // act
-        _sentryMonoBehaviour.CollectData();
         scopeUpdater.ConfigureScope(scope);
         scope.Apply(sentryEvent);
         scope.Apply(transaction);
@@ -361,30 +321,30 @@ public sealed class UnityEventProcessorTests
         unityEventProcessor.Process(transaction);
 
         // assert
-        AssertEventProcessorTags(sentryEvent.Tags);
-        AssertEventProcessorTags(transaction.Tags);
+        AssertEventProcessorTags(systemInfo, sentryEvent.Tags);
+        AssertEventProcessorTags(systemInfo, transaction.Tags);
     }
 
-    private void AssertEventProcessorTags(IReadOnlyDictionary<string, string> tags)
+    private void AssertEventProcessorTags(ISentrySystemInfo systemInfo, IReadOnlyDictionary<string, string> tags)
     {
         Assert.IsNotNull(tags);
         Assert.NotZero(tags.Count);
 
         var unityInstallMode = tags.SingleOrDefault(t => t.Key == "unity.install_mode");
         Assert.NotNull(unityInstallMode);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.InstallMode, unityInstallMode.Value);
+        Assert.AreEqual(systemInfo.InstallMode, unityInstallMode.Value);
 
         var supportsInstancing = tags.SingleOrDefault(t => t.Key == "unity.gpu.supports_instancing");
         Assert.NotNull(supportsInstancing);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsDrawCallInstancing, bool.Parse(supportsInstancing.Value));
+        Assert.AreEqual(systemInfo.SupportsDrawCallInstancing, bool.Parse(supportsInstancing.Value));
 
         var deviceType = tags.SingleOrDefault(t => t.Key == "unity.device.device_type");
         Assert.NotNull(deviceType);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceType!.Value, deviceType.Value);
+        Assert.AreEqual(systemInfo.DeviceType!.Value, deviceType.Value);
 
         var deviceUniqueIdentifier = tags.SingleOrDefault(t => t.Key == "unity.device.unique_identifier");
         Assert.NotNull(deviceUniqueIdentifier);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceUniqueIdentifier!.Value, deviceUniqueIdentifier.Value);
+        Assert.AreEqual(systemInfo.DeviceUniqueIdentifier!.Value, deviceUniqueIdentifier.Value);
 
         var isMainThread = tags.SingleOrDefault(t => t.Key == "unity.is_main_thread");
         Assert.NotNull(isMainThread);
@@ -395,23 +355,24 @@ public sealed class UnityEventProcessorTests
     public void OperatingSystemProtocol_Assigned()
     {
         // arrange
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo { OperatingSystem = "Windows" };
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        var systemInfo = new TestSentrySystemInfo { OperatingSystem = "Windows" };
+        MainThreadData.CollectData(systemInfo);
+
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.OperatingSystem, scope.Contexts.OperatingSystem.RawDescription);
+        Assert.AreEqual(systemInfo.OperatingSystem, scope.Contexts.OperatingSystem.RawDescription);
     }
 
     [Test]
     public void DeviceProtocol_Assigned()
     {
         const long toByte = 1048576L; // in `UnityEventProcessor.PopulateDevice`
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var systemInfo = new TestSentrySystemInfo
         {
             ProcessorCount = 1,
             DeviceType = new Lazy<string>(() => "Console"),
@@ -421,28 +382,29 @@ public sealed class UnityEventProcessorTests
             DeviceModel = new Lazy<string>(() => "Samsung Galaxy S3"),
             SystemMemorySize = 16000
         };
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        MainThreadData.CollectData(systemInfo);
+
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
         var device = scope.Contexts.Device;
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.ProcessorCount, device.ProcessorCount);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceType!.Value, device.DeviceType);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.CpuDescription, device.CpuDescription);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsVibration, device.SupportsVibration);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceName, device.Name);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.DeviceModel!.Value, device.Model);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SystemMemorySize * toByte, device.MemorySize);
+        Assert.AreEqual(systemInfo.ProcessorCount, device.ProcessorCount);
+        Assert.AreEqual(systemInfo.DeviceType!.Value, device.DeviceType);
+        Assert.AreEqual(systemInfo.CpuDescription, device.CpuDescription);
+        Assert.AreEqual(systemInfo.SupportsVibration, device.SupportsVibration);
+        Assert.AreEqual(systemInfo.DeviceName, device.Name);
+        Assert.AreEqual(systemInfo.DeviceModel!.Value, device.Model);
+        Assert.AreEqual(systemInfo.SystemMemorySize * toByte, device.MemorySize);
     }
 
     [Test]
     public void UnityProtocol_Assigned()
     {
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var systemInfo = new TestSentrySystemInfo
         {
             EditorVersion = "TestEditorVersion2022.3.2f1",
             InstallMode = "Editor",
@@ -450,28 +412,29 @@ public sealed class UnityEventProcessorTests
             CopyTextureSupport = new Lazy<string>(() => "Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture"),
             RenderingThreadingMode = new Lazy<string>(() => "MultiThreaded")
         };
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        MainThreadData.CollectData(systemInfo);
+
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
         scope.Contexts.TryGetValue(Unity.Protocol.Unity.Type, out var unityProtocolObject);
         var unityProtocol = unityProtocolObject as Unity.Protocol.Unity;
         Assert.IsNotNull(unityProtocol);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.EditorVersion, unityProtocol!.EditorVersion);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.InstallMode, unityProtocol.InstallMode);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.TargetFrameRate!.Value, unityProtocol.TargetFrameRate);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.CopyTextureSupport!.Value, unityProtocol.CopyTextureSupport);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.RenderingThreadingMode!.Value, unityProtocol.RenderingThreadingMode);
+        Assert.AreEqual(systemInfo.EditorVersion, unityProtocol!.EditorVersion);
+        Assert.AreEqual(systemInfo.InstallMode, unityProtocol.InstallMode);
+        Assert.AreEqual(systemInfo.TargetFrameRate!.Value, unityProtocol.TargetFrameRate);
+        Assert.AreEqual(systemInfo.CopyTextureSupport!.Value, unityProtocol.CopyTextureSupport);
+        Assert.AreEqual(systemInfo.RenderingThreadingMode!.Value, unityProtocol.RenderingThreadingMode);
     }
 
     [Test]
     public void GpuProtocol_Assigned()
     {
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var systemInfo = new TestSentrySystemInfo
         {
             GraphicsDeviceId = 1,
             GraphicsDeviceName = "GeForce RTX 3090",
@@ -488,29 +451,30 @@ public sealed class UnityEventProcessorTests
             SupportsComputeShaders = true,
             SupportsGeometryShaders = true
         };
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        MainThreadData.CollectData(systemInfo);
+
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
         var gpu = scope.Contexts.Gpu;
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceId, gpu.Id);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceName, gpu.Name);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceVendorId!.Value, gpu.VendorId);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceVendor, gpu.VendorName);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsMemorySize, gpu.MemorySize);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsMultiThreaded!.Value, gpu.MultiThreadedRendering);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.NpotSupport, gpu.NpotSupport);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceVersion, gpu.Version);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.GraphicsDeviceType, gpu.ApiType);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.MaxTextureSize, gpu.MaxTextureSize);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsDrawCallInstancing, gpu.SupportsDrawCallInstancing);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsRayTracing, gpu.SupportsRayTracing);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsComputeShaders, gpu.SupportsComputeShaders);
-        Assert.AreEqual(_sentryMonoBehaviour.SentrySystemInfo.SupportsGeometryShaders, gpu.SupportsGeometryShaders);
+        Assert.AreEqual(systemInfo.GraphicsDeviceId, gpu.Id);
+        Assert.AreEqual(systemInfo.GraphicsDeviceName, gpu.Name);
+        Assert.AreEqual(systemInfo.GraphicsDeviceVendorId!.Value, gpu.VendorId);
+        Assert.AreEqual(systemInfo.GraphicsDeviceVendor, gpu.VendorName);
+        Assert.AreEqual(systemInfo.GraphicsMemorySize, gpu.MemorySize);
+        Assert.AreEqual(systemInfo.GraphicsMultiThreaded!.Value, gpu.MultiThreadedRendering);
+        Assert.AreEqual(systemInfo.NpotSupport, gpu.NpotSupport);
+        Assert.AreEqual(systemInfo.GraphicsDeviceVersion, gpu.Version);
+        Assert.AreEqual(systemInfo.GraphicsDeviceType, gpu.ApiType);
+        Assert.AreEqual(systemInfo.MaxTextureSize, gpu.MaxTextureSize);
+        Assert.AreEqual(systemInfo.SupportsDrawCallInstancing, gpu.SupportsDrawCallInstancing);
+        Assert.AreEqual(systemInfo.SupportsRayTracing, gpu.SupportsRayTracing);
+        Assert.AreEqual(systemInfo.SupportsComputeShaders, gpu.SupportsComputeShaders);
+        Assert.AreEqual(systemInfo.SupportsGeometryShaders, gpu.SupportsGeometryShaders);
     }
 
     [Test]
@@ -518,17 +482,12 @@ public sealed class UnityEventProcessorTests
         [ValueSource(nameof(ShaderLevels))] (int, string) shaderValue)
     {
         var (shaderLevel, shaderDescription) = shaderValue;
+        MainThreadData.CollectData(new TestSentrySystemInfo { GraphicsShaderLevel = shaderLevel });
 
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
-        {
-            GraphicsShaderLevel = shaderLevel
-        };
-
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
         sut.ConfigureScope(scope);
 
         // assert
@@ -551,16 +510,16 @@ public sealed class UnityEventProcessorTests
     [Test]
     public void GpuProtocolGraphicsShaderLevelMinusOne_Ignored()
     {
-        _sentryMonoBehaviour.SentrySystemInfo = new TestSentrySystemInfo
+        var sentrySystemInfo = new TestSentrySystemInfo
         {
             GraphicsShaderLevel = -1
         };
 
-        var sut = new UnityScopeUpdater(_sentryOptions, _mainThreadData, _testApplication);
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
         // act
-        _sentryMonoBehaviour.CollectData();
+        MainThreadData.CollectData(sentrySystemInfo);
         sut.ConfigureScope(scope);
 
         // assert

--- a/test/Sentry.Unity.Tests/UnityViewHierarchyAttachmentTests.cs
+++ b/test/Sentry.Unity.Tests/UnityViewHierarchyAttachmentTests.cs
@@ -12,7 +12,7 @@ public class UnityViewHierarchyAttachmentTests
     {
         public SentryUnityOptions Options = new() { AttachViewHierarchy = true };
 
-        public UnityViewHierarchyAttachmentContent GetSut() => new(Options, SentryMonoBehaviour.Instance);
+        public UnityViewHierarchyAttachmentContent GetSut() => new(Options);
     }
 
     private Fixture _fixture = null!;


### PR DESCRIPTION
Initially, we deferred the collection of `MainThreadData` into our MonoBehaviour's Awake call. Since that data does not change at runtime, fetching it doesn't impose any performance impact (we were just doing it at a later point) we can rely on the `[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]` attribute. That way we have the data available right after initialization and irrespective whether an error gets captured on the main/UI or a background thread.