### PR TITLE
fix: main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
+        # if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
@@ -452,7 +452,7 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
+        # if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Download UPM package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,26 @@ jobs:
           $platform = if ($isAndroid -and $isNotMainBranch) { 'Android-Export' } else { '${{ matrix.platform }}' }
 
           ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols
-        
+      
+      # Dear lord, I don't know why we have to do this: If we do not "pre-build" the project then `exportAsGoogleAndroidProject` will stay `false` in `IPostGenerateGradleAndroidProject`
+      # and breaking all further steps in CI 
+      # Things I tried:
+        # 1. Setting the flag and restarting the editor prior to build
+        # 2. Setting the flag and reloading the domain in a step prior to building
+        # 3. Reloading the domain prior to building (does not work - build fails with a domain reload pending)
+      - name: Pre-Build Project for Unity 6
+        if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
+        run: |
+          $platform = '${{ matrix.platform }}'
+          if ('${{ github.ref_name }}' -ne 'main')
+          {
+            $checkSymbols = $false
+            $platform = 'Android-Export'
+            
+            ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols:$checkSymbols -UnityVersion "${{ matrix.unity-version }}"
+            Remove-Item -Path samples/IntegrationTest/Build -Recurse -Force -Confirm:$false
+          }
+            
       - name: Build Project
         run: |
           $platform = '${{ matrix.platform }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,18 +344,18 @@ jobs:
         # 1. Setting the flag and restarting the editor prior to build
         # 2. Setting the flag and reloading the domain in a step prior to building
         # 3. Reloading the domain prior to building (does not work - build fails with a domain reload pending)
-      - name: Pre-Build Project for Unity 6
-        if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
-        run: |
-          $platform = '${{ matrix.platform }}'
-          if ('${{ github.ref_name }}' -ne 'main')
-          {
-            $checkSymbols = $false
-            $platform = 'Android-Export'
+      # - name: Pre-Build Project for Unity 6
+      #   if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
+      #   run: |
+      #     $platform = '${{ matrix.platform }}'
+      #     if ('${{ github.ref_name }}' -ne 'main')
+      #     {
+      #       $checkSymbols = $false
+      #       $platform = 'Android-Export'
             
-            ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols:$checkSymbols -UnityVersion "${{ matrix.unity-version }}"
-            Remove-Item -Path samples/IntegrationTest/Build -Recurse -Force -Confirm:$false
-          }
+      #       ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols:$checkSymbols -UnityVersion "${{ matrix.unity-version }}"
+      #       Remove-Item -Path samples/IntegrationTest/Build -Recurse -Force -Confirm:$false
+      #     }
             
       - name: Build Project
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        # if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Configure Sentry
@@ -337,26 +337,7 @@ jobs:
           $platform = if ($isAndroid -and $isNotMainBranch) { 'Android-Export' } else { '${{ matrix.platform }}' }
 
           ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols
-      
-      # Dear lord, I don't know why we have to do this: If we do not "pre-build" the project then `exportAsGoogleAndroidProject` will stay `false` in `IPostGenerateGradleAndroidProject`
-      # and breaking all further steps in CI 
-      # Things I tried:
-        # 1. Setting the flag and restarting the editor prior to build
-        # 2. Setting the flag and reloading the domain in a step prior to building
-        # 3. Reloading the domain prior to building (does not work - build fails with a domain reload pending)
-      # - name: Pre-Build Project for Unity 6
-      #   if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
-      #   run: |
-      #     $platform = '${{ matrix.platform }}'
-      #     if ('${{ github.ref_name }}' -ne 'main')
-      #     {
-      #       $checkSymbols = $false
-      #       $platform = 'Android-Export'
-            
-      #       ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols:$checkSymbols -UnityVersion "${{ matrix.unity-version }}"
-      #       Remove-Item -Path samples/IntegrationTest/Build -Recurse -Force -Confirm:$false
-      #     }
-            
+        
       - name: Build Project
         run: |
           $platform = '${{ matrix.platform }}'
@@ -463,7 +444,7 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        # if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,10 +327,10 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
+        # if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
-      - name: Build with Sentry SDK
+      - name: Configure Sentry
         run: |
           $isAndroid = ('${{ matrix.platform }}' -eq 'Android')
           $isNotMainBranch = ('${{ github.ref_name }}' -ne 'main')
@@ -450,11 +450,6 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Build without Sentry SDK
-        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
       - name: Download UPM package
         uses: actions/download-artifact@v4
         with:
@@ -465,6 +460,11 @@ jobs:
 
       - name: Add Sentry to the project
         run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
+      - name: Build without Sentry SDK
+        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
+        # if: ${{ github.ref_name == 'main' }}
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry
         run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        # if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
