### PR TITLE
fix: Missing contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- The SDK no longer fails to report contexts like `device` and `gpu` ([#1850](https://github.com/getsentry/sentry-unity/pull/1850))
+
 ## 2.2.1
 
 ### Dependencies

--- a/src/Sentry.Unity/MainThreadData.cs
+++ b/src/Sentry.Unity/MainThreadData.cs
@@ -72,9 +72,6 @@ internal static class MainThreadData
     public static bool IsMainThread()
         => MainThreadId.HasValue && Thread.CurrentThread.ManagedThreadId == MainThreadId;
 
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-    private static void CollectData() => CollectData(SentrySystemInfoAdapter.Instance);
-
     internal static void CollectData(ISentrySystemInfo sentrySystemInfo)
     {
         MainThreadId = sentrySystemInfo.MainThreadId;

--- a/src/Sentry.Unity/MainThreadData.cs
+++ b/src/Sentry.Unity/MainThreadData.cs
@@ -72,8 +72,13 @@ internal static class MainThreadData
     public static bool IsMainThread()
         => MainThreadId.HasValue && Thread.CurrentThread.ManagedThreadId == MainThreadId;
 
-    internal static void CollectData(ISentrySystemInfo sentrySystemInfo)
+    // For testing
+    internal static ISentrySystemInfo? SentrySystemInfo { get; set; }
+
+    public static void CollectData()
     {
+        var sentrySystemInfo = SentrySystemInfo ?? SentrySystemInfoAdapter.Instance;
+
         MainThreadId = sentrySystemInfo.MainThreadId;
         ProcessorCount = sentrySystemInfo.ProcessorCount;
         OperatingSystem = sentrySystemInfo.OperatingSystem;

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -28,6 +28,8 @@ internal class SentryUnitySdk
             return null;
         }
 
+        MainThreadData.CollectData(SentrySystemInfoAdapter.Instance);
+
         // On Standalone, we disable cache dir in case multiple app instances run over the same path.
         // Note: we cannot use a named Mutex, because Unit doesn't support it. Instead, we create a file with `FileShare.None`.
         // https://forum.unity.com/threads/unsupported-internal-call-for-il2cpp-mutex-createmutex_internal-named-mutexes-are-not-supported.387334/

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -28,7 +28,7 @@ internal class SentryUnitySdk
             return null;
         }
 
-        MainThreadData.CollectData(SentrySystemInfoAdapter.Instance);
+        MainThreadData.CollectData();
 
         // On Standalone, we disable cache dir in case multiple app instances run over the same path.
         // Note: we cannot use a named Mutex, because Unit doesn't support it. Instead, we create a file with `FileShare.None`.

--- a/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
@@ -91,14 +91,12 @@ public class SmokeTester : MonoBehaviour
         t.Start("SMOKE");
         try
         {
+#if !UNITY_EDITOR
             var crashed = CrashedLastRun();
             t.Expect($"options.CrashedLastRun ({crashed}) == false (0)", crashed == 0);
-
+#endif
             var currentMessage = 0;
             t.ExpectMessage(currentMessage, "'type':'session'");
-
-            var guid = Guid.NewGuid().ToString();
-            Debug.LogError($"LogError(GUID)={guid}");
 
             // Skip the session init requests (there may be multiple of them). We can't skip them by a "positive"
             // because they're also repeated with standard events (in an envelope).
@@ -114,17 +112,34 @@ public class SmokeTester : MonoBehaviour
 
             t.ExpectMessage(currentMessage, "'type':'transaction");
             t.ExpectMessage(currentMessage, "'op':'app.start'"); // startup transaction
+#if !UNITY_EDITOR
             t.ExpectMessage(currentMessage, "'op':'awake','description':'Main Camera.SmokeTester'"); // auto instrumentation
+#endif
             t.ExpectMessageNot(currentMessage, "'length':0");
+            
+            var guid = Guid.NewGuid().ToString();
+            Debug.LogError($"LogError(GUID)={guid}");
+            currentMessage++;
 
-            t.ExpectMessage(++currentMessage, "'type':'event'");
+            t.ExpectMessage(currentMessage, "'type':'event'");
             t.ExpectMessage(currentMessage, $"LogError(GUID)={guid}");
+            // Contexts
+            t.ExpectMessage(currentMessage, "'type':'app',");
+            t.ExpectMessage(currentMessage, "'type':'device',");
+            t.ExpectMessage(currentMessage, "'type':'gpu',");
+            t.ExpectMessage(currentMessage, "'type':'os',");
+            t.ExpectMessage(currentMessage, "'type':'runtime',");
+            t.ExpectMessage(currentMessage, "'type':'unity',");
+            // User
             t.ExpectMessage(currentMessage, "'user':{'id':'"); // non-null automatic ID
+            // Attachment
             t.ExpectMessage(currentMessage, "'filename':'screenshot.jpg','attachment_type':'event.attachment'");
             t.ExpectMessageNot(currentMessage, "'length':0");
 
             SentrySdk.CaptureMessage($"CaptureMessage(GUID)={guid}");
-            t.ExpectMessage(++currentMessage, "'type':'event'");
+            currentMessage++;
+
+            t.ExpectMessage(currentMessage, "'type':'event'");
             t.ExpectMessage(currentMessage, $"CaptureMessage(GUID)={guid}");
             t.ExpectMessage(currentMessage, "'filename':'screenshot.jpg','attachment_type':'event.attachment'");
             t.ExpectMessageNot(currentMessage, "'length':0");
@@ -252,10 +267,12 @@ public class SmokeTester : MonoBehaviour
             }
             else
             {
+#if !UNITY_EDITOR
                 ExitCode = code;
                 Application.Quit(code);
                 // Application.Quit doesn't actually terminate immediately so exit the context at least...
                 throw new Exception($"Quitting with exit code {code}");
+#endif
             }
         }
 

--- a/test/Scripts.Integration.Test/run-smoke-test.ps1
+++ b/test/Scripts.Integration.Test/run-smoke-test.ps1
@@ -11,7 +11,12 @@
     [Parameter()]
     [switch] $Crash
 )
