### PR TITLE
fix: iOS native bridge creation with parameters

### DIFF
--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -33,11 +33,18 @@ void SentryNativeBridgeOptionsSetInt(const void *options, const char *name, int3
 void SentryNativeBridgeStartWithOptions(const void *options)
 {
     NSMutableDictionary *dictOptions = (__bridge_transfer NSMutableDictionary *)options;
-    id sentryOptions = [[SentryOptions alloc]
-        performSelector:@selector(initWithDict:didFailWithError:)
-        withObject:dictOptions withObject:nil];
+    NSError *error = nil;
+    
+    // selector -> direct call in order to prevent compile error
+    // "PerformSelector names a selector which retains the object"
+    SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:dictOptions didFailWithError:&error];
+    
+    if (error) {
+        NSLog(@"SentryOptions init failed: %@", error);
+        return;
+    }
 
-    [SentrySDK performSelector:@selector(startWithOptions:) withObject:sentryOptions];
+    [SentrySDK startWithOptions:sentryOptions];
 }
 
 int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 : 0; }

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -34,11 +34,9 @@ void SentryNativeBridgeStartWithOptions(const void *options)
 {
     NSMutableDictionary *dictOptions = (__bridge_transfer NSMutableDictionary *)options;
     NSError *error = nil;
-    
-    // selector -> direct call in order to prevent compile error
-    // "PerformSelector names a selector which retains the object"
+
     SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:dictOptions didFailWithError:&error];
-    
+
     if (error) {
         NSLog(@"SentryOptions init failed: %@", error);
         return;


### PR DESCRIPTION
Fixes an issue reported in https://github.com/getsentry/sentry-unity/issues/1951#issuecomment-2581075951

The original code that starts the iOS native bridge caused
compile error by XCode due to the retaining excessive ownership which can lead to a memory leak.

error name during the compilation: 
"PerformSelector names a selector which retains the object".

this fix with PR was already been created by @bitsandfoxes 
but thanks to him I could create my own PR for the first time.

I really appreciate the community.

