### PR TITLE
fix: Add missing `WER handler` on Windows

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -38,17 +38,17 @@ jobs:
       - run: cp -r package-dev/Plugins/${{ inputs.target }} sdk-static || echo "never mind, no files checked in..."
         shell: bash
 
-      - name: Restore from cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
-          # Output changes only depending on the git sha of the submodules
-          # hash of package/package.json for cache busting on release builds (version bump)
-          path: |
-            package-dev/Plugins
-            modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
-          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
+      # - name: Restore from cache
+      #   uses: actions/cache@v3
+      #   id: cache
+      #   with:
+      #     # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
+      #     # Output changes only depending on the git sha of the submodules
+      #     # hash of package/package.json for cache busting on release builds (version bump)
+      #     path: |
+      #       package-dev/Plugins
+      #       modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
+      #     key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
 
       - name: Installing Linux Dependencies
         if: ${{ inputs.target == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -38,17 +38,17 @@ jobs:
       - run: cp -r package-dev/Plugins/${{ inputs.target }} sdk-static || echo "never mind, no files checked in..."
         shell: bash
 
-      # - name: Restore from cache
-      #   uses: actions/cache@v3
-      #   id: cache
-      #   with:
-      #     # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
-      #     # Output changes only depending on the git sha of the submodules
-      #     # hash of package/package.json for cache busting on release builds (version bump)
-      #     path: |
-      #       package-dev/Plugins
-      #       modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
-      #     key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
+      - name: Restore from cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
+          # Output changes only depending on the git sha of the submodules
+          # hash of package/package.json for cache busting on release builds (version bump)
+          path: |
+            package-dev/Plugins
+            modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
+          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
 
       - name: Installing Linux Dependencies
         if: ${{ inputs.target == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- The SDK now also supports capturing crashes via the WER handler on Windows ([#1873](https://github.com/getsentry/sentry-unity/pull/1873))
+
 ### Dependencies
 
 - Bump Java SDK from v7.15.0 to v7.16.0 ([#1862](https://github.com/getsentry/sentry-unity/pull/1862))

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -213,10 +213,9 @@ Expected to exist:
     <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake --build build --target sentry --config RelWithDebInfo --parallel"></Exec>
     <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake --build build --target crashpad_handler --config Release --parallel"></Exec>
 
-    <Exec WorkingDirectory="$(SentryNativeRoot)" Command="dir build" StandardOutputImportance="High" />
-
     <ItemGroup>
       <NativeSdkArtifacts Include="$(SentryNativeRoot)build/crashpad_build/handler/Release/crashpad_handler.exe" />
+      <NativeSdkArtifacts Include="$(SentryNativeRoot)build/crashpad_build/handler/RelWithDebInfo/crashpad_wer.dll" />
       <NativeSdkArtifacts Include="$(SentryNativeRoot)build/RelWithDebInfo/sentry.dll" />
       <NativeSdkArtifacts Include="$(SentryNativeRoot)build/RelWithDebInfo/sentry.pdb" />
     </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -213,6 +213,8 @@ Expected to exist:
     <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake --build build --target sentry --config RelWithDebInfo --parallel"></Exec>
     <Exec WorkingDirectory="$(SentryNativeRoot)" Command="cmake --build build --target crashpad_handler --config Release --parallel"></Exec>
 
+    <Exec WorkingDirectory="$(SentryNativeRoot)" Command="dir build" StandardOutputImportance="High" />
+
     <ItemGroup>
       <NativeSdkArtifacts Include="$(SentryNativeRoot)build/crashpad_build/handler/Release/crashpad_handler.exe" />
       <NativeSdkArtifacts Include="$(SentryNativeRoot)build/RelWithDebInfo/sentry.dll" />

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -81,7 +81,7 @@ public static class BuildPostProcess
         {
             case BuildTarget.StandaloneWindows64:
                 crashpadPath = Path.Combine("Windows", "Sentry", "crashpad_handler.exe");
-                werHandlerPath = Path.Combine("Windows", "Sentry", "wer_handler.dll");
+                werHandlerPath = Path.Combine("Windows", "Sentry", "crashpad_wer.dll");
                 break;
             case BuildTarget.StandaloneLinux64:
             case BuildTarget.StandaloneOSX:

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -74,14 +74,11 @@ public static class BuildPostProcess
 
     private static void AddCrashHandler(IDiagnosticLogger logger, BuildTarget target, string buildOutputDir, string executableName)
     {
-        string crashpadPath;
-        string werHandlerPath;
-
         switch (target)
         {
             case BuildTarget.StandaloneWindows64:
-                crashpadPath = Path.Combine("Windows", "Sentry", "crashpad_handler.exe");
-                werHandlerPath = Path.Combine("Windows", "Sentry", "crashpad_wer.dll");
+                CopyHandler(logger, buildOutputDir, Path.Combine("Windows", "Sentry", "crashpad_handler.exe"));
+                CopyHandler(logger, buildOutputDir, Path.Combine("Windows", "Sentry", "crashpad_wer.dll"));
                 break;
             case BuildTarget.StandaloneLinux64:
             case BuildTarget.StandaloneOSX:
@@ -90,9 +87,6 @@ public static class BuildPostProcess
             default:
                 throw new ArgumentException($"Unsupported build target: {target}");
         }
-
-        CopyHandler(logger, buildOutputDir, crashpadPath);
-        CopyHandler(logger, buildOutputDir, werHandlerPath);
     }
 
     private static void CopyHandler(IDiagnosticLogger logger, string buildOutputDir, string handlerPath)

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -1291,6 +1291,8 @@ Plugins/Android/Sentry~/sentry.jar
 Plugins/Windows/Sentry.meta
 Plugins/Windows/Sentry/crashpad_handler.exe
 Plugins/Windows/Sentry/crashpad_handler.exe.meta
+Plugins/Windows/Sentry/crashpad_wer.dll
+Plugins/Windows/Sentry/crashpad_wer.dll.meta
 Plugins/Windows/Sentry/sentry.dll
 Plugins/Windows/Sentry/sentry.dll.meta
 Plugins/Windows/Sentry/sentry.pdb


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1866

We're currently very explicit with what we copy over from the `sentry-native` build
https://github.com/getsentry/sentry-unity/blob/4df953801eaf87d6de850c9756942dbf51637c4f/Directory.Build.targets#L212-L220
We need to include the `wer handler` as well.