### PR TITLE
fix: null ref in view hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is part of a larger effort to simplify the configuration of the native SDKs
 
 ### Fixes
 
+- Fix potential NullReferenceException when trying to attach a view hierarchy to an event  ([#1919](https://github.com/getsentry/sentry-unity/pull/1919))
 - The SDK no longer sends events when it fails to initialize the native SDK on Windows and Linux and logs those instead. It also suppresses `EntryPointNotFoundException` if sentry-native is not available at runtime. Native crashes won't get capture but it'll continue to capture C# errors. ([#1898](https://github.com/getsentry/sentry-unity/pull/1898))
 - The SDK no longer closes the underlying native SDK during the games shutdown if native support has not been enabled. This allows the SDK to support and capture errors in case of building the game as a library on a mobile (Android or iOS) game. ([#1897](https://github.com/getsentry/sentry-unity/pull/1897))
 

--- a/src/Sentry.Unity/UnityViewHierarchyAttachmentContent.cs
+++ b/src/Sentry.Unity/UnityViewHierarchyAttachmentContent.cs
@@ -72,6 +72,14 @@ internal class UnityViewHierarchyAttachmentContent : IAttachmentContent
     {
         var components = new List<Component>();
         transform.GetComponents(components);
+        var extras = new List<string>(components.Count);
+        foreach (var component in components)
+        {
+            if (component?.GetType().Name is { } componentName)
+            {
+                extras.Add(componentName);
+            }
+        }
         var node = new UnityViewHierarchyNode(transform.name)
         {
             Tag = transform.tag,
@@ -79,7 +87,7 @@ internal class UnityViewHierarchyAttachmentContent : IAttachmentContent
             Rotation = transform.rotation.eulerAngles.ToString(),
             Scale = transform.localScale.ToString(),
             Active = transform.gameObject.activeSelf,
-            Extras = components.Select(e => e.GetType().ToString()).ToList()
+            Extras = extras,
         };
 
         parentNode.Children.Add(node);


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-unity/issues/1918

Skips possible `null` components before trying to get their type info.

Not sure how to test this because it depends on a Unity API `GetComponents`

Also: replaced the LINQ call with a foreach and allocated a new List with the known size to avoid resizes. 