### PR TITLE
fix: CI - Set correct Java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,28 +493,7 @@ jobs:
 
       - name: Setup Java for Unity
         if: ${{ matrix.platform == 'Android' }}
-        run: |
-          switch -Regex ("${{ matrix.unity-version }}")
-          {
-              "2019" {
-                  $javaHome = $env:JAVA_HOME_8_X64
-                  Write-Host "Using Java 8 for Unity 2019"
-              }
-              "2022" {
-                $javaHome = "$env:JAVA_HOME_11_X64"
-                Write-Host "Using Java 11 for Unity 2022"
-              }
-              "6000" {
-                  $javaHome = "$env:JAVA_HOME_17_X64"
-                  Write-Host "Using Java 17 for Unity 6"
-              }
-              default {
-                  throw "Unexpected Unity version: ${{ matrix.unity-version }}"
-              }
-          }
-          
-          Write-Host "Selected JAVA_HOME: $javaHome"
-          "JAVA_HOME=$javaHome" >> $env:GITHUB_ENV
+        run: ./scripts/ci-setup-java.ps1 -UnityVersion "${{ matrix.unity-version }}"
 
       # We modify the exported gradle project to deal with the different build-environment
       # I.e. we're fixing the paths for SDK & NDK that have been hardcoded to point at the Unity installation 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,6 +491,31 @@ jobs:
           ndk-version: ${{ matrix.ndk }}
           add-to-path: false
 
+      - name: Setup Java for Unity
+        if: ${{ matrix.platform == 'Android' }}
+        run: |
+          switch -Regex ("${{ matrix.unity-version }}")
+          {
+              "2019" {
+                  $javaHome = $env:JAVA_HOME_8_X64
+                  Write-Host "Using Java 8 for Unity 2019"
+              }
+              "2022" {
+                $javaHome = "$env:JAVA_HOME_11_X64"
+                Write-Host "Using Java 11 for Unity 2022"
+              }
+              "6000" {
+                  $javaHome = "$env:JAVA_HOME_17_X64"
+                  Write-Host "Using Java 17 for Unity 6"
+              }
+              default {
+                  throw "Unexpected Unity version: ${{ matrix.unity-version }}"
+              }
+          }
+          
+          Write-Host "Selected JAVA_HOME: $javaHome"
+          "JAVA_HOME=$javaHome" >> $env:GITHUB_ENV
+
       # We modify the exported gradle project to deal with the different build-environment
       # I.e. we're fixing the paths for SDK & NDK that have been hardcoded to point at the Unity installation 
       - name: Modify gradle project
@@ -500,23 +525,18 @@ jobs:
             -AndroidSdkRoot $env:ANDROID_SDK_ROOT `
             -NdkPath ${{ steps.setup-ndk.outputs.ndk-path }} `
             -UnityVersion ${{ matrix.unity-version }}
-
-      - name: Setup JDK 17 for Unity 6
-        if: ${{ matrix.platform == 'Android' && matrix.unity-version == '6000' }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
   
       - name: Android smoke test
         if: ${{ matrix.platform == 'Android' }}
         run: ./scripts/smoke-test-android.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}"
+        timeout-minutes: 10
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
 
       - name: iOS smoke test
         if: ${{ matrix.platform == 'iOS' }}
         run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}"
+        timeout-minutes: 10
     
       - name: Upload Project project on failure
         if: ${{ failure() }}

--- a/scripts/ci-setup-java.ps1
+++ b/scripts/ci-setup-java.ps1
@@ -1,0 +1,35 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$UnityVersion
+)
+
+function Test-JavaPath {
+    param($Path, $Version)
+    if (-not (Test-Path $Path)) {
+        throw "Java $Version path not found at: $Path."
+    }
+}
+
+switch -Regex ($UnityVersion) {
+    "2019" {
+        Test-JavaPath $env:JAVA_HOME_8_X64 "8"
+        $javaHome = $env:JAVA_HOME_8_X64
+        Write-Host "Using Java 8 for Unity 2019"
+    }
+    "2022" {
+        Test-JavaPath $env:JAVA_HOME_11_X64 "11"
+        $javaHome = $env:JAVA_HOME_11_X64
+        Write-Host "Using Java 11 for Unity 2022"
+    }
+    "6000" {
+        Test-JavaPath $env:JAVA_HOME_17_X64 "17"
+        $javaHome = $env:JAVA_HOME_17_X64
+        Write-Host "Using Java 17 for Unity 6"
+    }
+    default {
+        throw "Unexpected Unity version: $UnityVersion"
+    }
+}
+
+Write-Host "Selected JAVA_HOME: $javaHome"
+"JAVA_HOME=$javaHome" >> $env:GITHUB_ENV


### PR DESCRIPTION
The default Java version is different on different runner images. An update to `-latest` causes Unity 2019 builds to fail.

With this, we explicitly set the correct Java version depending on the targeted Unity version, making this more resilient to future changes.
I've also added timeouts to the smoketests themselves. They tend to either fail fast or run indefinitely. This gets rid of the latter.

#skip-changelog