### PR TITLE
fix: Pin OS to work around `setup-dotnet` permission issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
   build:
     name: Build - ${{ matrix.unity-version }}
-    # Pinning ubuntu version to resolve permission issues with setup-dotnet: 
+    # Pinning ubuntu version to resolve permission issues with setup-dotnet: https://github.com/actions/setup-dotnet/issues/565
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
CI is currently blocked by this: https://github.com/getsentry/sentry-unity/actions/runs/12467261072/job/35272833714
Ubuntu runners are still on .NET 8: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
The `actions/setup-dotnet` has this issue tracked here: https://github.com/actions/setup-dotnet/issues/565

Let's see if we can do it manually.

#skip-changelog