### PR TITLE
fix: main CI for Unity 6 targeting Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
       - name: Pre-Build Project for Unity 6 and Android
         if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
         run: |
-          $platform = '${{ matrix.platform }}'  
+          $platform = '${{ matrix.platform }}'
           if ('${{ github.ref_name }}' -ne 'main')
           {
             $checkSymbols = $false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,7 @@ jobs:
       - name: Pre-Build Project for Unity 6 and Android
         if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
         run: |
+          $platform = '${{ matrix.platform }}'  
           if ('${{ github.ref_name }}' -ne 'main')
           {
             $checkSymbols = $false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,8 +326,6 @@ jobs:
         run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Build without Sentry SDK
-        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Build with Sentry SDK
@@ -344,18 +342,21 @@ jobs:
         # 1. Setting the flag and restarting the editor prior to build
         # 2. Setting the flag and reloading the domain in a step prior to building
         # 3. Reloading the domain prior to building (does not work - build fails with a domain reload pending)
-      - name: Pre-Build Project for Unity 6
+      - name: Pre-Build Project for Unity 6 and Android
         if: ${{ matrix.unity-version == '6000' && matrix.platform == 'Android' }}
         run: |
-          $platform = '${{ matrix.platform }}'
           if ('${{ github.ref_name }}' -ne 'main')
           {
             $checkSymbols = $false
             $platform = 'Android-Export'
-            
-            ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols:$checkSymbols -UnityVersion "${{ matrix.unity-version }}"
-            Remove-Item -Path samples/IntegrationTest/Build -Recurse -Force -Confirm:$false
           }
+          else
+          {
+            $checkSymbols = $false
+          }
+          
+          ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform $platform -CheckSymbols:$checkSymbols -UnityVersion "${{ matrix.unity-version }}"
+          Remove-Item -Path samples/IntegrationTest/Build -Recurse -Force -Confirm:$false
             
       - name: Build Project
         run: |
@@ -451,8 +452,6 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Build without Sentry SDK
-        # This hasn't broken for many months, so disabling on PRs to speed up CI. And also to test a clean build with Sentry SDK included.
-        if: ${{ github.ref_name == 'main' }}
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Download UPM package

--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -229,12 +229,7 @@ internal class DebugSymbolUpload
     internal List<string> GetSymbolUploadPaths(IApplication? application = null)
     {
         var paths = new List<string>();
-        if (IsNewerThanUnity6(application))
-        {
-            _logger.LogInfo("Unity version 6.0 or newer detected. Root for symbols upload: 'Library'.");
-            paths.Add(Path.Combine(_unityProjectPath, RelativeBuildOutputPathNew));
-        }
-        else if (IsNewerThanUnity2021_2(application))
+        if (IsNewerThanUnity2021_2(application))
         {
             _logger.LogInfo("Unity version 2021.2 or newer detected. Root for symbols upload: 'Library'.");
             paths.Add(Path.Combine(_unityProjectPath, RelativeBuildOutputPathNew));
@@ -252,9 +247,6 @@ internal class DebugSymbolUpload
 
     // Starting with Unity 2021.2 the build-process caches the build output inside 'Library' instead of 'Temp'
     internal static bool IsNewerThanUnity2021_2(IApplication? application = null) => SentryUnityVersion.IsNewerOrEqualThan("2021.2", application);
-
-    // Starting Unity 6 the build process no longer caches symbols in 'Library/Bee/Android'
-    internal static bool IsNewerThanUnity6(IApplication? application = null) => SentryUnityVersion.IsNewerOrEqualThan("6000.0", application);
 
     // Gradle doesn't support backslashes on path (Windows) so converting to forward slashes
     internal static string ConvertSlashes(string path) => path.Replace(@"\", "/");


### PR DESCRIPTION
With the incremental builds, the added build-times for building an empty project are negligible. And it takes away a tiny bit of complexity.

#skip-changelog