### PR TITLE
chore: CI desktop flake

### DIFF
--- a/test/Scripts.Integration.Test/run-smoke-test.ps1
+++ b/test/Scripts.Integration.Test/run-smoke-test.ps1
@@ -117,8 +117,9 @@ function RunTest([string] $type)
             Write-Host "$type test: Player.log contents END" -ForegroundColor Yellow
         }
 
-        # ExitCode 200 is the status code indicating success inside SmokeTest.cs
-        If ($process.ExitCode -eq 200)
+        # Relying on ExitCode does not seem reliable. We're looking for the line "SmokeTester is quitting." instead to indicate 
+        # a successful shut-down.
+        If ($appLog | Select-String "SmokeTester is quitting.")
         {
             Write-Host "$type test: PASSED" -ForegroundColor Green
         }


### PR DESCRIPTION
Similarly to the Android SmokeTests, where relying on Unity's exit code turned out to be flaky, we're checking the logs for the shutdown-marker `SmokeTester is quitting.` https://github.com/getsentry/sentry-unity/blob/037bcddbb0d56c93e76d1974c460c82f6133baf5/scripts/smoke-test-android.ps1#L336

#skip-changelog