### PR TITLE
fix: Suppress and log known exceptions during native initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Suppress EntryPointNotFoundException if sentry-native is not available at runtime. It'll continue to capture C# errors at least, but no native crashes. ([#1895](https://github.com/getsentry/sentry-unity/pull/1895))
+- Suppress EntryPointNotFoundException if sentry-native is not available at runtime. It'll continue to capture C# errors at least, but no native crashes. ([#1898](https://github.com/getsentry/sentry-unity/pull/1898))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Suppress EntryPointNotFoundException if sentry-native is not available at runtime. It'll continue to capture C# errors at least, but no native crashes. ([#1895](https://github.com/getsentry/sentry-unity/pull/1895))
+
 ### Dependencies
 
 - Bump .NET SDK from v4.12.1 to v4.13.0 ([#1879](https://github.com/getsentry/sentry-unity/pull/1879), [#1885](https://github.com/getsentry/sentry-unity/pull/1885))

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -60,7 +60,6 @@ namespace Sentry.Unity
             if (options != null && options.ShouldInitializeSdk())
             {
                 SentryIntegrations.Configure(options);
-                Exception nativeInitException = null;
 
                 try
                 {
@@ -76,20 +75,16 @@ namespace Sentry.Unity
                 }
                 catch (DllNotFoundException e)
                 {
-                    nativeInitException = new Exception(
+                    options.DiagnosticLogger?.LogError(
                         "Sentry native-error capture configuration failed to load a native library. This usually " +
                         "means the library is missing from the application bundle or the installation directory.", e);
                 }
                 catch (Exception e)
                 {
-                    nativeInitException = new Exception("Sentry native error capture configuration failed.", e);
+                    options.DiagnosticLogger?.LogError("Sentry native error capture configuration failed.", e);
                 }
 
                 SentryUnity.Init(options);
-                if (nativeInitException != null)
-                {
-                    SentrySdk.CaptureException(nativeInitException);
-                }
 
 #if !SENTRY_WEBGL
                 if (options.TracesSampleRate > 0.0f && options.AutoStartupTraces)

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -118,25 +118,6 @@ namespace Sentry.Unity
 #endif
             }
         }
-
-#if SENTRY_NATIVE
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        public static void ReinstallBackend()
-        {
-            try
-            {
-                // At this point Unity has taken the signal handler and will not invoke our handler. So we register our
-                // backend once more to make sure user-defined data is available in the crash report and the SDK is able
-                // to capture the crash.
-                SentryNative.ReinstallBackend();
-            }
-            catch (EntryPointNotFoundException e)
-            {
-                // See: https://github.com/getsentry/sentry-unity/issues/1864
-                // TODO: if option.Debug: true, debug log this
-            }
-        }
-#endif
     }
 
     public class SentryUnityInfo : ISentryUnityInfo

--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -123,10 +123,18 @@ namespace Sentry.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void ReinstallBackend()
         {
-            // At this point Unity has taken the signal handler and will not invoke our handler. So we register our
-            // backend once more to make sure user-defined data is available in the crash report and the SDK is able
-            // to capture the crash.
-            SentryNative.ReinstallBackend();
+            try
+            {
+                // At this point Unity has taken the signal handler and will not invoke our handler. So we register our
+                // backend once more to make sure user-defined data is available in the crash report and the SDK is able
+                // to capture the crash.
+                SentryNative.ReinstallBackend();
+            }
+            catch (EntryPointNotFoundException e)
+            {
+                // See: https://github.com/getsentry/sentry-unity/issues/1864
+                // TODO: if option.Debug: true, debug log this
+            }
         }
 #endif
     }

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -111,7 +111,7 @@ public static class SentryNative
         }
         catch (EntryPointNotFoundException e)
         {
-            Logger?.LogError(e, "The SDK failed to reinstall the backend - native crashes are not captured.");
+            Logger?.LogError(e, "Native dependency not found. Did you delete sentry.dll or move files around?");
         }
     }
 }

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -98,7 +98,7 @@ public static class SentryNative
         // The backend should only be reinstalled if the native SDK has been initialized successfully.
         if (!ShouldReinstallBackend)
         {
-            Logger?.LogDebug("Skipping reinstalling the native backend as the initialization seems to have failed.");
+            Logger?.LogWarning("Skipping reinstalling the native backend.");
             return;
         }
 

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -100,6 +100,8 @@ public static class SentryNative
         {
             Logger?.LogWarning("Skipping reinstalling the native backend.");
             return;
+        } else {
+            Logger?.LogDebug("Reinstalling the native backend to make sure we capture native crashes.");
         }
 
         try

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -100,7 +100,7 @@ public static class SentryNative
             // to capture the crash.
             ReinstallBackendFunction?.Invoke();
         }
