### PR TITLE
fix: vendorId is a String in sentry-java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The gpu.vendorId is now properly passed as a String to sentry-java ([#1813](https://github.com/getsentry/sentry-unity/pull/1813))
+
 ### Features
 
 - Contexts, such as `device` and `gpu` that the SDK retrieves during the game's startup is now available even earlier and irrespective whether an error was captured on the main or on a background thread ([#1802](https://github.com/getsentry/sentry-unity/pull/1802))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- The gpu.vendorId is now properly passed as a String to sentry-java ([#1813](https://github.com/getsentry/sentry-unity/pull/1813))
+- The SDK no longer passes a mangled `gpu.vendorId` to the Android native layer ([#1813](https://github.com/getsentry/sentry-unity/pull/1813))
 
 ### Features
 

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -103,11 +103,7 @@ internal class SentryJava : ISentryJava
             using var gpu = new AndroidJavaObject("io.sentry.protocol.Gpu");
             gpu.SetIfNotNull("name", GpuName);
             gpu.SetIfNotNull("id", GpuId);
-            if (GpuVendorId is not null && int.TryParse(GpuVendorId, out var intVendorId) && intVendorId != 0)
-            {
-                using var integer = new AndroidJavaObject("java.lang.Integer", intVendorId);
-                gpu.Set("vendorId", integer);
-            }
+            gpu.SetIfNotNull("vendorId", GpuVendorId);
             gpu.SetIfNotNull("vendorName", GpuVendorName);
             gpu.SetIfNotNull("memorySize", GpuMemorySize);
             gpu.SetIfNotNull("apiType", GpuApiType);


### PR DESCRIPTION
Starting with `sentry-java` 6.7.1, `"vendorId"` is expected to be a String: https://github.com/getsentry/sentry-java/blob/6c8acb80b8a3a1991a7f614347c12c460a90c746/sentry/src/main/java/io/sentry/protocol/Gpu.java#L82

Not sure if we have ways to write tests for this, if so please let me know!

Related issue: https://github.com/getsentry/team-mobile/issues/67