### PR TITLE
fix: Improve IL2CPP debug symbol guidance in Editor

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/AdvancedTab.cs
@@ -200,7 +200,20 @@ internal static class AdvancedTab
                 }
                 else if (cliOptions is not null && !cliOptions.IsValid(null, EditorUserBuildSettings.development))
                 {
-                    EditorGUILayout.HelpBox("The IL2CPP line number support relies on the Debug Symbol Upload to be properly set up.", MessageType.Error);
+                    EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+                    var errorIcon = EditorGUIUtility.IconContent("console.erroricon").image;
+                    var content = new GUIContent("The IL2CPP line number support relies on the Debug Symbol Upload to be enabled and configured." +
+                                                 "\nAdditionally, this requires an Auth Token, an Org-Slug and the Project Name." +
+                                                 "\nLearn more about how our IL2CPP support works in our docs.", errorIcon);
+                    EditorGUILayout.LabelField(content, EditorStyles.wordWrappedLabel);
+
+                    if (GUILayout.Button("Open Documentation", EditorStyles.linkLabel))
+                    {
+                        Application.OpenURL("https://docs.sentry.io/platforms/unity/configuration/il2cpp/");
+                    }
+
+                    EditorGUILayout.EndVertical();
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1840

The error-box now lists the requirements and links to the docs, explaining how our IL2CPP line number support works.
![Screenshot 2024-10-22 at 14 51 54](https://github.com/user-attachments/assets/8843f9c3-6b12-4b61-864e-916380ea5f20)
![Screenshot 2024-10-22 at 14 52 00](https://github.com/user-attachments/assets/565cf845-a7fb-4123-9fed-b2449f97a215)



#skip-changelog
