### PR TITLE
fix: The `asmdef` no explicitly sets the included platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## Unreleased
 
-### Dependencies
-
-- Bump Java SDK from v7.19.0 to v7.20.0 ([#1947](https://github.com/getsentry/sentry-unity/pull/1947))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7200)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.19.0...7.20.0)
 ### Fixes
 
+- The SDK now sets the supported platforms in the `.asmdef` explicitely, preventing runtime issues on currently non-supported platforms ([#1974](https://github.com/getsentry/sentry-unity/pull/1974))
 - Fixed iOS native SDK initialization that could cause memory management issues ([#1964](https://github.com/getsentry/sentry-unity/pull/1964))
 - The SDK now  properly sets up logging by respecting the debug settings set during the configure callback. Logs created during the configuration of the native SDKs no longer get lost ([#1959]https://github.com/getsentry/sentry-unity/pull/1959)
 - ANR events now include the relevant mechanism they have been captured from ([#1955](https://github.com/getsentry/sentry-unity/pull/1955))
@@ -18,9 +14,9 @@
 - Bump Cocoa SDK from v8.42.0 to v8.43.0 ([#1949](https://github.com/getsentry/sentry-unity/pull/1949))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8430)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.42.0...8.43.0)
-- Bump Java SDK from v7.19.0 to v7.19.1 ([#1946](https://github.com/getsentry/sentry-unity/pull/1946))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7191)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.19.0...7.19.1)
+- Bump Java SDK from v7.19.0 to v7.20.0 ([#1946](https://github.com/getsentry/sentry-unity/pull/1946), [#1947](https://github.com/getsentry/sentry-unity/pull/1947))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7200)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.19.0...7.20.0)
 - Bump Cocoa SDK from v8.42.0 to v8.42.1 ([#1945](https://github.com/getsentry/sentry-unity/pull/1945))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8421)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.42.0...8.42.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,12 @@
 
 ### Dependencies
 
-- Bump Cocoa SDK from v8.42.0 to v8.43.0 ([#1949](https://github.com/getsentry/sentry-unity/pull/1949))
+- Bump Cocoa SDK from v8.42.0 to v8.43.0 ([#1945](https://github.com/getsentry/sentry-unity/pull/1945), [#1949](https://github.com/getsentry/sentry-unity/pull/1949))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8430)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.42.0...8.43.0)
 - Bump Java SDK from v7.19.0 to v7.20.0 ([#1946](https://github.com/getsentry/sentry-unity/pull/1946), [#1947](https://github.com/getsentry/sentry-unity/pull/1947))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7200)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.19.0...7.20.0)
-- Bump Cocoa SDK from v8.42.0 to v8.42.1 ([#1945](https://github.com/getsentry/sentry-unity/pull/1945))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8421)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.42.0...8.42.1)
 - Bump CLI from v2.39.1 to v2.40.0 ([#1948](https://github.com/getsentry/sentry-unity/pull/1948))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2400)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.39.1...2.40.0)

--- a/package-dev/Runtime/io.sentry.unity.dev.runtime.asmdef
+++ b/package-dev/Runtime/io.sentry.unity.dev.runtime.asmdef
@@ -1,7 +1,24 @@
 {
     "name": "io.sentry.unity.dev.runtime",
-    "references": [""],
-    "includePlatforms": [],
+    "references": [
+        ""
+    ],
+    "includePlatforms": [
+        "Android",
+        "Editor",
+        "GameCoreScarlett",
+        "GameCoreXboxOne",
+        "iOS",
+        "LinuxStandalone64",
+        "Lumin",
+        "macOSStandalone",
+        "Stadia",
+        "Switch",
+        "WSA",
+        "WebGL",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1962