@@ -452,7 +452,7 @@ jobs:
 
       - name: Build without Sentry SDK
         # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        # if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Download UPM package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,11 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
+      - name: Build without Sentry SDK
+        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
+        if: ${{ github.ref_name == 'main' }}
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
+
       - name: Download UPM package
         uses: actions/download-artifact@v4
         with:
@@ -324,11 +329,6 @@ jobs:
 
       - name: Add Sentry to the project
         run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
-      - name: Build without Sentry SDK
-        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Configure Sentry
         run: |
@@ -450,6 +450,11 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
+      - name: Build without Sentry SDK
+        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
+        if: ${{ github.ref_name == 'main' }}
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
       - name: Download UPM package
         uses: actions/download-artifact@v4
         with:
@@ -460,11 +465,6 @@ jobs:
 
       - name: Add Sentry to the project
         run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
-      - name: Build without Sentry SDK
-        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry
         run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -59,10 +59,12 @@ public class Builder
         if (target == BuildTarget.Android)
         {
             // Android does not support appending builds. We make sure the directory is clean
-            if (Directory.Exists(args["buildPath"]))
+                        // Android does not support appending builds. We make sure the directory is clean
+            var outputDir = Path.GetDirectoryName(args["buildPath"]);
+            if (Directory.Exists(outputDir))
             {
                 Debug.Log("Builder: Cleaning the buildPath");
-                Directory.Delete(args["buildPath"], true);
+                Directory.Delete(outputDir, true);
             }
 
 #if !UNITY_6000_0_OR_NEWER

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -16,6 +16,8 @@ public class Builder
         var args = ParseCommandLineArguments();
         ValidateArguments(args);
 
+        Debug.Log($"Builder: Starting build. Output will be '{args["buildPath"]}'.");
+
         // Make sure the configuration is right.
         EditorUserBuildSettings.selectedBuildTargetGroup = group;
         EditorUserBuildSettings.allowDebugging = false;
@@ -59,20 +61,12 @@ public class Builder
         if (target == BuildTarget.Android)
         {
             // Android does not support appending builds. We make sure the directory is clean
-                        // Android does not support appending builds. We make sure the directory is clean
             var outputDir = Path.GetDirectoryName(args["buildPath"]);
             if (Directory.Exists(outputDir))
             {
                 Debug.Log("Builder: Cleaning the buildPath");
                 Directory.Delete(outputDir, true);
             }
-
-#if !UNITY_6000_0_OR_NEWER
-            // Unity 6 does not like the build folder already being present and will error with
-            // The destination path collides with existing folder. Please delete '/sentry-unity/samples/IntegrationTest/Build/' before retrying the operation.
-            Debug.Log("Builder: Creating buildpath directory");
-            Directory.CreateDirectory(args["buildPath"]);
-#endif
 
             Debug.Log("Builder: Enabling minify");
 #if UNITY_2020_1_OR_NEWER

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 public class Builder
 {
-    public static void BuildIl2CPPPlayer(BuildTarget target, BuildTargetGroup group, BuildPlayerOptions buildPlayerOptions)
+    public static void BuildIl2CPPPlayer(BuildTarget target, BuildTargetGroup group, BuildOptions buildOptions)
     {
         Debug.Log("Builder: Starting to build");
 
@@ -35,9 +35,13 @@ public class Builder
 #endif
 
         Debug.Log("Builder: Updating BuildPlayerOptions");
-        buildPlayerOptions.locationPathName = args["buildPath"];
-        buildPlayerOptions.target = target;
-        buildPlayerOptions.targetGroup = group;
+        var buildPlayerOptions = new BuildPlayerOptions
+        {
+            locationPathName = args["buildPath"],
+            target = target,
+            targetGroup = group,
+            options = buildOptions
+        };
 
         Debug.Log("Builder: Disabling optimizations to reduce build time");
 #if UNITY_2021_2_OR_NEWER
@@ -113,51 +117,39 @@ public class Builder
     public static void BuildWindowsIl2CPPPlayer()
     {
         Debug.Log("Builder: Building Windows IL2CPP Player");
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
-        BuildIl2CPPPlayer(BuildTarget.StandaloneWindows64, BuildTargetGroup.Standalone, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.StandaloneWindows64, BuildTargetGroup.Standalone, BuildOptions.StrictMode);
     }
     public static void BuildMacIl2CPPPlayer()
     {
         Debug.Log("Builder: Building macOS IL2CPP Player");
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
-        BuildIl2CPPPlayer(BuildTarget.StandaloneOSX, BuildTargetGroup.Standalone, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.StandaloneOSX, BuildTargetGroup.Standalone, BuildOptions.StrictMode);
     }
     public static void BuildLinuxIl2CPPPlayer()
     {
         Debug.Log("Builder: Building Linux IL2CPP Player");
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
-        BuildIl2CPPPlayer(BuildTarget.StandaloneLinux64, BuildTargetGroup.Standalone, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.StandaloneLinux64, BuildTargetGroup.Standalone, BuildOptions.StrictMode);
     }
     public static void BuildAndroidIl2CPPPlayer()
     {
         Debug.Log("Builder: Building Android IL2CPP Player");
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
-        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android, BuildOptions.StrictMode);
     }
     public static void BuildAndroidIl2CPPProject()
     {
         Debug.Log("Builder: Building Android IL2CPP Project");
-        Debug.Log("Builder: Setting export settings 'exportAsGoogleAndroidProject' to 'true'");
-
         EditorUserBuildSettings.exportAsGoogleAndroidProject = true;
-
-        Debug.Log("Builder: Overwriting BuildPlayerOptions to accept external modifications for 2022 and newer");
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.AcceptExternalModificationsToPlayer };
-
-        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android, BuildOptions.AcceptExternalModificationsToPlayer);
     }
     public static void BuildIOSProject()
     {
         Debug.Log("Builder: Building iOS Project");
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
-        BuildIl2CPPPlayer(BuildTarget.iOS, BuildTargetGroup.iOS, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.iOS, BuildTargetGroup.iOS, BuildOptions.StrictMode);
     }
     public static void BuildWebGLPlayer()
     {
         Debug.Log("Builder: Building WebGL Player");
         PlayerSettings.WebGL.compressionFormat = WebGLCompressionFormat.Brotli;
-        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
-        BuildIl2CPPPlayer(BuildTarget.WebGL, BuildTargetGroup.WebGL, buildPlayerOptions);
+        BuildIl2CPPPlayer(BuildTarget.WebGL, BuildTargetGroup.WebGL, BuildOptions.StrictMode);
     }
 
     public static Dictionary<string, string> ParseCommandLineArguments()

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -68,8 +68,10 @@ public class Builder
                 Directory.Delete(outputDir, true);
             }
 
