### PR TITLE
fix: Respect fileIO restrictions on unknown platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- The SDK no longer calls into `Application.persistentDataPath` on unknown platforms. This prevents crashes during startup on platforms with restricted disk access like the Nintendo Switch ([#1870](https://github.com/getsentry/sentry-unity/pull/1870))
+
 ## 2.2.2
 
 ### Fixes

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -206,13 +206,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
 
         options.SetupLogging();
 
-        // Bail early if we're building the player.
-        if (isBuilding)
-        {
-            return options;
-        }
-
-        if (RuntimeOptionsConfiguration != null)
+        if (RuntimeOptionsConfiguration != null && !isBuilding)
         {
             // This has to happen in between options object creation and updating the options based on programmatic changes
             RuntimeOptionsConfiguration.Configure(options);
@@ -223,7 +217,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
             options.AddIl2CppExceptionProcessor(unityInfo);
         }
 
-        HandlePlatformRestrictedOptions(options, application, unityInfo);
+        HandlePlatformRestrictedOptions(options, unityInfo, application);
         HandleExceptionFilter(options);
 
         if (!AnrDetectionEnabled)
@@ -234,7 +228,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
         return options;
     }
 
-    internal virtual void HandlePlatformRestrictedOptions(SentryUnityOptions options, IApplication application, ISentryUnityInfo? unityInfo)
+    internal void HandlePlatformRestrictedOptions(SentryUnityOptions options, ISentryUnityInfo? unityInfo, IApplication application)
     {
         if (unityInfo?.IsKnownPlatform() == false)
         {

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -178,6 +178,42 @@ public class ScriptableSentryUnityOptionsTests
         Assert.True(filters.OfType<UnityBadGatewayExceptionFilter>().Any());
     }
 
+    [Test]
+    public void HandlePlatformRestrictedOptions_UnknownPlatform_SetsRestrictedOptions()
+    {
+        _fixture.UnityInfo = new TestUnityInfo(false);
+
+        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+        scriptableOptions.EnableOfflineCaching = true;
+
+        var options = new SentryUnityOptions
+        {
+            DisableFileWrite = false,
+            CacheDirectoryPath = "some/path",
+            AutoSessionTracking = true
+        };
+
+        scriptableOptions.HandlePlatformRestrictedOptions(options, _fixture.UnityInfo, _fixture.Application);
+
+        Assert.IsTrue(options.DisableFileWrite);
+        Assert.IsNull(options.CacheDirectoryPath);
+        Assert.IsFalse(options.AutoSessionTracking);
+        Assert.IsTrue(options.BackgroundWorker is WebBackgroundWorker);
+    }
+
+    [Test]
+    public void HandlePlatformRestrictedOptions_KnownPlatform_SetsRestrictedOptions()
+    {
+        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
+        scriptableOptions.EnableOfflineCaching = true;
+
+        var options = new SentryUnityOptions();
+
+        scriptableOptions.HandlePlatformRestrictedOptions(options, _fixture.UnityInfo, _fixture.Application);
+
+        Assert.AreEqual(options.CacheDirectoryPath, _fixture.Application.PersistentDataPath);
+    }
+
     public static void AssertOptions(SentryUnityOptions expected, SentryUnityOptions actual)
     {
         Assert.AreEqual(expected.Enabled, actual.Enabled);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1861

Calling `application.PersistentDataPath` implicitly creates a directory. So the SDK **must not** call into this Unity API if we're not sure if it's safe (known) to do so.