### PR TITLE
feat: Add mechanism to ANR event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- ANR events now include the relevant mechanism they have been captured from ([#1955](https://github.com/getsentry/sentry-unity/pull/1955))
+
 ### Dependencies
 
 - Bump Java SDK from v7.19.0 to v7.19.1 ([#1946](https://github.com/getsentry/sentry-unity/pull/1946))

--- a/src/Sentry.Unity/Integrations/AnrIntegration.cs
+++ b/src/Sentry.Unity/Integrations/AnrIntegration.cs
@@ -78,7 +78,10 @@ internal abstract class AnrWatchDog
         {
             var message = $"Application not responding for at least {DetectionTimeoutMs} ms.";
             Logger?.LogInfo("Detected an ANR event: {0}", message);
-            OnApplicationNotResponding?.Invoke(this, new ApplicationNotRespondingException(message));
+
+            var exception = new ApplicationNotRespondingException(message);
+            exception.SetSentryMechanism("ANR", handled: false);
+            OnApplicationNotResponding?.Invoke(this, exception);
         }
     }
 }

--- a/src/Sentry.Unity/Integrations/AnrIntegration.cs
+++ b/src/Sentry.Unity/Integrations/AnrIntegration.cs
@@ -47,6 +47,8 @@ internal class AnrIntegration : ISdkIntegration
 
 internal abstract class AnrWatchDog
 {
+    public const string Mechanism = "MainThreadWatchdog";
+
     protected readonly int DetectionTimeoutMs;
     // Note: we don't sleep for the whole detection timeout or we wouldn't capture if the ANR started later.
     protected readonly int SleepIntervalMs;
@@ -80,7 +82,7 @@ internal abstract class AnrWatchDog
             Logger?.LogInfo("Detected an ANR event: {0}", message);
 
             var exception = new ApplicationNotRespondingException(message);
-            exception.SetSentryMechanism("MainThreadWatchdog", "Main thread unresponsive.", false);
+            exception.SetSentryMechanism(Mechanism, "Main thread unresponsive.", false);
             OnApplicationNotResponding?.Invoke(this, exception);
         }
     }

--- a/src/Sentry.Unity/Integrations/AnrIntegration.cs
+++ b/src/Sentry.Unity/Integrations/AnrIntegration.cs
@@ -80,7 +80,7 @@ internal abstract class AnrWatchDog
             Logger?.LogInfo("Detected an ANR event: {0}", message);
 
             var exception = new ApplicationNotRespondingException(message);
-            exception.SetSentryMechanism("ANR", handled: false);
+            exception.SetSentryMechanism("MainThreadWatchdog", "Main thread unresponsive.", false);
             OnApplicationNotResponding?.Invoke(this, exception);
         }
     }

--- a/test/Sentry.Unity.Tests/AnrDetectionTests.cs
+++ b/test/Sentry.Unity.Tests/AnrDetectionTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Sentry.Extensibility;
+using Sentry.Protocol;
 using Sentry.Unity.Integrations;
 using Sentry.Unity.Tests.SharedClasses;
 
@@ -67,6 +68,8 @@ public class AnrDetectionTests
 
         Assert.IsNotNull(arn);
         Assert.That(arn!.Message, Does.StartWith("Application not responding "));
+        Assert.That(arn!.Data.Contains(Mechanism.MechanismKey)); // Sanity Check
+        Assert.That(arn!.Data[Mechanism.MechanismKey], Is.EqualTo(AnrWatchDog.Mechanism));
     }
 
     [UnityTest]


### PR DESCRIPTION
Addresses the improvement part of https://github.com/getsentry/sentry-unity/issues/1954

In line with Java and the [V1 ANR watchdog](https://github.com/getsentry/sentry-java/blob/bfbaf37fae93cd88c3c1cd570f6296af1bf064be/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java#L144) (documented [here](https://arc.net/l/quote/zzpsagea)), the SDK will now add the `ANR` mechanism when capturing an ANR event.

Relates to:

* https://github.com/getsentry/sentry-unity/issues/1961