### PR TITLE
chore: Run iOS tests on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Upload test artifacts (playmode)
         uses: actions/upload-artifact@v4
         with:
-          name: Test results (playmode)
+          name: Test results (playmode) - ${{matrix.unity-version}}
           path: artifacts/test/playmode
 
       - name: Run Unity tests (editmode)
@@ -185,7 +185,7 @@ jobs:
       - name: Upload test artifacts (editmode)
         uses: actions/upload-artifact@v4
         with:
-          name: Test results (editmode)
+          name: Test results (playmode) - ${{matrix.unity-version}}
           path: artifacts/test/editmode
 
   package-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,6 @@ jobs:
           docker exec unity dotnet msbuild /t:UnityPlayModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Tests
 
       - name: Upload test artifacts (playmode)
-        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: Test results (playmode)
@@ -184,7 +183,6 @@ jobs:
         run: docker exec unity dotnet msbuild /t:UnityEditModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Editor.Tests
 
       - name: Upload test artifacts (editmode)
-        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: Test results (editmode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Upload test artifacts (editmode)
         uses: actions/upload-artifact@v4
         with:
-          name: Test results (playmode) - ${{matrix.unity-version}}
+          name: Test results (editmode) - ${{matrix.unity-version}}
           path: artifacts/test/editmode
 
   package-validation:

--- a/package-dev/Tests/Editor/Sentry.Unity.Editor.iOS.Tests.dll.meta
+++ b/package-dev/Tests/Editor/Sentry.Unity.Editor.iOS.Tests.dll.meta
@@ -20,6 +20,7 @@ PluginImporter:
         Exclude Editor: 0
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
+        Exclude WebGL: 1
         Exclude Win: 1
         Exclude Win64: 1
         Exclude iOS: 1
@@ -41,13 +42,13 @@ PluginImporter:
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
-        OS: OSX
+        OS: AnyOS
   - first:
       Standalone: Linux64
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1272
Outputting the testresults confirms that the iOS tests now run as well.

#skip-changelog