### PR TITLE
chore: Pick newest installed Unity for local repackaging

### DIFF
--- a/scripts/repack.ps1
+++ b/scripts/repack.ps1
@@ -1,12 +1,14 @@
 assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
 assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"
 
-$unity_version = Get-Content ./samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt | grep m_EditorVersion -m 1 | cut -d ' ' -f 2
-
-if ($IsWindows){
+if ($IsWindows) {
+    $unity_versions = Get-ChildItem "C:\Program Files\Unity\Hub\Editor\" -Directory | Select-Object -ExpandProperty Name
+    $unity_version = $unity_versions | Sort-Object -Descending | Select-Object -First 1
     $unity_path = "C:\Program Files\Unity\Hub\Editor\${unity_version}\Editor\Unity.exe"
 }
 else {
+    $unity_versions = Get-ChildItem "/Applications/Unity/Hub/Editor/" -Directory | Select-Object -ExpandProperty Name 
+    $unity_version = $unity_versions | Sort-Object -Descending | Select-Object -First 1
     $unity_path = "/Applications/Unity/Hub/Editor/$unity_version/Unity.app/Contents/MacOS/Unity"
 }
 


### PR DESCRIPTION
This is for local development only.
Pick the newest installed, it's just so much faster.

#skip-changelog