### PR TITLE
fix: Cocoa version regex

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -146,7 +146,7 @@ Expected to exist:
 
     <PropertyGroup>
         <PropertiesContent>$([System.IO.File]::ReadAllText("$(RepoRoot)modules/sentry-cocoa.properties"))</PropertiesContent>
-        <CocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(PropertiesContent), 'version\s*=\s*(\d+\.\d+\.\d+)').Groups[1].Value)</CocoaVersion>
+        <CocoaVersion>$([System.Text.RegularExpressions.Regex]::Match($(PropertiesContent), 'version\s*=\s*([^\s]+)').Groups[1].Value)</CocoaVersion>
     </PropertyGroup>
 
     <Message Importance="High" Text="Setting up the Cocoa SDK version '$(CocoaVersion)'." />


### PR DESCRIPTION
Updated (copied from .NET SDK) the regex used to parse the current Cocoa SDK version.
See https://github.com/getsentry/sentry-dotnet/pull/3727#discussion_r1830302013 for more context.

#skip-changelog