-. $PSScriptRoot/globals.ps1
+
+if (-not $Global:NewProjectPathCache)
+{
+    . ./test/Scripts.Integration.Test/globals.ps1
+}
+
 . $PSScriptRoot/common.ps1
 
 Write-Host "Given parameters:"

--- a/test/Sentry.Unity.Tests/ContextWriterTests.cs
+++ b/test/Sentry.Unity.Tests/ContextWriterTests.cs
@@ -78,7 +78,7 @@ public sealed class ContextWriterTests
         };
 
         // act
-        MainThreadData.CollectData(sysInfo);
+        MainThreadData.SentrySystemInfo = sysInfo;
         SentryUnity.Init(options);
         Assert.IsTrue(context.SyncFinished.WaitOne(TimeSpan.FromSeconds(10)));
 

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -118,8 +118,9 @@ public sealed class UnityEventProcessorThreadingTests
             DiagnosticLogger = _testLogger
         };
 
-        // In an actual build, the collection is automatically triggered by `RuntimeInitializeLoadType.BeforeSceneLoad`
-        MainThreadData.CollectData(systemInfo);
+        // In an actual build, the collection is automatically triggered before the SDK initializes
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
 
         SentryUnity.Init(options);
 
@@ -232,7 +233,11 @@ public sealed class UnityEventProcessorTests
     public void DeviceUniqueIdentifierWithSendDefaultPii_IsNotNull()
     {
         // arrange
-        MainThreadData.CollectData(new TestSentrySystemInfo { DeviceUniqueIdentifier = new Lazy<string>(() => "83fdd6d4-50b1-4735-a4d1-d4f7de64aff0") });
+        MainThreadData.SentrySystemInfo = new TestSentrySystemInfo
+        {
+            DeviceUniqueIdentifier = new Lazy<string>(() => "83fdd6d4-50b1-4735-a4d1-d4f7de64aff0")
+        };
+        MainThreadData.CollectData();
 
         var sentryOptions = new SentryUnityOptions { SendDefaultPii = true };
         var sut = new UnityScopeUpdater(sentryOptions, _testApplication);
@@ -304,7 +309,8 @@ public sealed class UnityEventProcessorTests
             DeviceUniqueIdentifier = new(() => "f810306c-68db-4ebe-89ba-13c457449339"),
             InstallMode = ApplicationInstallMode.Store.ToString()
         };
