### PR TITLE
fix: iOS native bridge option creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed iOS native SDK initialization that could cause memory management issues ([#1963](https://github.com/getsentry/sentry-unity/pull/1963))
+
 ### Dependencies
 
 - Bump Java SDK from v7.19.0 to v7.19.1 ([#1946](https://github.com/getsentry/sentry-unity/pull/1946))

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -1,3 +1,4 @@
+#import <Sentry/SentryOptions+HybridSDKs.h>
 #import <Sentry/PrivateSentrySDKOnly.h>
 #import <Sentry/Sentry.h>
 
@@ -33,11 +34,12 @@ void SentryNativeBridgeOptionsSetInt(const void *options, const char *name, int3
 void SentryNativeBridgeStartWithOptions(const void *options)
 {
     NSMutableDictionary *dictOptions = (__bridge_transfer NSMutableDictionary *)options;
-    id sentryOptions = [[SentryOptions alloc]
-        performSelector:@selector(initWithDict:didFailWithError:)
-        withObject:dictOptions withObject:nil];
-
-    [SentrySDK performSelector:@selector(startWithOptions:) withObject:sentryOptions];
+    NSError *error = nil;
+    SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:dictOptions didFailWithError:&error];
+    
+    if (sentryOptions) {
+        [SentrySDK startWithOptions:sentryOptions];
+    }
 }
 
 int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 : 0; }


### PR DESCRIPTION
Fixes an issue reported in https://github.com/getsentry/sentry-unity/issues/1951#issuecomment-2581075951

```
<REDACTED>/data/jenkins/workspace/<REDACTED>/iOS/Build/iOS/Libraries/io.sentry.unity/SentryNativeBridge.m:37:9: error: performSelector names a selector which retains the object
   37 |         performSelector:@selector(initWithDict:didFailWithError:)
      |         ^
In module 'Sentry' imported from <REDACTED>/data/jenkins/workspace/<REDACTED>/iOS/Build/iOS/Libraries/io.sentry.unity/SentryNativeBridge.m:1:
<REDACTED>/Library/Developer/Xcode/DerivedData/Unity-iPhone-cseycvbiwfelbyekvlwxliadxfvi/Build/Intermediates.noindex/ArchiveIntermediates/Unity-iPhone/BuildProductsPath/Release-iphoneos/Sentry.framework/PrivateHeaders/SentryOptions+HybridSDKs.h:11:1: note: method 'initWithDict:didFailWithError:' declared here
   11 | - (_Nullable instancetype)initWithDict:(NSDictionary<NSString *, id> *)options
      | ^
1 error generated.
```

If I read that correctly, then this is due to the `performSelector` not respecting ARC rules properly.
Instead, we're creating the options now directly.