### PR TITLE
fix: Log error with exception argument order

### DIFF
--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -75,13 +75,13 @@ namespace Sentry.Unity
                 }
                 catch (DllNotFoundException e)
                 {
-                    options.DiagnosticLogger?.LogError(
+                    options.DiagnosticLogger?.LogError(e,
                         "Sentry native-error capture configuration failed to load a native library. This usually " +
-                        "means the library is missing from the application bundle or the installation directory.", e);
+                        "means the library is missing from the application bundle or the installation directory.");
                 }
                 catch (Exception e)
                 {
-                    options.DiagnosticLogger?.LogError("Sentry native error capture configuration failed.", e);
+                    options.DiagnosticLogger?.LogError(e, "Sentry native error capture configuration failed.");
                 }
 
                 SentryUnity.Init(options);


### PR DESCRIPTION
Fixing the order of arguments when logging errors that provide exceptions introduced in
- https://github.com/getsentry/sentry-unity/pull/1898
- https://github.com/getsentry/sentry-unity/pull/1900

The [signature](https://github.com/getsentry/sentry-dotnet/blob/cbe1af4c722b22eb6ee0cbe5c70b25a8d7056d41/src/Sentry/Extensibility/DiagnosticLoggerExtensions.cs#L267C1-L270C24) is 
```
    public static void LogError(
        this IDiagnosticLogger logger,
        Exception exception,
        string message)
```
#skip-changelog