-        MainThreadData.CollectData(systemInfo);
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
 
         var sentryOptions = new SentryUnityOptions { SendDefaultPii = true };
         var scopeUpdater = new UnityScopeUpdater(sentryOptions, _testApplication);
@@ -356,7 +362,8 @@ public sealed class UnityEventProcessorTests
     {
         // arrange
         var systemInfo = new TestSentrySystemInfo { OperatingSystem = "Windows" };
-        MainThreadData.CollectData(systemInfo);
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
 
         var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
@@ -382,7 +389,8 @@ public sealed class UnityEventProcessorTests
             DeviceModel = new Lazy<string>(() => "Samsung Galaxy S3"),
             SystemMemorySize = 16000
         };
-        MainThreadData.CollectData(systemInfo);
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
 
         var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
@@ -412,7 +420,8 @@ public sealed class UnityEventProcessorTests
             CopyTextureSupport = new Lazy<string>(() => "Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture"),
             RenderingThreadingMode = new Lazy<string>(() => "MultiThreaded")
         };
-        MainThreadData.CollectData(systemInfo);
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
 
         var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
@@ -451,7 +460,8 @@ public sealed class UnityEventProcessorTests
             SupportsComputeShaders = true,
             SupportsGeometryShaders = true
         };
-        MainThreadData.CollectData(systemInfo);
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
 
         var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
@@ -482,7 +492,8 @@ public sealed class UnityEventProcessorTests
         [ValueSource(nameof(ShaderLevels))] (int, string) shaderValue)
     {
         var (shaderLevel, shaderDescription) = shaderValue;
-        MainThreadData.CollectData(new TestSentrySystemInfo { GraphicsShaderLevel = shaderLevel });
+        MainThreadData.SentrySystemInfo = new TestSentrySystemInfo { GraphicsShaderLevel = shaderLevel };
+        MainThreadData.CollectData();
 
         var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
@@ -510,7 +521,7 @@ public sealed class UnityEventProcessorTests
     [Test]
     public void GpuProtocolGraphicsShaderLevelMinusOne_Ignored()
     {
-        var sentrySystemInfo = new TestSentrySystemInfo
+        var systemInfo = new TestSentrySystemInfo
         {
             GraphicsShaderLevel = -1
         };
@@ -519,7 +530,8 @@ public sealed class UnityEventProcessorTests
         var scope = new Scope(_sentryOptions);
 
         // act
-        MainThreadData.CollectData(sentrySystemInfo);
+        MainThreadData.SentrySystemInfo = systemInfo;
+        MainThreadData.CollectData();
         sut.ConfigureScope(scope);
 
         // assert


### PR DESCRIPTION
We moved the collection of `MainThreadData` out of the `MonoBehaviour`'s Awake call in https://github.com/getsentry/sentry-unity/pull/1802
I'm actually not 100% why that worked in the first place. The Awake happens past the SceneLoad so the contexts should not have been available at that time either.

### Why is it broken

- The SDK initializes during `RuntimeInitializeLoadType.SubsystemRegistration`
https://github.com/getsentry/sentry-unity/blob/03af53dcd6462bc2525e8abfcbef7f4ad8060c8e/package-dev/Runtime/SentryInitialization.cs#L54
- The SDK registers the integrations on the options
- The UnityScopeIntegration gets registered and populates the contexts
https://github.com/getsentry/sentry-unity/blob/e7a45a96ab82e20394c6ad8711e3e0011594798c/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs#L46-L58
- The `MainThreadData` has not been collected at this point because this happens during `BeforeSceneLoad`
https://github.com/getsentry/sentry-unity/blob/f1fe17a033b2a0861c937efd931dd19645908bda/src/Sentry.Unity/MainThreadData.cs#L75-L76
- The contexts are missing

### How to fix it

Instead of relying on the Unity `RuntimeInitialize` we can just collect the contexts right before initialization
https://github.com/getsentry/sentry-unity/blob/e7a45a96ab82e20394c6ad8711e3e0011594798c/src/Sentry.Unity/SentryUnitySDK.cs#L31
Everything is nice and explicit.
Updated our smoketest so contexts won't go missing anymore.