### PR TITLE
chore: Updated sample

### DIFF
--- a/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
+++ b/samples/unity-of-bugs/Assets/Resources/Sentry/SentryOptions.asset
@@ -52,11 +52,16 @@ MonoBehaviour:
   <MaxQueueItems>k__BackingField: 30
   <AnrDetectionEnabled>k__BackingField: 1
   <AnrTimeout>k__BackingField: 5000
+  <CaptureFailedRequests>k__BackingField: 1
+  <FailedRequestStatusCodes>k__BackingField: f401000057020000
   <FilterBadGatewayExceptions>k__BackingField: 1
   <FilterWebExceptions>k__BackingField: 1
   <FilterSocketExceptions>k__BackingField: 1
   <IosNativeSupportEnabled>k__BackingField: 1
   <AndroidNativeSupportEnabled>k__BackingField: 1
+  <NdkIntegrationEnabled>k__BackingField: 1
+  <NdkScopeSyncEnabled>k__BackingField: 1
+  <PostGenerateGradleProjectCallbackOrder>k__BackingField: 1
   <WindowsNativeSupportEnabled>k__BackingField: 1
   <MacosNativeSupportEnabled>k__BackingField: 1
   <LinuxNativeSupportEnabled>k__BackingField: 1

--- a/scripts/create-sentry-cli-options.ps1
+++ b/scripts/create-sentry-cli-options.ps1
@@ -38,6 +38,9 @@ MonoBehaviour:
   <Auth>k__BackingField: $Env:SENTRY_AUTH_TOKEN
   <Organization>k__BackingField: sentry-sdks
   <Project>k__BackingField: sentry-unity
+  <IgnoreCliErrors>k__BackingField: 0
+  <CliOptionsConfiguration>k__BackingField: {fileID: 11400000, guid: 8c8107e4a8950413eb741aa6d47c3b73,
+    type: 2}
 "@
 
 $assetPath = "$PSScriptRoot/../samples/unity-of-bugs/Assets/Plugins/Sentry/"

--- a/src/Sentry.Unity.Editor/SentryCliOptionsEditor.cs
+++ b/src/Sentry.Unity.Editor/SentryCliOptionsEditor.cs
@@ -20,6 +20,10 @@ public class SentryCliOptionsEditor : UnityEditor.Editor
         EditorGUILayout.TextField("Org-Slug", cliOptions.Organization);
         EditorGUILayout.TextField("Project Name", cliOptions.Project);
 
+        EditorGUILayout.LabelField("Options Configuration", EditorStyles.boldLabel);
+        EditorGUILayout.ObjectField("Runtime Configuration", cliOptions.CliOptionsConfiguration,
+            typeof(SentryCliOptionsConfiguration), false);
+
         EditorGUI.EndDisabledGroup();
     }
 }


### PR DESCRIPTION
We've introduces programmatic configuration of the sentry CLI via dedicated scriptable object in https://github.com/getsentry/sentry-unity/pull/1887
I've updated the sample and the cli config that gets generated during repo restoration to properly connect those. We have to do it like that because the CLI options are explicitly not under version control. (i.e. auth token being sensitive)

#skip-changelog