### PR TITLE
Change access modifier to `private` for stack trace mode option setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,12 @@
 - The SDK now uses the .NET SDK's `Options.FileWriteDisabled` to opt-out on any writing operations on 'unknown' platforms such as the Nintendo Switch ([1814](https://github.com/getsentry/sentry-unity/pull/1814))
 - The SDK no longer freezes the game during shutdown when targeting WebGL ([#3619](https://github.com/getsentry/sentry-dotnet/pull/3619))
 - The SDK no longer passes a mangled `gpu.vendorId` to the Android native layer ([#1813](https://github.com/getsentry/sentry-unity/pull/1813))
+- Access to the `StackTraceMode` was intended to be restricted due to incompatibility between IL2CPP and `StackTraceMode.Enhanced`. The access modifier has been changed to `private` to avoid pitfall and potential crashes ([#1806](https://github.com/getsentry/sentry-unity/pull/1806))
 
 ### Features
 
 - Contexts, such as `device` and `gpu` that the SDK retrieves during the game's startup is now available even earlier and irrespective whether an error was captured on the main or on a background thread ([#1802](https://github.com/getsentry/sentry-unity/pull/1802))
 - Added an `ApplicationNotRespondingException` type that allows filtering of ANR events ([#1800](https://github.com/getsentry/sentry-unity/pull/1800))
-
-### Fixes
-
-- Access to the `StackTraceMode` was intended to be restricted due to incompatibility between IL2CPP and `StackTraceMode.Enhanced`. The access modifier has been changed to `private` to avoid pitfall and potential crashes ([#1806](https://github.com/getsentry/sentry-unity/pull/1806))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Contexts, such as `device` and `gpu` that the SDK retrieves during the game's startup is now available even earlier and irrespective whether an error was captured on the main or on a background thread ([#1802](https://github.com/getsentry/sentry-unity/pull/1802))
 - Added an `ApplicationNotRespondingException` type that allows filtering of ANR events ([#1800](https://github.com/getsentry/sentry-unity/pull/1800))
 
+### Fixes
+
+- Change access modifier to `private` for stack trace mode option setter ([#1806](https://github.com/getsentry/sentry-unity/pull/1806))
+
 ### Dependencies
 
 - Bump CLI from v2.34.1 to v2.36.1 ([#1788](https://github.com/getsentry/sentry-unity/pull/1788), [#1792](https://github.com/getsentry/sentry-unity/pull/1792), [#1796](https://github.com/getsentry/sentry-unity/pull/1796))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Change access modifier to `private` for stack trace mode option setter ([#1806](https://github.com/getsentry/sentry-unity/pull/1806))
+- Change access modifier of `StackTraceMode` to `private` to avoid pitfall ([#1806](https://github.com/getsentry/sentry-unity/pull/1806))
 
 ### Dependencies
 

--- a/scripts/build-and-alias.ps1
+++ b/scripts/build-and-alias.ps1
@@ -1,0 +1,3 @@
+Remove-Item "package-dev/Runtime/*.dll"
+dotnet build
+assemblyalias --target-directory "./package-dev/Runtime/" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -194,7 +194,9 @@ public sealed class SentryUnityOptions : SentryOptions
     /// </summary>
     public bool PerformanceAutoInstrumentationEnabled { get; set; } = false;
 
-    // This option is hidden due to incompatibility between IL2CPP and Enhanced mode.
+    /// <summary>
+    /// This option is restricted due to incompatibility between IL2CPP and Enhanced mode.
+    /// </summary>
     public new StackTraceMode StackTraceMode { get; private set; }
 
     // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -195,7 +195,7 @@ public sealed class SentryUnityOptions : SentryOptions
     public bool PerformanceAutoInstrumentationEnabled { get; set; } = false;
 
     // This option is hidden due to incompatibility between IL2CPP and Enhanced mode.
-    private new StackTraceMode StackTraceMode { get; set; }
+    public new StackTraceMode StackTraceMode { get; private set; }
 
     // Initialized by native SDK binding code to set the User.ID in .NET (UnityEventProcessor).
     internal string? _defaultUserId;


### PR DESCRIPTION
This PR should prevent users from accidentally enabling `Enhanced` stack trace mode via the `SentryUnityOptions` parent class property. Enhanced mode is not supported in IL2CPP builds (see #1033 for more details) and thus could cause crashes like in #1783.

Closes #1783 