### PR TITLE
fix: Only close the native SDKs if native support has been enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- The SDK no longer closes the underlying native SDK during the games shutdown if native support has not been enabled. This enables the SDK to support and capture errors in case of building the game as a library. ([#1897](https://github.com/getsentry/sentry-unity/pull/1897))
+
 ### Dependencies
 
 - Bump .NET SDK from v4.12.1 to v4.13.0 ([#1879](https://github.com/getsentry/sentry-unity/pull/1879), [#1885](https://github.com/getsentry/sentry-unity/pull/1885))

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -112,9 +112,9 @@ namespace Sentry.Unity
             {
                 // Closing down the native layer that are set up during build and self-initialize
 #if SENTRY_NATIVE_COCOA
-                SentryNativeCocoa.Close(options.DiagnosticLogger);
+                SentryNativeCocoa.Close(options, sentryUnityInfo);
 #elif SENTRY_NATIVE_ANDROID
-                SentryNativeAndroid.Close(options.DiagnosticLogger);
+                SentryNativeAndroid.Close(options, sentryUnityInfo);
 #endif
             }
         }

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -1,5 +1,7 @@
 using System;
 using Sentry.Extensibility;
+using Sentry.Unity.Integrations;
+using UnityEngine;
 using UnityEngine.Analytics;
 
 namespace Sentry.Unity.Android;
@@ -74,7 +76,7 @@ public static class SentryNativeAndroid
                 e, "Failed to reinstall backend. Captured native crashes will miss scope data and tag.");
         }
 
-        options.NativeSupportCloseCallback = () => Close(options.DiagnosticLogger);
+        options.NativeSupportCloseCallback = () => Close(options, sentryUnityInfo);
 
         options.DefaultUserId = SentryJava.GetInstallationId(JniExecutor);
         if (string.IsNullOrEmpty(options.DefaultUserId))
@@ -101,15 +103,18 @@ public static class SentryNativeAndroid
     /// <summary>
     /// Closes the native Android support.
     /// </summary>
-    public static void Close(IDiagnosticLogger? logger = null)
+    public static void Close(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo) =>
+        Close(options, sentryUnityInfo, ApplicationAdapter.Instance.Platform);
+
+    internal static void Close(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo, RuntimePlatform platform)
     {
-        if (!SentryJava.IsSentryJavaPresent())
+        if (!sentryUnityInfo.IsNativeSupportEnabled(options, platform) || !SentryJava.IsSentryJavaPresent())
         {
             return;
         }
 
         // Sentry Native is initialized and closed by the Java SDK, no need to call into it directly
-        logger?.LogDebug("Closing the sentry-java SDK");
+        options.DiagnosticLogger?.LogDebug("Closing the sentry-java SDK");
 
         // This is an edge-case where the Android SDK has been enabled and setup during build-time but is being
         // shut down at runtime. In this case Configure() has not been called and there is no JniExecutor yet

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -110,6 +110,7 @@ public static class SentryNativeAndroid
     {
         if (!sentryUnityInfo.IsNativeSupportEnabled(options, platform) || !SentryJava.IsSentryJavaPresent())
         {
+            options.DiagnosticLogger?.LogDebug("Native Support is not enable. Skipping closing the native SDK");
             return;
         }
 

--- a/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
+++ b/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
@@ -88,6 +88,7 @@ public static class SentryNativeCocoa
     {
         if (!sentryUnityInfo.IsNativeSupportEnabled(options, platform))
         {
+            options.DiagnosticLogger?.LogDebug("Native Support is not enable. Skipping closing the native SDK");
             return;
         }
 

--- a/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
+++ b/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
@@ -53,7 +53,7 @@ public static class SentryNativeCocoa
             return crashedLastRun;
         };
 
-        options.NativeSupportCloseCallback += () => Close(options.DiagnosticLogger);
+        options.NativeSupportCloseCallback += () => Close(options, sentryUnityInfo, platform);
         if (sentryUnityInfo.IL2CPP)
         {
             options.DefaultUserId = SentryCocoaBridgeProxy.GetInstallationId();
@@ -81,9 +81,17 @@ public static class SentryNativeCocoa
     /// <summary>
     /// Closes the native Cocoa support.
     /// </summary>
-    public static void Close(IDiagnosticLogger? logger = null)
+    public static void Close(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo) =>
+        Close(options, sentryUnityInfo, ApplicationAdapter.Instance.Platform);
+
+    internal static void Close(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo, RuntimePlatform platform)
     {
-        logger?.LogDebug("Closing the sentry-cocoa SDK");
+        if (!sentryUnityInfo.IsNativeSupportEnabled(options, platform))
+        {
+            return;
+        }
+
+        options.DiagnosticLogger?.LogDebug("Closing the sentry-cocoa SDK");
         SentryCocoaBridgeProxy.Close();
     }
 }


### PR DESCRIPTION
Relates to: https://github.com/getsentry/sentry-unity/issues/1727

When having the game run as a library, closing the game closes the SDK. This causes the surrounding app's native SDK to close as well.
Because the SDK can't determine the setup it is used in, it should only close the native SDKs if it is sure it was the one enabling it.