### PR TITLE
chore: Cleanup OptionsConfiguration template

### DIFF
--- a/src/Sentry.Unity/SentryOptionsConfiguration.cs
+++ b/src/Sentry.Unity/SentryOptionsConfiguration.cs
@@ -14,59 +14,6 @@ public abstract class SentryOptionsConfiguration : ScriptableObject
             public override void Configure(SentryUnityOptions options)
             {
                 // Here you can programmatically modify the Sentry option properties used for the SDK's initialization
-
-        #if UNITY_ANDROID || UNITY_IOS
-                // NOTE!
-                // On Android and iOS, ALL options configured here will be "baked" into the exported project
-                // during the build process.
-                // Changes to the options at runtime will not affect the native SDKs (Java, C/C++, Objective-C)
-                // and only apply to the C# layer.
-
-                /*
-                * Sentry Unity SDK - Hybrid Architecture
-                * ======================================
-                *
-                *          Build Time                          Runtime
-                *  ┌─────────────────────────┐        ┌─────────────────────────┐
-                *  │      Unity Editor       │        │       Game Startup      │
-                *  └──────────┬──────────────┘        └───────────┬─────────────┘
-                *             │                                   │
-                *             ▼                                   ▼
-                *  ┌────────────────────────────────────────────────────────────┐
-                *  │                    Options Configuration                   │
-                *  │                       (This Method)                        │
-                *  └─────────────────────────────┬──────────────────────────────┘
-                *                                │
-                *               ┌───────────────────────────────────┐
-                *               │      Options used for Init        │
-                *               ▼                                   ▼
-                *  ┌──────────────────────────┐         ┌──────────────────────┐
-                *  │        Native SDK        │         │     Unity C# SDK     │
-                *  │       Android & iOS      │         │    Initialization    │
-                *  │  ┌────────────────────┐  │         └──────────────────────┘
-                *  │  │ Options "Baked in" │  │
-                *  │  └────────────────────┘  │
-                *  │  The configure call made │
-                *  │  for this part ran on    │
-                *  │  your build-machine      │
-                *  └──────────────────────────┘
-                *               │
-                *               ▼
-                *  ┌──────────────────────────┐
-                *  │        Native SDK        │
-                *  │       Android & iOS      │
-                *  └──────────────────────────┘
-                */
-
-                // Works as expected and will enable all debug logging
-                // options.Debug = true;
-
-                // Will NOT work as expected.
-                // This will run twice.
-                //    1. Once during the build, being baked into the native SDKs
-                //    2. And a second time every time when the game starts
-                // options.Release = ComputeVersion();
-        #endif
             }
         }
         """;


### PR DESCRIPTION
Cleanup of both, the template and the one in our `/Samples`.
#skip-changelog