### PR TITLE
fix: Logger argument order

### DIFF
--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -44,7 +44,7 @@ public static class SentryNative
         }
         catch (Exception e)
         {
-            Logger?.LogError("Sentry native initialization failed - native crashes are not captured.", e);
+            Logger?.LogError(e, "Sentry native initialization failed - native crashes are not captured.");
             return;
         }
 
@@ -111,7 +111,7 @@ public static class SentryNative
         }
         catch (EntryPointNotFoundException e)
         {
-            Logger?.LogError("Native dependency not found. Did you delete sentry.dll or move files around?", e);
+            Logger?.LogError(e, "Native dependency not found. Did you delete sentry.dll or move files around?");
         }
     }
 }


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry-unity/pull/1900

I had https://github.com/getsentry/sentry-dotnet/pull/2715 and https://github.com/getsentry/sentry-dotnet/pull/3630 wrong in my head and assumed the order was the issue.

#skip-changelog