### PR TITLE
fix: Update to Unity `2022.3.55f1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
           - unity-version: "2019"
             ndk: "r19"
           - unity-version: "2022"
-            ndk: "r21d"
+            ndk: "r23b"
           - unity-version: "6000"
             ndk: "r23b"
             

--- a/scripts/ci-env.ps1
+++ b/scripts/ci-env.ps1
@@ -14,7 +14,7 @@ switch ($name) {
         return "2021.3.45f1"
     }
     "unity2022" {
-        return "2022.3.42f1"
+        return "2022.3.55f1"
     }
     "unity2023" {
         return "2023.2.20f1"

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -34,6 +34,13 @@ public class Builder
         EditorUserBuildSettings.il2CppCodeGeneration = UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
 #endif
 
+        // This is a workaround for build issues with Unity 2022.3. and newer.
+        // https://discussions.unity.com/t/gradle-build-issues-for-android-api-sdk-35-in-unity-2022-3lts/1502187/10
+#if UNITY_2022_3_OR_NEWER
+        Debug.Log("Builder: Setting Android target API level to 33");
+        PlayerSettings.Android.targetSdkVersion = AndroidSdkVersions.AndroidApiLevel33;
+#endif
+
         Debug.Log("Builder: Updating BuildPlayerOptions");
         var buildPlayerOptions = new BuildPlayerOptions
         {


### PR DESCRIPTION
The current LTS of Unity requires a bump to `ndk: "r23b"`.
This PR contains workarounds for an [ongoing issue](https://discussions.unity.com/t/gradle-build-issues-for-android-api-sdk-35-in-unity-2022-3lts/1502187/10) with the current 2022 LTS. This requires us to fix an additional absolut path set in the gradle properties and to pin the targeted Android API target.

#skip-changelog