+#if !UNITY_6000_0_OR_NEWER
             Debug.Log($"Builder: Creating output directory at '{outputDir}'");
             Directory.CreateDirectory(outputDir);
+#endif
 
             Debug.Log("Builder: Enabling minify");
 #if UNITY_2020_1_OR_NEWER

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -68,10 +68,8 @@ public class Builder
                 Directory.Delete(outputDir, true);
             }
 
-#if !UNITY_6000_0_OR_NEWER
             Debug.Log($"Builder: Creating output directory at '{outputDir}'");
             Directory.CreateDirectory(outputDir);
-#endif
 
             Debug.Log("Builder: Enabling minify");
 #if UNITY_2020_1_OR_NEWER
@@ -84,11 +82,6 @@ public class Builder
 #if UNITY_6000_0_OR_NEWER
             Debug.Log("Builder: Setting target architectures");
             PlayerSettings.Android.targetArchitectures = AndroidArchitecture.All;
-
-            Debug.Log("Builder: Overwriting BuildPlayerOptions to accept external modifications for 2022 and newer");
-            buildPlayerOptions.options = BuildOptions.AcceptExternalModificationsToPlayer;
-
-            Debug.Log($"Builder: Double-checking for export options: {EditorUserBuildSettings.exportAsGoogleAndroidProject}");
 #endif
         }
 
@@ -144,11 +137,13 @@ public class Builder
     public static void BuildAndroidIl2CPPProject()
     {
         Debug.Log("Builder: Building Android IL2CPP Project");
-
-        Debug.Log($"Builder: Checking it again: {EditorUserBuildSettings.exportAsGoogleAndroidProject}");
         Debug.Log("Builder: Setting export settings 'exportAsGoogleAndroidProject' to 'true'");
                 
         EditorUserBuildSettings.exportAsGoogleAndroidProject = true;
+
+        Debug.Log("Builder: Overwriting BuildPlayerOptions to accept external modifications for 2022 and newer");
+        buildPlayerOptions.options = BuildOptions.AcceptExternalModificationsToPlayer;
+
         BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android);
     }
     public static void BuildIOSProject()

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -68,6 +68,9 @@ public class Builder
                 Directory.Delete(outputDir, true);
             }
 
