### PR TITLE
fix: iOS native bridge import missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+Fixed iOS native SDK initialization that could cause memory management issues ([#1964](https://github.com/getsentry/sentry-unity/pull/1964))
 - ANR events now include the relevant mechanism they have been captured from ([#1955](https://github.com/getsentry/sentry-unity/pull/1955))
 
 ### Dependencies

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -39,7 +39,7 @@ void SentryNativeBridgeStartWithOptions(const void *options)
 
     if (error != nil)
     {
-        SENTRY_LOG_ERROR(@"SentryOptions init failed: %@", error);
+        NSLog(@"SentryOptions init failed: %@", error);
         return;
     }
 

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -37,8 +37,9 @@ void SentryNativeBridgeStartWithOptions(const void *options)
 
     SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:dictOptions didFailWithError:&error];
 
-    if (error) {
-        NSLog(@"SentryOptions init failed: %@", error);
+    if (error != nil)
+    {
+        SENTRY_LOG_ERROR(@"SentryOptions init failed: %@", error);
         return;
     }
 

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -1,4 +1,5 @@
 #import <Sentry/PrivateSentrySDKOnly.h>
+#import <Sentry/SentryOptions+HybridSDKs.h>
 #import <Sentry/Sentry.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -30,20 +31,19 @@ void SentryNativeBridgeOptionsSetInt(const void *options, const char *name, int3
     dictOptions[[NSString stringWithUTF8String:name]] = [NSNumber numberWithInt:value];
 }
 
-void SentryNativeBridgeStartWithOptions(const void *options)
+int SentryNativeBridgeStartWithOptions(const void *options)
 {
     NSMutableDictionary *dictOptions = (__bridge_transfer NSMutableDictionary *)options;
     NSError *error = nil;
 
     SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:dictOptions didFailWithError:&error];
-
     if (error != nil)
     {
-        NSLog(@"SentryOptions init failed: %@", error);
-        return;
+        return 0;
     }
 
     [SentrySDK startWithOptions:sentryOptions];
+    return 1;
 }
 
 int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 : 0; }

--- a/package-dev/Plugins/iOS/SentryNativeBridgeNoOp.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridgeNoOp.m
@@ -5,7 +5,7 @@ int SentryNativeBridgeLoadLibrary() { return 0; }
 void *_Nullable SentryNativeBridgeOptionsNew() { return nil; }
 void SentryNativeBridgeOptionsSetString(void *options, const char *name, const char *value) { }
 void SentryNativeBridgeOptionsSetInt(void *options, const char *name, int32_t value) { }
-void SentryNativeBridgeStartWithOptions(void *options) { }
+int SentryNativeBridgeStartWithOptions(void *options) { return 0; }
 
 int SentryNativeBridgeCrashedLastRun() { return 0; }
 

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -80,7 +80,7 @@ internal static class SentryCocoaBridgeProxy
     private static extern void OptionsSetInt(IntPtr options, string name, int value);
 
     [DllImport("__Internal", EntryPoint = "SentryNativeBridgeStartWithOptions")]
-    private static extern void StartWithOptions(IntPtr options);
+    private static extern int StartWithOptions(IntPtr options);
 
     [DllImport("__Internal", EntryPoint = "SentryNativeBridgeCrashedLastRun")]
     public static extern int CrashedLastRun();

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -60,8 +60,8 @@ internal static class SentryCocoaBridgeProxy
         options.DiagnosticLogger?.LogDebug("Setting MaxCacheItems: {0}", options.MaxCacheItems);
         OptionsSetInt(cOptions, "maxCacheItems", options.MaxCacheItems);
 
-        StartWithOptions(cOptions);
-        return true;
+        var result = StartWithOptions(cOptions);
+        return result is 1;
     }
 
     [DllImport("__Internal", EntryPoint = "SentryNativeBridgeLoadLibrary")]


### PR DESCRIPTION
A followup of https://github.com/getsentry/sentry-unity/pull/1964

#skip-changelog