### PR TITLE
fix: Write `SampleRate` as `float` to manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed an issue where the SDK would write the `SampleRate` as an `int` instead of a `float` to the Android Manifest, causing issues during the Android SDK's initialization ([#1872](https://github.com/getsentry/sentry-unity/pull/1872))
+
 ## 2.2.2
 
 ### Fixes

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
@@ -157,7 +158,8 @@ public class AndroidManifestConfiguration
 
         if (_options.SampleRate.HasValue)
         {
-            _logger.LogDebug("Setting SampleRate: {0}", _options.SampleRate);
+            // To keep the logs in line with what the SDK writes to the AndroidManifest we're formatting here too
+            _logger.LogDebug("Setting SampleRate: {0}", ((float)_options.SampleRate).ToString("F", CultureInfo.InvariantCulture));
             androidManifest.SetSampleRate(_options.SampleRate.Value);
         }
 
@@ -420,7 +422,8 @@ internal class AndroidManifest : AndroidXmlDocument
     internal void SetDsn(string dsn) => SetMetaData($"{SentryPrefix}.dsn", dsn);
 
     internal void SetSampleRate(float sampleRate) =>
-        SetMetaData($"{SentryPrefix}.sample-rate", sampleRate.ToString());
+        // Keeping the sample-rate as float: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
+        SetMetaData($"{SentryPrefix}.sample-rate", sampleRate.ToString("F", CultureInfo.InvariantCulture));
 
     internal void SetRelease(string release) => SetMetaData($"{SentryPrefix}.release", release);
 

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -223,17 +223,18 @@ public class AndroidManifestTests
     }
 
     [Test]
-    public void ModifyManifest_SampleRate_SetIfNotNull()
+    [TestCase(0.45f, "0.45")]
+    [TestCase(1, "1.00")]
+    public void ModifyManifest_SampleRate_SetIfNotNull(float sampleRate, string expectedSampleRate)
     {
-        const float expected = 0.6f;
-        _fixture.SentryUnityOptions!.SampleRate = expected;
+        _fixture.SentryUnityOptions!.SampleRate = sampleRate;
         var sut = _fixture.GetSut();
         var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
 
-        _fixture.UnityTestLogger.AssertLogContains(SentryLevel.Debug, $"Setting SampleRate: {expected}");
+        _fixture.UnityTestLogger.AssertLogContains(SentryLevel.Debug, $"Setting SampleRate: {expectedSampleRate}");
 
         Assert.True(manifest.Contains(
-                $"<meta-data android:name=\"io.sentry.sample-rate\" android:value=\"{expected}\" />"),
+                $"<meta-data android:name=\"io.sentry.sample-rate\" android:value=\"{expectedSampleRate}\" />"),
             $"Expected 'io.sentry.sample-rate' in Manifest:\n{manifest}");
     }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1871