-        catch (EntryPointNotFoundException e)
+        catch (Exception e)
         {
             SentrySdk.CaptureException(new Exception("The SDK failed to reinstall the backend and won't capture native errors.", e));
         }

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -100,7 +100,9 @@ public static class SentryNative
         {
             Logger?.LogWarning("Skipping reinstalling the native backend.");
             return;
-        } else {
+        }
+        else
+        {
             Logger?.LogDebug("Reinstalling the native backend to make sure we capture native crashes.");
         }
 

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -15,7 +15,7 @@ public static class SentryNative
     private static readonly Dictionary<string, bool> PerDirectoryCrashInfo = new();
 
     private static bool ShouldReinstallBackend;
-    private static IDiagnosticLogger? _logger;
+    private static IDiagnosticLogger? Logger;
 
     /// <summary>
     /// Configures the native SDK.
@@ -24,13 +24,13 @@ public static class SentryNative
     /// <param name="sentryUnityInfo">Infos about the current Unity environment</param>
     public static void Configure(SentryUnityOptions options, ISentryUnityInfo sentryUnityInfo)
     {
-        _logger = options.DiagnosticLogger;
+        Logger = options.DiagnosticLogger;
 
-        _logger?.LogInfo("Attempting to configure native support via the Native SDK");
+        Logger?.LogInfo("Attempting to configure native support via the Native SDK");
 
         if (!sentryUnityInfo.IsNativeSupportEnabled(options, ApplicationAdapter.Instance.Platform))
         {
-            _logger?.LogDebug("Native support is disabled for '{0}'.", ApplicationAdapter.Instance.Platform);
+            Logger?.LogDebug("Native support is disabled for '{0}'.", ApplicationAdapter.Instance.Platform);
             return;
         }
 
@@ -38,21 +38,21 @@ public static class SentryNative
         {
             if (!SentryNativeBridge.Init(options, sentryUnityInfo))
             {
-                _logger?
+                Logger?
                     .LogWarning("Sentry native initialization failed - native crashes are not captured.");
                 return;
             }
         }
         catch (Exception e)
         {
-            _logger?
+            Logger?
                 .LogError(e, "Sentry native initialization failed - native crashes are not captured.");
             return;
         }
 
         ApplicationAdapter.Instance.Quitting += () =>
         {
-            _logger?.LogDebug("Closing the sentry-native SDK");
+            Logger?.LogDebug("Closing the sentry-native SDK");
             SentryNativeBridge.Close();
         };
         options.ScopeObserver = new NativeScopeObserver(options);
@@ -81,7 +81,7 @@ public static class SentryNative
                 crashedLastRun = SentryNativeBridge.HandleCrashedLastRun(options);
                 PerDirectoryCrashInfo.Add(cacheDirectory, crashedLastRun);
 
-                _logger?
+                Logger?
                     .LogDebug("Native SDK reported: 'crashedLastRun': '{0}'", crashedLastRun);
             }
         }
@@ -98,7 +98,7 @@ public static class SentryNative
         // The backend should only be reinstalled if the native SDK has been initialized successfully.
         if (!ShouldReinstallBackend)
         {
-            _logger?.LogDebug("Skipping reinstalling the native backend as the initialization seems to have failed.");
+            Logger?.LogDebug("Skipping reinstalling the native backend as the initialization seems to have failed.");
             return;
         }
 
@@ -111,7 +111,7 @@ public static class SentryNative
         }
         catch (EntryPointNotFoundException e)
         {
-            _logger?.LogError(e, "The SDK failed to reinstall the backend - native crashes are not captured.");
+            Logger?.LogError(e, "The SDK failed to reinstall the backend - native crashes are not captured.");
         }
     }
 }


### PR DESCRIPTION
The SDK will no longer attempt to reinstall the backend without native support enabled and without successful initialization.
It'll also capture `EntryPointNotFoundException` during reinstallation.