### PR TITLE
fix: Disable file-write on unknown platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@
 
 ### Fixes
 
+- The SDK now uses the .NET SDK's `Options.FileWriteDisabled` to opt-out on any writing operations on 'unknown' platforms such as the Nintendo Switch ([1814](https://github.com/getsentry/sentry-unity/pull/1814))
 - The SDK no longer freezes the game during shutdown when targeting WebGL ([#3619](https://github.com/getsentry/sentry-dotnet/pull/3619))
-### Fixes
-
 - The SDK no longer passes a mangled `gpu.vendorId` to the Android native layer ([#1813](https://github.com/getsentry/sentry-unity/pull/1813))
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Unreleased
 
+### API Changes
+
+- The `SentrySdk.Metrics` module is deprecated and will be removed in the next major release. 
+  Sentry will reject all metrics sent after October 7, 2024.
+  Learn more: https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics  ([#3619](https://github.com/getsentry/sentry-dotnet/pull/3619))
+
 ### Fixes
 
-- The SDK now automatically opts-out of all file-writing operations on `unknown platforms` like the Nintendo Switch ([#1814](https://github.com/getsentry/sentry-unity/pull/1814))
+- The SDK no longer freezes the game during shutdown when targeting WebGL ([#3619](https://github.com/getsentry/sentry-dotnet/pull/3619))
+- The SDK no longer passes a mangled `gpu.vendorId` to the Android native layer ([#1813](https://github.com/getsentry/sentry-unity/pull/1813))
 
 ### Features
 
@@ -13,9 +20,12 @@
 
 ### Dependencies
 
-- Bump CLI from v2.34.1 to v2.36.1 ([#1788](https://github.com/getsentry/sentry-unity/pull/1788), [#1792](https://github.com/getsentry/sentry-unity/pull/1792), [#1796](https://github.com/getsentry/sentry-unity/pull/1796))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2361)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.34.1...2.36.1)
+- Bump Native SDK from v0.7.9 to v0.7.10 ([#1809](https://github.com/getsentry/sentry-unity/pull/1809))
+  - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0710)
+  - [diff](https://github.com/getsentry/sentry-native/compare/0.7.9...0.7.10)
+- Bump CLI from v2.34.1 to v2.36.4 ([#1788](https://github.com/getsentry/sentry-unity/pull/1788), [#1792](https://github.com/getsentry/sentry-unity/pull/1792), [#1796](https://github.com/getsentry/sentry-unity/pull/1796), [#1810](https://github.com/getsentry/sentry-unity/pull/1810), [#1815](https://github.com/getsentry/sentry-unity/pull/1815), [#1819](https://github.com/getsentry/sentry-unity/pull/1819))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2364)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.34.1...2.36.4)
 
 ## 2.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The SDK now automatically opts-out of all file-writing operations on `unknown platforms` like the Nintendo Switch ([#1814](https://github.com/getsentry/sentry-unity/pull/1814))
+
 ### Features
 
 - Contexts, such as `device` and `gpu` that the SDK retrieves during the game's startup is now available even earlier and irrespective whether an error was captured on the main or on a background thread ([#1802](https://github.com/getsentry/sentry-unity/pull/1802))

--- a/scripts/build-and-alias.ps1
+++ b/scripts/build-and-alias.ps1
@@ -1,0 +1,3 @@
+Remove-Item "package-dev/Runtime/*.dll"
+dotnet build
+assemblyalias --target-directory "./package-dev/Runtime/" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -239,6 +239,8 @@ public class ScriptableSentryUnityOptions : ScriptableObject
     {
         if (unityInfo?.IsKnownPlatform() == false)
         {
+            options.DisableFileWrite = true;
+
             // This is only provided on a best-effort basis for other than the explicitly supported platforms.
             if (options.BackgroundWorker is null)
             {
@@ -258,13 +260,6 @@ public class ScriptableSentryUnityOptions : ScriptableObject
             {
                 options.DiagnosticLogger?.LogDebug("Platform support for automatic session tracking is unknown: disabling.");
                 options.AutoSessionTracking = false;
-            }
-
-            // Requires file access
-            if (options.TracesSampleRate > 0.0f)
-            {
-                options.DiagnosticLogger?.LogDebug("Platform support for tracing is unknown: disabling.");
-                options.TracesSampleRate = null;
             }
         }
     }

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -58,6 +58,15 @@ public class Builder
 
         if (target == BuildTarget.Android)
         {
+            // Android does not support appending builds. We make sure the directory does not exist
+            Debug.Log("Builder: Attempting to clean the buildPath");
+
+            if (Directory.Exists(args["buildPath"]))
+            {
+                Debug.Log("Builder: Cleaning the buildPath");
+                Directory.Delete(args["buildPath"], true);
+            }
+
             Debug.Log("Builder: Enabling minify");
 #if UNITY_2020_1_OR_NEWER
             PlayerSettings.Android.minifyDebug = PlayerSettings.Android.minifyRelease = true;

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using Sentry.Extensibility;
+using Sentry.Unity.Integrations;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
 
@@ -133,6 +137,45 @@ public class ScriptableSentryUnityOptionsTests
 
         Assert.IsNull(options.CacheDirectoryPath);
         Assert.IsFalse(options.AutoSessionTracking);
+    }
+
+    [Test]
+    public void ToSentryUnityOptions_WebExceptionFilterAdded()
+    {
+        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+        _fixture.UnityInfo = new TestUnityInfo(true);
+
+        var options = scriptableOptions.ToSentryUnityOptions(false, _fixture.UnityInfo, _fixture.Application);
+
+        var exceptionFiltersPropertyInfo = typeof(SentryOptions).GetProperty("ExceptionFilters", BindingFlags.NonPublic | BindingFlags.Instance);
+        var filters = exceptionFiltersPropertyInfo.GetValue(options) as List<IExceptionFilter>;
+        Assert.True(filters.OfType<UnityWebExceptionFilter>().Any());
+    }
+
+    [Test]
+    public void ToSentryUnityOptions_UnitySocketExceptionFilterAdded()
+    {
+        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+        _fixture.UnityInfo = new TestUnityInfo(true);
+
+        var options = scriptableOptions.ToSentryUnityOptions(false, _fixture.UnityInfo, _fixture.Application);
+
+        var exceptionFiltersPropertyInfo = typeof(SentryOptions).GetProperty("ExceptionFilters", BindingFlags.NonPublic | BindingFlags.Instance);
+        var filters = exceptionFiltersPropertyInfo.GetValue(options) as List<IExceptionFilter>;
+        Assert.True(filters.OfType<UnitySocketExceptionFilter>().Any());
+    }
+
+    [Test]
+    public void ToSentryUnityOptions_UnityBadGatewayExceptionFilterAdded()
+    {
+        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+        _fixture.UnityInfo = new TestUnityInfo(true);
+
+        var options = scriptableOptions.ToSentryUnityOptions(false, _fixture.UnityInfo, _fixture.Application);
+
+        var exceptionFiltersPropertyInfo = typeof(SentryOptions).GetProperty("ExceptionFilters", BindingFlags.NonPublic | BindingFlags.Instance);
+        var filters = exceptionFiltersPropertyInfo.GetValue(options) as List<IExceptionFilter>;
+        Assert.True(filters.OfType<UnityBadGatewayExceptionFilter>().Any());
     }
 
     public static void AssertOptions(SentryUnityOptions expected, SentryUnityOptions actual)

--- a/test/Sentry.Unity.Tests/UnityBadGatewayExceptionFilterTests.cs
+++ b/test/Sentry.Unity.Tests/UnityBadGatewayExceptionFilterTests.cs
@@ -24,19 +24,6 @@ public class UnityBadGatewayExceptionFilterTests
 
         Assert.IsTrue(new UnityBadGatewayExceptionFilter().Filter(new Exception(UnityBadGatewayExceptionFilter.Message)));
 
-    [Test]
-    public void Init_WithDefaultOptions_DoesNotSendBadGatewayExceptions()
-    {
-        LogAssert.ignoreFailingMessages = true; // The TestHttpClientHandler will complain about timing out (and it should!)
-
-        using var _ = SentryTests.InitSentrySdk(testHttpClientHandler: _testHttpClientHandler);
-
-        SentrySdk.CaptureException(new Exception(UnityBadGatewayExceptionFilter.Message + _identifyingEventValue));
-
-        var createdEvent = _testHttpClientHandler.GetEvent(_identifyingEventValue, _eventReceiveTimeout);
-        Assert.AreEqual(string.Empty, createdEvent);
-    }
-
     internal IDisposable InitSentrySdk(Action<SentryUnityOptions>? configure = null)
     {
         SentryUnity.Init(options =>

--- a/test/Sentry.Unity.Tests/UnitySocketExceptionFilterTests.cs
+++ b/test/Sentry.Unity.Tests/UnitySocketExceptionFilterTests.cs
@@ -17,17 +17,4 @@ public class UnitySocketExceptionFilterTests
     [Test]
     public void Filter_FiltersBadGatewayExceptionsOfTypeException() =>
         Assert.IsTrue(new UnitySocketExceptionFilter().Filter(new System.Net.Sockets.SocketException(10049)));
-
-    [Test]
-    public void Init_WithDefaultOptions_DoesNotSendFilteredSocketExceptions()
-    {
-        LogAssert.ignoreFailingMessages = true; // The TestHttpClientHandler will complain about timing out (and it should!)
-
-        using var _ = SentryTests.InitSentrySdk(testHttpClientHandler: _testHttpClientHandler);
-
-        SentrySdk.CaptureException(new System.Net.Sockets.SocketException(10049)); // The requested address is not valid in this context
-
-        var createdEvent = _testHttpClientHandler.GetEvent(UnitySocketExceptionFilter.Message, _eventReceiveTimeout);
-        Assert.AreEqual(string.Empty, createdEvent);
-    }
 }

--- a/test/Sentry.Unity.Tests/UnityWebExceptionFilterTests.cs
+++ b/test/Sentry.Unity.Tests/UnityWebExceptionFilterTests.cs
@@ -26,12 +26,9 @@ public class UnityWebExceptionFilterTests
 
         using var _ = SentryTests.InitSentrySdk(testHttpClientHandler: _testHttpClientHandler);
 
-        var message = UnityWebExceptionFilter.Message + Guid.NewGuid();
-        SentrySdk.CaptureException(new System.Net.WebException(message));
+        SentrySdk.CaptureException(new System.Net.WebException(UnityWebExceptionFilter.Message));
 
-        var createdEvent = _testHttpClientHandler.GetEvent(message, _eventReceiveTimeout);
-        Debug.Log("captured event was:");
-        Debug.Log(createdEvent);
+        var createdEvent = _testHttpClientHandler.GetEvent(UnityWebExceptionFilter.Message, _eventReceiveTimeout);
         Assert.AreEqual(string.Empty, createdEvent);
     }
 }

--- a/test/Sentry.Unity.Tests/UnityWebExceptionFilterTests.cs
+++ b/test/Sentry.Unity.Tests/UnityWebExceptionFilterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using Sentry.Unity.Integrations;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Sentry.Unity.Tests;
@@ -25,9 +26,12 @@ public class UnityWebExceptionFilterTests
 
         using var _ = SentryTests.InitSentrySdk(testHttpClientHandler: _testHttpClientHandler);
 
-        SentrySdk.CaptureException(new System.Net.WebException(UnityWebExceptionFilter.Message));
+        var message = UnityWebExceptionFilter.Message + Guid.NewGuid();
+        SentrySdk.CaptureException(new System.Net.WebException(message));
 
-        var createdEvent = _testHttpClientHandler.GetEvent(UnityWebExceptionFilter.Message, _eventReceiveTimeout);
+        var createdEvent = _testHttpClientHandler.GetEvent(message, _eventReceiveTimeout);
+        Debug.Log("captured event was:");
+        Debug.Log(createdEvent);
         Assert.AreEqual(string.Empty, createdEvent);
     }
 }

--- a/test/Sentry.Unity.Tests/UnityWebExceptionFilterTests.cs
+++ b/test/Sentry.Unity.Tests/UnityWebExceptionFilterTests.cs
@@ -18,17 +18,4 @@ public class UnityWebExceptionFilterTests
     [Test]
     public void Filter_FiltersBadGatewayExceptionsOfTypeException() =>
         Assert.IsTrue(new UnityWebExceptionFilter().Filter(new System.Net.WebException(UnityWebExceptionFilter.Message)));
-
-    [Test]
-    public void Init_WithDefaultOptions_DoesNotSendFilteredWebExceptions()
-    {
-        LogAssert.ignoreFailingMessages = true; // The TestHttpClientHandler will complain about timing out (and it should!)
-
-        using var _ = SentryTests.InitSentrySdk(testHttpClientHandler: _testHttpClientHandler);
-
-        SentrySdk.CaptureException(new System.Net.WebException(UnityWebExceptionFilter.Message));
-
-        var createdEvent = _testHttpClientHandler.GetEvent(UnityWebExceptionFilter.Message, _eventReceiveTimeout);
-        Assert.AreEqual(string.Empty, createdEvent);
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1804, https://github.com/getsentry/sentry-unity/issues/1779

Also reverts https://github.com/getsentry/sentry-unity/pull/1728

Tracing itself has nothing to do with file-write. Turns out that simply making the request requires some access to the file system 
https://github.com/getsentry/sentry-dotnet/blob/12c7d7ca046ab985b0267f43c5fd35f2caad108c/src/Sentry/Internal/Http/HttpTransport.cs#L42