### PR TITLE
chore: Skipping Android on Unity 2022 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [30, 31, 34] # last updated January 2025
-        unity-version: ["2019", "2022", "6000"]
+        unity-version: ["2019", "6000"]
 
   mobile-smoke-test-compile:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
@@ -507,7 +507,13 @@ jobs:
   
       - name: Android smoke test
         if: ${{ matrix.platform == 'Android' }}
-        run: ./scripts/smoke-test-android.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}"
+        # Skipping Android on Unity 2022 for now
+        run: |
+          if (${{ matrix.unity-version == '2022' }}) {
+            Write-Host "Skipping Android smoke test for Unity 2022"
+            return
+          }
+          ./scripts/smoke-test-android.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}"
         timeout-minutes: 10
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -530,6 +536,9 @@ jobs:
 
       - name: Upload app
         uses: actions/upload-artifact@v4
+        # Skipping Android on Unity 2022 for now
+        if: |
+          !(matrix.platform == 'Android' && matrix.unity-version == '2022') || matrix.platform == 'iOS'
         with:
           name: testapp-${{ matrix.platform }}-compiled-${{ matrix.unity-version }}
           # Collect app but ignore the files that are not required for the test.


### PR DESCRIPTION
The gradle builds coming from Unity 2022 are stuck indefinitely during the IL2CPP build. Skipping for now to unblock CI.

#skip-changelog