+            Debug.Log($"Builder: Creating output directory at '{outputDir}'");
+            Directory.CreateDirectory(outputDir);
+
             Debug.Log("Builder: Enabling minify");
 #if UNITY_2020_1_OR_NEWER
             PlayerSettings.Android.minifyDebug = PlayerSettings.Android.minifyRelease = true;

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 public class Builder
 {
-    public static void BuildIl2CPPPlayer(BuildTarget target, BuildTargetGroup group)
+    public static void BuildIl2CPPPlayer(BuildTarget target, BuildTargetGroup group, BuildPlayerOptions buildPlayerOptions)
     {
         Debug.Log("Builder: Starting to build");
 
@@ -34,14 +34,10 @@ public class Builder
         EditorUserBuildSettings.il2CppCodeGeneration = UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
 #endif
 
-        Debug.Log("Builder: Creating BuildPlayerOptions");
-        var buildPlayerOptions = new BuildPlayerOptions
-        {
-            locationPathName = args["buildPath"],
-            target = target,
-            targetGroup = group,
-            options = BuildOptions.StrictMode
-        };
+        Debug.Log("Builder: Updating BuildPlayerOptions");
+        buildPlayerOptions.locationPathName = args["buildPath"];
+        buildPlayerOptions.target = target;
+        buildPlayerOptions.targetGroup = group;
 
         Debug.Log("Builder: Disabling optimizations to reduce build time");
 #if UNITY_2021_2_OR_NEWER
@@ -117,45 +113,51 @@ public class Builder
     public static void BuildWindowsIl2CPPPlayer()
     {
         Debug.Log("Builder: Building Windows IL2CPP Player");
-        BuildIl2CPPPlayer(BuildTarget.StandaloneWindows64, BuildTargetGroup.Standalone);
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
+        BuildIl2CPPPlayer(BuildTarget.StandaloneWindows64, BuildTargetGroup.Standalone, buildPlayerOptions);
     }
     public static void BuildMacIl2CPPPlayer()
     {
         Debug.Log("Builder: Building macOS IL2CPP Player");
-        BuildIl2CPPPlayer(BuildTarget.StandaloneOSX, BuildTargetGroup.Standalone);
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
+        BuildIl2CPPPlayer(BuildTarget.StandaloneOSX, BuildTargetGroup.Standalone, buildPlayerOptions);
     }
     public static void BuildLinuxIl2CPPPlayer()
     {
         Debug.Log("Builder: Building Linux IL2CPP Player");
-        BuildIl2CPPPlayer(BuildTarget.StandaloneLinux64, BuildTargetGroup.Standalone);
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
+        BuildIl2CPPPlayer(BuildTarget.StandaloneLinux64, BuildTargetGroup.Standalone, buildPlayerOptions);
     }
     public static void BuildAndroidIl2CPPPlayer()
     {
         Debug.Log("Builder: Building Android IL2CPP Player");
-        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android);
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
+        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android, buildPlayerOptions);
     }
     public static void BuildAndroidIl2CPPProject()
     {
         Debug.Log("Builder: Building Android IL2CPP Project");
         Debug.Log("Builder: Setting export settings 'exportAsGoogleAndroidProject' to 'true'");
-                
+
         EditorUserBuildSettings.exportAsGoogleAndroidProject = true;
 
         Debug.Log("Builder: Overwriting BuildPlayerOptions to accept external modifications for 2022 and newer");
-        buildPlayerOptions.options = BuildOptions.AcceptExternalModificationsToPlayer;
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.AcceptExternalModificationsToPlayer };
 
-        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android);
+        BuildIl2CPPPlayer(BuildTarget.Android, BuildTargetGroup.Android, buildPlayerOptions);
     }
     public static void BuildIOSProject()
     {
         Debug.Log("Builder: Building iOS Project");
-        BuildIl2CPPPlayer(BuildTarget.iOS, BuildTargetGroup.iOS);
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
+        BuildIl2CPPPlayer(BuildTarget.iOS, BuildTargetGroup.iOS, buildPlayerOptions);
     }
     public static void BuildWebGLPlayer()
     {
         Debug.Log("Builder: Building WebGL Player");
         PlayerSettings.WebGL.compressionFormat = WebGLCompressionFormat.Brotli;
-        BuildIl2CPPPlayer(BuildTarget.WebGL, BuildTargetGroup.WebGL);
+        var buildPlayerOptions = new BuildPlayerOptions { options = BuildOptions.StrictMode };
+        BuildIl2CPPPlayer(BuildTarget.WebGL, BuildTargetGroup.WebGL, buildPlayerOptions);
     }
 
     public static Dictionary<string, string> ParseCommandLineArguments()


### PR DESCRIPTION
The issue is having to set `buildPlayerOptions.options = BuildOptions.AcceptExternalModificationsToPlayer;` only when exporting a Gradle project. Otherwise this breaks `main` in the `Build without SDK` step.

#skip-changelog