### PR TITLE
fix: improve jni stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 - The native layer on mobile platforms (iOS and Android) no longer self-initializes before the Unity game starts. Previously, the SDK would use the options at build-time and bake them into the native layer. Instead, the SDK will now take the options passed into the `Configure` callback and use those to initialize the native SDKs. This allows users to modify the native SDK's options at runtime programmatically.
 The initialization behaviour is controlled by `IosNativeInitializationType` and `AndroidNativeInitializationType` options. These can be set from `Runtime` (default) to `BuildTime` to restore the previous flow and bake the options into the native projects. ([#1915](https://github.com/getsentry/sentry-unity/pull/1915), [#1924](https://github.com/getsentry/sentry-unity/pull/1924))
- 
+
+### Fixes
+
+- On Android, the SDK not longer freezes the game when failing to sync with the native SDK ([#1927](https://github.com/getsentry/sentry-unity/pull/1927))
+
 ### Dependencies
 
 - Bump CLI from v2.39.0 to v2.39.1 ([#1922](https://github.com/getsentry/sentry-unity/pull/1922))

--- a/src/Sentry.Unity.Android/JniExecutor.cs
+++ b/src/Sentry.Unity.Android/JniExecutor.cs
@@ -8,7 +8,8 @@ namespace Sentry.Unity.Android;
 
 internal class JniExecutor : IJniExecutor
 {
-    private const int TimeoutMs = 16;
+    // We're capping out at 16ms - 1 frame at 60 frames per second
+    private static readonly TimeSpan Timeout = TimeSpan.FromMilliseconds(16);
 
     private readonly CancellationTokenSource _shutdownSource;
     private readonly AutoResetEvent _taskEvent;
@@ -98,9 +99,9 @@ internal class JniExecutor : IJniExecutor
 
             try
             {
-                if (!_taskCompletionSource.Task.Wait(TimeoutMs))
+                if (!_taskCompletionSource.Task.Wait(Timeout))
                 {
-                    throw new TimeoutException($"JNI operation timed out after {TimeoutMs}ms");
+                    throw new TimeoutException($"JNI operation timed out after {Timeout.Milliseconds}ms");
                 }
                 return (TResult?)_taskCompletionSource.Task.Result;
             }
@@ -126,9 +127,9 @@ internal class JniExecutor : IJniExecutor
 
             try
             {
-                if (!_taskCompletionSource.Task.Wait(TimeoutMs))
+                if (!_taskCompletionSource.Task.Wait(Timeout))
                 {
-                    throw new TimeoutException($"JNI operation timed out after {TimeoutMs}ms");
+                    throw new TimeoutException($"JNI operation timed out after {Timeout.Milliseconds}ms");
                 }
             }
             catch (Exception e)

--- a/src/Sentry.Unity.Android/JniExecutor.cs
+++ b/src/Sentry.Unity.Android/JniExecutor.cs
@@ -93,16 +93,14 @@ internal class JniExecutor : IJniExecutor
     {
         lock (_lock)
         {
+            using var timeoutCts = new CancellationTokenSource(Timeout);
             _taskCompletionSource = new TaskCompletionSource<object?>();
             _currentTask = jniOperation;
             _taskEvent.Set();
 
             try
             {
-                if (!_taskCompletionSource.Task.Wait(Timeout))
-                {
-                    throw new TimeoutException($"JNI operation timed out after {Timeout.Milliseconds}ms");
-                }
+                _taskCompletionSource.Task.Wait(timeoutCts.Token);
                 return (TResult?)_taskCompletionSource.Task.Result;
             }
             catch (Exception e)
@@ -121,16 +119,14 @@ internal class JniExecutor : IJniExecutor
     {
         lock (_lock)
         {
+            using var timeoutCts = new CancellationTokenSource(Timeout);
             _taskCompletionSource = new TaskCompletionSource<object?>();
             _currentTask = jniOperation;
             _taskEvent.Set();
 
             try
             {
-                if (!_taskCompletionSource.Task.Wait(Timeout))
-                {
-                    throw new TimeoutException($"JNI operation timed out after {Timeout.Milliseconds}ms");
-                }
+                _taskCompletionSource.Task.Wait(timeoutCts.Token);
             }
             catch (Exception e)
             {

--- a/src/Sentry.Unity.Android/JniExecutor.cs
+++ b/src/Sentry.Unity.Android/JniExecutor.cs
@@ -98,12 +98,11 @@ internal class JniExecutor : IJniExecutor
 
             try
             {
-                // if (!_taskCompletionSource.Task.Wait(TimeoutMs))
-                // {
-                //     throw new TimeoutException($"JNI operation timed out after {TimeoutMs}ms");
-                // }
-                // return (TResult?)_taskCompletionSource.Task.Result;
-                return (TResult?)_taskCompletionSource.Task.GetAwaiter().GetResult();
+                if (!_taskCompletionSource.Task.Wait(TimeoutMs))
+                {
+                    throw new TimeoutException($"JNI operation timed out after {TimeoutMs}ms");
+                }
+                return (TResult?)_taskCompletionSource.Task.Result;
             }
             catch (Exception e)
             {
@@ -127,11 +126,10 @@ internal class JniExecutor : IJniExecutor
 
             try
             {
-                // if (!_taskCompletionSource.Task.Wait(TimeoutMs))
-                // {
-                //     throw new TimeoutException($"JNI operation timed out after {TimeoutMs}ms");
-                // }
-                _taskCompletionSource.Task.Wait();
+                if (!_taskCompletionSource.Task.Wait(TimeoutMs))
+                {
+                    throw new TimeoutException($"JNI operation timed out after {TimeoutMs}ms");
+                }
             }
             catch (Exception e)
             {

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -66,23 +66,30 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setDebug", options.Debug);
                 androidOptions.Call("setRelease", options.Release);
                 androidOptions.Call("setEnvironment", options.Environment);
-                androidOptions.Call("setDiagnosticLevel", GetLevelString(options.DiagnosticLevel));
-                if (options.SampleRate.HasValue)
-                {
-                    androidOptions.Call("setSampleRate", options.SampleRate.Value);
-                }
+
+                var sentryLevelClass = new AndroidJavaClass("io.sentry.SentryLevel");
+                var levelString = GetLevelString(options.DiagnosticLevel);
+                var sentryLevel = sentryLevelClass.GetStatic<AndroidJavaObject>(levelString);
+                androidOptions.Call("setDiagnosticLevel", sentryLevel);
+
+                // if (options.SampleRate.HasValue)
+                // {
+                //     androidOptions.SetIfNotNull("setSampleRate", options.SampleRate.Value);
+                // }
 
                 androidOptions.Call("setMaxBreadcrumbs", options.MaxBreadcrumbs);
                 androidOptions.Call("setMaxCacheItems", options.MaxCacheItems);
-                androidOptions.Call("setSendDefaultPii", options.SendDefaultPii);
+
+                // Causes `FormatException`. Works with `new object[] { false }`
+                // androidOptions.SetIfNotNull("setSendDefaultPii", options.SendDefaultPii);
                 // Note: doesn't work - produces a blank (white) screenshot
-                androidOptions.Call("setAttachScreenshot", false);
-                androidOptions.Call("setNdkIntegrationEnabled", options.NdkIntegrationEnabled);
-                androidOptions.Call("setNdkScopeSyncEnabled", options.NdkScopeSyncEnabled);
-                androidOptions.Call("setEnableAutoSessionTracking", false);
-                androidOptions.Call("setEnableAutoAppLifecycleBreadcrumbs", false);
-                androidOptions.Call("setEnableAnr", false);
-                androidOptions.Call("setEnablePersistentScopeObserver", false);
+                // androidOptions.SetIfNotNull("setAttachScreenshot", false);
+                // androidOptions.SetIfNotNull("setNdkIntegrationEnabled", options.NdkIntegrationEnabled);
+                // androidOptions.SetIfNotNull("setNdkScopeSyncEnabled", options.NdkScopeSyncEnabled);
+                // androidOptions.SetIfNotNull("setEnableAutoSessionTracking", false);
+                // androidOptions.SetIfNotNull("setEnableAutoAppLifecycleBreadcrumbs", false);
+                // androidOptions.SetIfNotNull("setEnableAnr", false);
+                // androidOptions.SetIfNotNull("setEnablePersistentScopeObserver", false);
             }, options.DiagnosticLogger));
         });
 
@@ -249,12 +256,12 @@ internal class SentryJava : ISentryJava
     // https://github.com/getsentry/sentry-java/blob/db4dfc92f202b1cefc48d019fdabe24d487db923/sentry/src/main/java/io/sentry/SentryLevel.java#L4-L9
     internal static string GetLevelString(SentryLevel level) => level switch
     {
-        SentryLevel.Debug => "debug",
-        SentryLevel.Error => "error",
-        SentryLevel.Fatal => "fatal",
-        SentryLevel.Info => "info",
-        SentryLevel.Warning => "warning",
-        _ => "debug"
+        SentryLevel.Debug => "DEBUG",
+        SentryLevel.Error => "ERROR",
+        SentryLevel.Fatal => "FATAL",
+        SentryLevel.Info => "INFO",
+        SentryLevel.Warning => "WARNING",
+        _ => "DEBUG"
     };
 }
 
@@ -277,6 +284,8 @@ internal static class AndroidJavaObjectExtension
     }
     public static void SetIfNotNull(this AndroidJavaObject javaObject, string property, int? value) =>
         SetIfNotNull(javaObject, property, value, "java.lang.Integer");
+    public static void SetIfNotNull(this AndroidJavaObject javaObject, string property, bool value) =>
+        SetIfNotNull(javaObject, property, value, "java.lang.Boolean");
     public static void SetIfNotNull(this AndroidJavaObject javaObject, string property, bool? value) =>
         SetIfNotNull(javaObject, property, value, "java.lang.Boolean");
 }

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -37,7 +37,7 @@ public static class SentryNativeAndroid
             return;
         }
 
-        JniExecutor ??= new JniExecutor();
+        JniExecutor ??= new JniExecutor(options.DiagnosticLogger);
 
         options.DiagnosticLogger?.LogDebug("Checking whether the Android Native Support is enabled.");
         if (SentryJava.IsEnabled(JniExecutor) is false)
@@ -100,15 +100,17 @@ public static class SentryNativeAndroid
             // It's a randomly generated GUID that gets created immediately after installation helping
             // to identify the same instance of the game
             // options.DefaultUserId = AnalyticsSessionInfo.userId;
-            // if (options.DefaultUserId is not null)
-            // {
-            //     options.ScopeObserver.SetUser(new SentryUser { Id = options.DefaultUserId });
-            // }
-            // else
-            // {
-            //     options.DiagnosticLogger?.LogDebug("Failed to create new 'Default User ID'.");
-            // }
+            if (options.DefaultUserId is not null)
+            {
+                options.ScopeObserver.SetUser(new SentryUser { Id = options.DefaultUserId });
+            }
+            else
+            {
+                options.DiagnosticLogger?.LogDebug("Failed to create new 'Default User ID'.");
+            }
         }
+
+        options.DiagnosticLogger?.LogInfo("Successfully configured native support via the Android SDK");
     }
 
     /// <summary>
@@ -130,7 +132,7 @@ public static class SentryNativeAndroid
 
         // This is an edge-case where the Android SDK has been enabled and setup during build-time but is being
         // shut down at runtime. In this case Configure() has not been called and there is no JniExecutor yet
-        JniExecutor ??= new JniExecutor();
+        JniExecutor ??= new JniExecutor(options.DiagnosticLogger);
         SentryJava?.Close(JniExecutor);
         JniExecutor.Dispose();
     }


### PR DESCRIPTION
Previously, if something went wrong while we were calling into Java, the game would freeze. Now we have a timeout of 1 frame to at least not break things.