### PR TITLE
feat: Separate CI jobs into workflows

### DIFF
--- a/.github/workflows/android-smoke-test-build.yml
+++ b/.github/workflows/android-smoke-test-build.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Upload test app
         uses: actions/upload-artifact@v4
         with:
-          name: testapp-${{ matrix.platform }}-${{ inputs.unity-version }}-runtime
+          name: testapp-android-${{ inputs.unity-version }}-runtime
           if-no-files-found: error
           path: test-app-runtime.tar.gz
           retention-days: 14
@@ -127,7 +127,7 @@ jobs:
       - name: Upload test app (build-time initialization)
         uses: actions/upload-artifact@v4
         with:
-          name: testapp-${{ matrix.platform }}-${{ inputs.unity-version }}-buildtime
+          name: testapp-android-${{ inputs.unity-version }}-buildtime
           if-no-files-found: error
           path: test-app-buildtime.tar.gz
           retention-days: 14
@@ -136,7 +136,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: failed-project-${{ matrix.platform }}-${{ inputs.unity-version }}
+          name: failed-project-android-${{ inputs.unity-version }}
           path: |
             samples/IntegrationTest
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame

--- a/.github/workflows/android-smoke-test-build.yml
+++ b/.github/workflows/android-smoke-test-build.yml
@@ -1,0 +1,144 @@
+name: Android Create Smoke Test Project
+
+on:
+  workflow_call:
+    inputs:
+      unity-version:
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  android-build-smoke-test:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    name: ${{ inputs.unity-version }} Android Smoke Test Build
+    # needs: [smoke-test-create]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: Android
+            check_symbols: false
+            build_platform: Android-Export
+    env:
+      UNITY_PATH: docker exec unity unity-editor
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8
+        with:
+          android: true
+          dotnet: false
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+      - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
+
+      - name: Docker Login
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }} 
+          password: ${{ secrets.GITHUB_TOKEN }} 
+
+      - name: Start the Unity docker container
+        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' '${{ matrix.platform }}' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        shell: bash
+
+      # Workaround for missing libMonoPosixHelper.so
+      # See https://github.com/getsentry/sentry-unity/pull/1295
+      - name: Install mono-devel
+        if: ${{ inputs.unity-version == '2019' }}
+        run: |
+          docker exec --user root unity apt-get update
+          docker exec --user root unity apt-get -y -q install mono-devel
+
+      - name: Download IntegrationTest project
+        uses: actions/download-artifact@v4
+        with:
+          name: smoke-test-${{ inputs.unity-version }}
+
+      - name: Extract project archive
+        run: tar -xvzf test-project.tar.gz
+
+    #   - name: Build without Sentry SDK
+    #     run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
+
+      - name: Download UPM package
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
+        with:
+          name: ${{ github.sha }}
+          wait-timeout: 3600
+
+      - name: Extract UPM package
+        run: ./test/Scripts.Integration.Test/extract-package.ps1
+
+      - name: Add Sentry to the project
+        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
+      - name: Configure Sentry
+        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols
+
+      - name: Build Project
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${{ inputs.unity-version }}"
+
+      # We create tar explicitly because upload-artifact is slow for many files.
+      - name: Create archive
+        shell: bash
+        run: |
+          # Note: remove local.properties file that contains Android SDK & NDK paths in the Unity installation.
+          rm -rf samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
+          tar -cvzf test-app-runtime.tar.gz samples/IntegrationTest/Build
+
+      # Upload runtime initialization build
+      - name: Upload test app
+        uses: actions/upload-artifact@v4
+        with:
+          name: testapp-${{ matrix.platform }}-${{ inputs.unity-version }}-runtime
+          if-no-files-found: error
+          path: test-app-runtime.tar.gz
+          retention-days: 14
+
+      - name: Configure Sentry for mobile platforms (build-time initialization)
+        run: |
+          $optionsPath = "samples/IntegrationTest/Assets/Scripts/OptionsConfiguration.cs"
+          $content = Get-Content $optionsPath -Raw
+          $content = $content -replace 'AndroidNativeInitializationType = NativeInitializationType.Runtime', 'AndroidNativeInitializationType = NativeInitializationType.BuildTime'
+          Set-Content $optionsPath $content
+
+      - name: Build Project for mobile platforms (build-time initialization)
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${{ inputs.unity-version }}"
+
+      - name: Create archive (build-time initialization)
+        shell: bash
+        run: |
+          rm -rf samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
+          tar -cvzf test-app-buildtime.tar.gz samples/IntegrationTest/Build
+
+      # Upload build-time initialization build
+      - name: Upload test app (build-time initialization)
+        uses: actions/upload-artifact@v4
+        with:
+          name: testapp-${{ matrix.platform }}-${{ inputs.unity-version }}-buildtime
+          if-no-files-found: error
+          path: test-app-buildtime.tar.gz
+          retention-days: 14
+          
+      - name: Upload IntegrationTest project on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-project-${{ matrix.platform }}-${{ inputs.unity-version }}
+          path: |
+            samples/IntegrationTest
+            !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
+          # Lower retention period - we only need this to retry CI.
+          retention-days: 14

--- a/.github/workflows/android-smoke-test-build.yml
+++ b/.github/workflows/android-smoke-test-build.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-    #   - name: Build without Sentry SDK
-    #     run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
-
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:

--- a/.github/workflows/android-smoke-test-build.yml
+++ b/.github/workflows/android-smoke-test-build.yml
@@ -87,6 +87,7 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${{ inputs.unity-version }}"
 
       # We create tar explicitly because upload-artifact is slow for many files.
+      # TODO verify this is still true with upload-artifact@v4 which improved performance a lot.
       - name: Create archive
         shell: bash
         run: |

--- a/.github/workflows/android-smoke-test-build.yml
+++ b/.github/workflows/android-smoke-test-build.yml
@@ -1,5 +1,3 @@
-name: Android Create Smoke Test Project
-
 on:
   workflow_call:
     inputs:
@@ -12,9 +10,9 @@ defaults:
     shell: pwsh
 
 jobs:
-  android-build-smoke-test:
+  build:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    name: ${{ inputs.unity-version }} Android Smoke Test Build
+    name: ${{ inputs.unity-version }}
     # needs: [smoke-test-create]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/android-smoke-test-compile.yml
+++ b/.github/workflows/android-smoke-test-compile.yml
@@ -1,0 +1,103 @@
+name: Android Compile Smoke Test Project
+
+on:
+  workflow_call:
+    inputs:
+      unity-version:
+        required: true
+        type: string
+      init-type:
+          required: true
+          type: string
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  android-compile-smoke-test:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    name: ${{ inputs.unity-version }} ${{ inputs.init-type }} Compile Smoke Test
+    runs-on: 'ubuntu-latest-4-cores'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # See supported version in https://docs.unity3d.com/6000.0/Documentation/Manual/android-sdksetup.html
+          - unity-version: "2019"
+            ndk: "r19"
+          - unity-version: "2022"
+            ndk: "r23b"
+          - unity-version: "6000"
+            ndk: "r23b"
+            
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download app project
+        uses: actions/download-artifact@v4
+        with:
+          name: testapp-android-${{ inputs.unity-version }}-${{ inputs.init-type }}
+
+      - name: Extract app project
+        run: tar -xvzf test-app-${{ inputs.init-type }}.tar.gz
+
+      - name: Setup Android
+        uses: android-actions/setup-android@7c5672355aaa8fde5f97a91aa9a99616d1ace6bc # pin@v2
+
+      - name: Setup NDK
+        uses: nttld/setup-ndk@8c3b609ff4d54576ea420551943fd34b4d03b0dc # pin@v1
+        id: setup-ndk
+        with:
+          ndk-version: ${{ matrix.ndk }}
+          add-to-path: false
+
+      - name: Setup Java for Unity
+        run: ./scripts/ci-setup-java.ps1 -UnityVersion "${{ inputs.unity-version }}"
+
+      # We modify the exported gradle project to deal with the different build-environment
+      # I.e. we're fixing the paths for SDK & NDK that have been hardcoded to point at the Unity installation 
+      - name: Modify gradle project
+        run: |
+          ./test/Scripts.Integration.Test/modify-gradle-project.ps1 `
+            -AndroidSdkRoot $env:ANDROID_SDK_ROOT `
+            -NdkPath ${{ steps.setup-ndk.outputs.ndk-path }} `
+            -UnityVersion ${{ inputs.unity-version }}
+  
+      - name: Android smoke test
+        # Skipping Android on Unity 2022 for now
+        run: |
+          if ("${{ inputs.unity-version }}" -ne "2022")
+          {
+            ./scripts/smoke-test-android.ps1 Build -IsIntegrationTest -UnityVersion "${{ inputs.unity-version }}"
+          }
+        timeout-minutes: 10
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+    
+      - name: Upload integration-test project on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-project-android-${{ inputs.unity-version }}-${{ inputs.init-type }}-but-compiled
+          path: |
+            samples/IntegrationTest
+            !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
+          # Lower retention period - we only need this to retry CI.
+          retention-days: 14
+
+      - name: Upload app
+        uses: actions/upload-artifact@v4
+        # Skipping Android on Unity 2022 for now
+        if: ${{ inputs.unity-version != '2022' }}
+        with:
+          name: testapp-android-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
+          # Collect app but ignore the files that are not required for the test.
+          path: |
+            samples/IntegrationTest/Build/*.apk
+            samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator/
+            !**/Release-iphonesimulator/*.dSYM
+            !**/Release-iphonesimulator/UnityFramework.framework/*
+          # Lower retention period - we only need this to retry CI.
+          retention-days: 14

--- a/.github/workflows/android-smoke-test-compile.yml
+++ b/.github/workflows/android-smoke-test-compile.yml
@@ -14,11 +14,8 @@ defaults:
 
 jobs:
   compile:
-    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     name: ${{ inputs.unity-version }} ${{ inputs.init-type }}
     runs-on: 'ubuntu-latest-4-cores'
-    strategy:
-      fail-fast: false
             
     steps:
       - name: Checkout
@@ -70,7 +67,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: failed-project-android-${{ inputs.unity-version }}-${{ inputs.init-type }}-but-compiled
+          name: failed-project-android-${{ inputs.unity-version }}-${{ inputs.init-type }}-compiled
           path: |
             samples/IntegrationTest
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
@@ -86,8 +83,5 @@ jobs:
           # Collect app but ignore the files that are not required for the test.
           path: |
             samples/IntegrationTest/Build/*.apk
-            samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator/
-            !**/Release-iphonesimulator/*.dSYM
-            !**/Release-iphonesimulator/UnityFramework.framework/*
           # Lower retention period - we only need this to retry CI.
           retention-days: 14

--- a/.github/workflows/android-smoke-test-compile.yml
+++ b/.github/workflows/android-smoke-test-compile.yml
@@ -1,5 +1,3 @@
-name: Android Compile Smoke Test Project
-
 on:
   workflow_call:
     inputs:
@@ -7,29 +5,20 @@ on:
         required: true
         type: string
       init-type:
-          required: true
-          type: string
+        required: true
+        type: string
 
 defaults:
   run:
     shell: pwsh
 
 jobs:
-  android-compile-smoke-test:
+  compile:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    name: ${{ inputs.unity-version }} ${{ inputs.init-type }} Compile Smoke Test
+    name: ${{ inputs.unity-version }} ${{ inputs.init-type }}
     runs-on: 'ubuntu-latest-4-cores'
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # See supported version in https://docs.unity3d.com/6000.0/Documentation/Manual/android-sdksetup.html
-          - unity-version: "2019"
-            ndk: "r19"
-          - unity-version: "2022"
-            ndk: "r23b"
-          - unity-version: "6000"
-            ndk: "r23b"
             
     steps:
       - name: Checkout
@@ -50,7 +39,8 @@ jobs:
         uses: nttld/setup-ndk@8c3b609ff4d54576ea420551943fd34b4d03b0dc # pin@v1
         id: setup-ndk
         with:
-          ndk-version: ${{ matrix.ndk }}
+          # See supported version in https://docs.unity3d.com/6000.0/Documentation/Manual/android-sdksetup.html
+          ndk-version: ${{ inputs.unity-version == '2019' && 'r19' || 'r23b' }}
           add-to-path: false
 
       - name: Setup Java for Unity

--- a/.github/workflows/android-smoke-test-run.yml
+++ b/.github/workflows/android-smoke-test-run.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Download test app artifact
         uses: actions/download-artifact@v4
         with:
-          name: testapp-Android-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
+          name: testapp-android-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           path: samples/IntegrationTest/Build
 
       # See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/

--- a/.github/workflows/android-smoke-test-run.yml
+++ b/.github/workflows/android-smoke-test-run.yml
@@ -30,6 +30,7 @@ jobs:
     # Map the job outputs to step outputs
     outputs:
       status: ${{ steps.smoke-test.outputs.status }}
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/android-smoke-test-run.yml
+++ b/.github/workflows/android-smoke-test-run.yml
@@ -16,16 +16,17 @@ on:
         description: "Smoke test status"
         value: ${{ jobs.run.outputs.status }}
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   run:
-    name: Android Smoke Test
+    name: ${{ inputs.unity-version }} ${{ inputs.init-type }}
     runs-on: ubuntu-latest
     env:
       ARTIFACTS_PATH: samples/IntegrationTest/test-artifacts/
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-    defaults:
-      run:
-        shell: pwsh
     # Map the job outputs to step outputs
     outputs:
       status: ${{ steps.smoke-test.outputs.status }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   build:
     name: Build - ${{ inputs.unity-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,138 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      unity-version:
+        required: true
+        type: string
+
+env:
+  LOWEST_SUPPORTED_UNITY_VERSION: 2019
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: 1
+
+jobs:
+  build:
+    name: Build - ${{ inputs.unity-version }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive src/sentry-dotnet
+
+      - name: Load env
+        id: env
+        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ inputs.unity-version }}")" >> $env:GITHUB_OUTPUT
+
+      - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
+
+      - name: Restore Unity Packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            samples/unity-of-bugs/Library/Packages
+            temp/unity-packages/Library/ScriptAssemblies/*.TestRunner.*
+          key: samples/unity-of-bugs|${{ steps.env.outputs.unityVersion }}-${{ hashFiles('samples/unity-of-bugs/Packages/packages-lock.json') }}
+
+      - name: Docker Login
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }} 
+          password: ${{ secrets.GITHUB_TOKEN }} 
+
+      - name: Start the Unity docker container
+        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'ios' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        shell: bash
+
+      - name: Install .NET SDK
+        if: runner.os != 'Windows'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.100
+        
+      - name: Install Android dotnet workflow
+        run: dotnet workload install android --temp-dir "${{ runner.temp }}"
+
+      - name: Download CLI
+        run: ./scripts/download-sentry-cli.ps1
+
+      - name: Download Android SDK
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
+        with:
+          name: Android-sdk
+          path: package-dev/Plugins/Android
+          wait-timeout: 3600
+
+      - name: Download Android Libraries
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
+        with:
+          name: Android-libraries
+          path: modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
+          wait-timeout: 3600
+
+      - name: Download Linux SDK
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
+        with:
+          name: Linux-sdk
+          path: package-dev/Plugins/Linux
+          wait-timeout: 3600
+
+      - name: Download Windows SDK
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
+        with:
+          name: Windows-sdk
+          path: package-dev/Plugins/Windows
+          wait-timeout: 3600
+
+      - name: Build Sentry.Unity Solution
+        run: docker exec unity dotnet build -c Release
+
+      - name: Install assemblyalias
+        run: docker exec unity dotnet tool install --global Alias --version 0.4.3
+
+      - name: Alias editor assemblies
+        run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"
+
+      - name: Alias runtime assemblies
+        run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
+
+      - name: Package for release
+        if: ${{ inputs.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
+        run: |
+          docker exec unity dotnet msbuild /t:UnityConfigureSentryOptions /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
+          ./scripts/pack.ps1
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
+        with:
+          name: ${{ github.sha }}
+          if-no-files-found: error
+          path: |
+            package-release.zip
+            modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib/*
+
+      - name: Run Unity tests (playmode)
+        run: |
+          docker exec unity dotnet msbuild /t:UnityConfigureSentryOptions /p:TestDsn= /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
+          docker exec unity dotnet msbuild /t:UnityPlayModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Tests
+
+      - name: Upload test artifacts (playmode)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test results (playmode) - ${{inputs.unity-version}}
+          path: artifacts/test/playmode
+
+      - name: Run Unity tests (editmode)
+        run: docker exec unity dotnet msbuild /t:UnityEditModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Editor.Tests
+
+      - name: Upload test artifacts (editmode)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test results (editmode) - ${{inputs.unity-version}}
+          path: artifacts/test/editmode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Unity SDK
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,140 +43,14 @@ jobs:
       runsOn: ${{ matrix.host }}
 
   build:
-    name: Build - ${{ matrix.unity-version }}
-    # Pinning ubuntu version to resolve permission issues with setup-dotnet: https://github.com/actions/setup-dotnet/issues/565
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         # Building the SDK with Unity 2022 and newer requires ns2.1 - skipping for now
         unity-version: ["2019", "2020", "2021"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Checkout submodules
-        run: git submodule update --init --recursive src/sentry-dotnet
-
-      - name: Load env
-        id: env
-        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
-
-      - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
-
-      - name: Restore Unity Packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            samples/unity-of-bugs/Library/Packages
-            temp/unity-packages/Library/ScriptAssemblies/*.TestRunner.*
-          key: samples/unity-of-bugs|${{ steps.env.outputs.unityVersion }}-${{ hashFiles('samples/unity-of-bugs/Packages/packages-lock.json') }}
-
-      - name: Docker Login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }} 
-          password: ${{ secrets.GITHUB_TOKEN }} 
-
-      - name: Start the Unity docker container
-        # We must use the iOS version of the image instead of 'base' - Sentry.Unity.Editor.iOS.csproj requires some libraries.
-        # Maybe we could just cache the needed file instead of pulling the 1 GB larger image on every build...
-        run: ./scripts/ci-docker.sh '${{ matrix.unity-version }}' 'ios' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
-        shell: bash
-
-      - name: Install .NET SDK
-        if: runner.os != 'Windows'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            9.0.100
-        
-      # Required by sentry-dotnet since 3.19.0
-      - name: Install Android dotnet workflow
-        run: dotnet workload install android --temp-dir "${{ runner.temp }}"
-
-      - name: Download CLI
-        run: ./scripts/download-sentry-cli.ps1
-
-      - name: Download Android SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
-        with:
-          name: Android-sdk
-          path: package-dev/Plugins/Android
-          wait-timeout: 3600
-
-      - name: Download Android Libraries
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
-        with:
-          name: Android-libraries
-          path: modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib
-          wait-timeout: 3600
-
-      - name: Download Linux SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
-        with:
-          name: Linux-sdk
-          path: package-dev/Plugins/Linux
-          wait-timeout: 3600
-
-      - name: Download Windows SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
-        with:
-          name: Windows-sdk
-          path: package-dev/Plugins/Windows
-          wait-timeout: 3600
-
-      - name: Build Sentry.Unity Solution
-        run: docker exec unity dotnet build -c Release
-
-      - name: Install assemblyalias
-        run: docker exec unity dotnet tool install --global Alias --version 0.4.3
-
-      - name: Alias editor assemblies
-        run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"
-
-      - name: Alias runtime assemblies
-        run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
-
-      - name: Package for release
-        if: ${{ matrix.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
-        run: |
-          # Before packaging, we need to open & close Unity on the sample project to update .meta files in package-dev.
-          # We could add a new custom target but reusing UnityConfigureSentryOptions is good enough.
-          docker exec unity dotnet msbuild /t:UnityConfigureSentryOptions /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
-          ./scripts/pack.ps1
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
-        with:
-          name: ${{ github.sha }}
-          if-no-files-found: error
-          # Adding the native libraries so the symbol collector craft target can find/upload them
-          path: |
-            package-release.zip
-            modules/sentry-java/sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib/*
-
-      - name: Run Unity tests (playmode)
-        run: |
-          docker exec unity dotnet msbuild /t:UnityConfigureSentryOptions /p:TestDsn= /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
-          docker exec unity dotnet msbuild /t:UnityPlayModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Tests
-
-      - name: Upload test artifacts (playmode)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test results (playmode) - ${{matrix.unity-version}}
-          path: artifacts/test/playmode
-
-      - name: Run Unity tests (editmode)
-        run: docker exec unity dotnet msbuild /t:UnityEditModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Editor.Tests
-
-      - name: Upload test artifacts (editmode)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test results (editmode) - ${{matrix.unity-version}}
-          path: artifacts/test/editmode
+    uses: ./.github/workflows/build.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
 
   package-validation:
     name: UPM Package validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       unity-version: ${{ matrix.unity-version }}
+    secrets: inherit
 
   package-validation:
     name: UPM Package validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       runsOn: ${{ matrix.host }}
 
   build:
+    secrets: inherit
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +52,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       unity-version: ${{ matrix.unity-version }}
-    secrets: inherit
+    
 
   package-validation:
     name: UPM Package validation
@@ -75,49 +76,17 @@ jobs:
 
   # This produces the `samples/IntegrationTest` as `smoke-test-${{ matrix.unity-version }}`.
   smoke-test-create:
+    secrets: inherit
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     name: ${{ matrix.unity-version }} Prepare Smoke Test
-    runs-on: ubuntu-latest
-    needs: [package-validation]
     strategy:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-    env:
-      UNITY_PATH: docker exec unity unity-editor
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
-
-      - name: Docker Login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }} 
-          password: ${{ secrets.GITHUB_TOKEN }} 
-
-      - name: Start the Unity docker container
-        run: ./scripts/ci-docker.sh '${{ matrix.unity-version }}' 'base' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
-        shell: bash
-
-      - name: Create new Project
-        run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
-      # We create tar explicitly because upload-artifact is slow for many files.
-      - name: Create archive
-        run: tar -cvzf test-project.tar.gz samples/IntegrationTest
-
-      - name: Upload project
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoke-test-${{ matrix.unity-version }}
-          if-no-files-found: error
-          path: test-project.tar.gz
-          # Lower retention period - we only need this to retry CI.
-          retention-days: 14
-
+    uses: ./.github/workflows/smoke-test-create.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
+    
   # A Linux, docker-based build to prepare a game ("player") for some platforms. The tests run in `smoke-test-run`.
   smoke-test-build:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
@@ -192,9 +161,10 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
-        uses: actions/download-artifact@v4
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
           name: ${{ github.sha }}
+          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Build without Sentry SDK
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
+      # - name: Build without Sentry SDK
+      #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
@@ -187,15 +187,6 @@ jobs:
           name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}-runtime
           if-no-files-found: error
           path: test-app-runtime.tar.gz
-          retention-days: 14
-
-      # Upload build-time initialization build
-      - name: Upload test app (build-time initialization)
-        uses: actions/upload-artifact@v4
-        with:
-          name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}-buildtime
-          if-no-files-found: error
-          path: test-app-buildtime.tar.gz
           retention-days: 14
           
       - name: Upload IntegrationTest project on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       target: ${{ matrix.target }}
       runsOn: ${{ matrix.host }}
 
-  build:
+  build-unity-sdk:
     secrets: inherit
     strategy:
       fail-fast: false
@@ -97,14 +97,11 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-        platform: ["Android", "WebGL", "Linux", "iOS"]
+        platform: ["WebGL", "Linux", "iOS"]
         include:
           - platform: iOS
             check_symbols: false
             build_platform: iOS
-          - platform: Android
-            check_symbols: false
-            build_platform: Android-Export
           - platform: WebGL
             check_symbols: true
             build_platform: WebGL
@@ -234,82 +231,38 @@ jobs:
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 
-  desktop-smoke-test:
-    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    name: ${{ matrix.unity-version }} ${{ matrix.os }} Run Smoke Test
+  android-smoke-test-build:
     needs: [smoke-test-create]
-    runs-on: ${{ matrix.os }}-latest
+    secrets: inherit
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    name: ${{ matrix.unity-version }} Build Android Smoke Test
     strategy:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-        # os: ["windows", "macos"]
-        os: ["windows"]
-        include:
-          - os: windows
-            unity-modules: windows-il2cpp
-            unity-config-path: C:/ProgramData/Unity/config/
-          # - os: macos
-          #   unity-modules: mac-il2cpp
-          #   unity-config-path: /Library/Application Support/Unity/config/
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    uses: ./.github/workflows/android-smoke-test-build.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
 
-      - name: Load env
-        id: env
-        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
-
-      - name: Setup Unity
-        uses: getsentry/setup-unity@d84ad1d1fb3020e48883c3ac8e87d64baf1135c7
-        with:
-          unity-version: ${{ steps.env.outputs.unityVersion }}
-          unity-modules: ${{ matrix.unity-modules }}
-
-      - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
-
-      - name: Create Unity license config
-        run: |
-          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
-          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
-
-      - name: Download IntegrationTest project
-        uses: actions/download-artifact@v4
-        with:
-          name: smoke-test-${{ matrix.unity-version }}
-
-      - name: Extract project archive
-        run: tar -xvzf test-project.tar.gz
-
-      - name: Build without Sentry SDK
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
-      - name: Download UPM package
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.sha }}
-
-      - name: Extract UPM package
-        run: ./test/Scripts.Integration.Test/extract-package.ps1
-
-      - name: Add Sentry to the project
-        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
-
-      - name: Configure Sentry
-        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols
-
-      - name: Build with Sentry SDK
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols -UnityVersion "${{ matrix.unity-version }}"
-
-      - name: Run Smoke Test
-        run: ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Smoke
-
-      - name: Run Crash Test
-        run: ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Crash
+  android-smoke-test-compile:
+    needs: [android-smoke-test-build]
+    secrets: inherit
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    name: ${{ matrix.unity-version }} ${{ matrix.init-type }} Compile Android Smoke Test
+    strategy:
+      fail-fast: false
+      matrix:
+        # unity-version: ["2019", "2022", "6000"]
+        unity-version: ["2019", "6000"]
+        init-type: ["runtime", "buildtime"]
+    uses: ./.github/workflows/android-smoke-test-compile.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
+      init-type: ${{ matrix.init-type }}
 
   android-smoke-test-run:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [mobile-smoke-test-compile]
+    needs: [android-smoke-test-build]
     name: ${{ matrix.unity-version }} Android ${{ matrix.api-level }} ${{ matrix.init-type }} Run Smoke Test
     uses: ./.github/workflows/android-smoke-test.yml
     with:
@@ -332,7 +285,7 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-        platform: ["Android", "iOS"]
+        platform: ["iOS"]
         init-type: ["runtime", "buildtime"]
         include:
           # See supported version in https://docs.unity3d.com/6000.0/Documentation/Manual/android-sdksetup.html
@@ -509,4 +462,77 @@ jobs:
 
       - name: Run Crash Test (Linux)
         if: ${{ matrix.platform == 'Linux' }}
+        run: ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Crash
+
+  desktop-smoke-test:
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    name: ${{ matrix.unity-version }} ${{ matrix.os }} Run Smoke Test
+    needs: [smoke-test-create]
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ["2019", "2022", "6000"]
+        # os: ["windows", "macos"]
+        os: ["windows"]
+        include:
+          - os: windows
+            unity-modules: windows-il2cpp
+            unity-config-path: C:/ProgramData/Unity/config/
+          # - os: macos
+          #   unity-modules: mac-il2cpp
+          #   unity-config-path: /Library/Application Support/Unity/config/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load env
+        id: env
+        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
+
+      - name: Setup Unity
+        uses: getsentry/setup-unity@d84ad1d1fb3020e48883c3ac8e87d64baf1135c7
+        with:
+          unity-version: ${{ steps.env.outputs.unityVersion }}
+          unity-modules: ${{ matrix.unity-modules }}
+
+      - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
+
+      - name: Create Unity license config
+        run: |
+          New-Item -Path '${{ matrix.unity-config-path }}' -ItemType Directory
+          Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+
+      - name: Download IntegrationTest project
+        uses: actions/download-artifact@v4
+        with:
+          name: smoke-test-${{ matrix.unity-version }}
+
+      - name: Extract project archive
+        run: tar -xvzf test-project.tar.gz
+
+      - name: Build without Sentry SDK
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
+      - name: Download UPM package
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.sha }}
+
+      - name: Extract UPM package
+        run: ./test/Scripts.Integration.Test/extract-package.ps1
+
+      - name: Add Sentry to the project
+        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
+
+      - name: Configure Sentry
+        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols
+
+      - name: Build with Sentry SDK
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -CheckSymbols -UnityVersion "${{ matrix.unity-version }}"
+
+      - name: Run Smoke Test
+        run: ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Smoke
+
+      - name: Run Crash Test
         run: ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Crash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,8 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-        platform: ["WebGL", "Linux", "iOS"]
+        platform: ["WebGL", "Linux"]
         include:
-          - platform: iOS
-            check_symbols: false
-            build_platform: iOS
           - platform: WebGL
             check_symbols: true
             build_platform: WebGL
@@ -192,25 +189,6 @@ jobs:
           path: test-app-runtime.tar.gz
           retention-days: 14
 
-      - name: Configure Sentry for mobile platforms (build-time initialization)
-        if: ${{ matrix.platform == 'iOS' || matrix.platform == 'Android' }}
-        run: |
-          $optionsPath = "samples/IntegrationTest/Assets/Scripts/OptionsConfiguration.cs"
-          $content = Get-Content $optionsPath -Raw
-          $content = $content -replace 'AndroidNativeInitializationType = NativeInitializationType.Runtime', 'AndroidNativeInitializationType = NativeInitializationType.BuildTime'
-          $content = $content -replace 'IosNativeInitializationType = NativeInitializationType.Runtime', 'IosNativeInitializationType = NativeInitializationType.BuildTime'
-          Set-Content $optionsPath $content
-
-      - name: Build Project for mobile platforms (build-time initialization)
-        if: ${{ matrix.platform == 'iOS' || matrix.platform == 'Android' }}
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$${{ matrix.check_symbols }} -UnityVersion "${{ matrix.unity-version }}"
-
-      - name: Create archive (build-time initialization)
-        shell: bash
-        run: |
-          rm -rf samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
-          tar -cvzf test-app-buildtime.tar.gz samples/IntegrationTest/Build
-
       # Upload build-time initialization build
       - name: Upload test app (build-time initialization)
         uses: actions/upload-artifact@v4
@@ -250,7 +228,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # unity-version: ["2019", "2022", "6000"]
         unity-version: ["2019", "6000"]
         init-type: ["runtime", "buildtime"]
     uses: ./.github/workflows/android-smoke-test-compile.yml
@@ -273,113 +250,40 @@ jobs:
         init-type: ["runtime", "buildtime"]
         unity-version: ["2019", "6000"]
 
-  mobile-smoke-test-compile:
+  ios-smoke-test-build:
+    needs: [smoke-test-create]
+    secrets: inherit
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build]
-    name: ${{ matrix.unity-version }} ${{ matrix.platform }} ${{ matrix.init-type }} Compile Smoke Test
-    runs-on: ${{ matrix.platform == 'iOS' && 'macos-latest' || 'ubuntu-latest-4-cores' }}
     strategy:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-        platform: ["iOS"]
+    uses: ./.github/workflows/ios-smoke-test-build.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
+
+  ios-smoke-test-compile:
+    needs: [ios-smoke-test-build]
+    secrets: inherit
+    if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ["2019", "2022", "6000"]
         init-type: ["runtime", "buildtime"]
-        include:
-          # See supported version in https://docs.unity3d.com/6000.0/Documentation/Manual/android-sdksetup.html
-          - unity-version: "2019"
-            ndk: "r19"
-          - unity-version: "2022"
-            ndk: "r23b"
-          - unity-version: "6000"
-            ndk: "r23b"
-            
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download app project
-        uses: actions/download-artifact@v4
-        with:
-          name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}-${{ matrix.init-type }}
-
-      - name: Extract app project
-        run: tar -xvzf test-app-${{ matrix.init-type }}.tar.gz
-
-      - name: Setup Android
-        uses: android-actions/setup-android@7c5672355aaa8fde5f97a91aa9a99616d1ace6bc # pin@v2
-        if: ${{ matrix.platform == 'Android' }}
-
-      - name: Setup NDK
-        uses: nttld/setup-ndk@8c3b609ff4d54576ea420551943fd34b4d03b0dc # pin@v1
-        if: ${{ matrix.platform == 'Android' }}
-        id: setup-ndk
-        with:
-          ndk-version: ${{ matrix.ndk }}
-          add-to-path: false
-
-      - name: Setup Java for Unity
-        if: ${{ matrix.platform == 'Android' }}
-        run: ./scripts/ci-setup-java.ps1 -UnityVersion "${{ matrix.unity-version }}"
-
-      # We modify the exported gradle project to deal with the different build-environment
-      # I.e. we're fixing the paths for SDK & NDK that have been hardcoded to point at the Unity installation 
-      - name: Modify gradle project
-        if: ${{ matrix.platform == 'Android' }}
-        run: |
-          ./test/Scripts.Integration.Test/modify-gradle-project.ps1 `
-            -AndroidSdkRoot $env:ANDROID_SDK_ROOT `
-            -NdkPath ${{ steps.setup-ndk.outputs.ndk-path }} `
-            -UnityVersion ${{ matrix.unity-version }}
-  
-      - name: Android smoke test
-        if: ${{ matrix.platform == 'Android' }}
-        # Skipping Android on Unity 2022 for now
-        run: |
-          if ("${{ matrix.unity-version }}" -ne "2022")
-          {
-            ./scripts/smoke-test-android.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}"
-          }
-        timeout-minutes: 10
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME }}
-
-      - name: iOS smoke test
-        if: ${{ matrix.platform == 'iOS' }}
-        run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${{ matrix.unity-version }}" -iOSMinVersion "16.1"
-        timeout-minutes: 10
-    
-      - name: Upload integration-test project on failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: failed-project-${{ matrix.platform }}-${{ matrix.unity-version }}-${{ matrix.init-type }}-but-compiled
-          path: |
-            samples/IntegrationTest
-            !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
-          # Lower retention period - we only need this to retry CI.
-          retention-days: 14
-
-      - name: Upload app
-        uses: actions/upload-artifact@v4
-        # Skipping Android on Unity 2022 for now
-        if: |
-          !(matrix.platform == 'Android' && matrix.unity-version == '2022') || matrix.platform == 'iOS'
-        with:
-          name: testapp-${{ matrix.platform }}-compiled-${{ matrix.unity-version }}-${{ matrix.init-type }}
-          # Collect app but ignore the files that are not required for the test.
-          path: |
-            samples/IntegrationTest/Build/*.apk
-            samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator/
-            !**/Release-iphonesimulator/*.dSYM
-            !**/Release-iphonesimulator/UnityFramework.framework/*
-          # Lower retention period - we only need this to retry CI.
-          retention-days: 14
+    uses: ./.github/workflows/ios-smoke-test-compile.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
+      init-type: ${{ matrix.init-type }}
 
   ios-smoke-test-run:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [mobile-smoke-test-compile]
-    name: ${{ matrix.unity-version }} iOS ${{ matrix.ios }} ${{ matrix.init-type }} Run Smoke Test
-    runs-on: macos-13 # Pinning to get the oldest, supported version of iOS simulator
+    needs: [ios-smoke-test-compile]
+    uses: ./.github/workflows/ios-smoke-test-run.yml
+    with:
+      unity-version: ${{ matrix.unity-version }}
+      ios-version: ${{ matrix.ios-version }}
+      init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
       matrix:
@@ -393,35 +297,8 @@ jobs:
         # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
         # Also make sure to match the versions available here:
         #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        ios: ["16.1", latest] # last updated October 2024
+        ios-version: ["16.1", latest] # last updated October 2024
         init-type: ["runtime", "buildtime"]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download app artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: testapp-iOS-compiled-${{ matrix.unity-version }}-${{ matrix.init-type }}
-          path: samples/IntegrationTest/Build
-
-      - name: Set Xcode for iOS version ${{matrix.ios}}
-        if: ${{ matrix.ios != 'latest'}}
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # pin@v1.6
-        with:
-          xcode-version: '14.1' # to run iOS 16.1 we need Xcode 14.1
-
-      - name: Smoke test
-        id: smoke-test-ios
-        timeout-minutes: 20
-        run: |
-          $runtime = "${{ matrix.ios }}"
-          If ($runtime -ne "latest")
-          {
-            $runtime = "iOS " + $runtime
-          }
-          ./Scripts/smoke-test-ios.ps1 Test "$runtime" -IsIntegrationTest
 
   smoke-test-run:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
 
   android-smoke-test-run:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [android-smoke-test-build]
+    needs: [android-smoke-test-compile]
     name: ${{ matrix.unity-version }} Android ${{ matrix.api-level }} ${{ matrix.init-type }} Run Smoke Test
     uses: ./.github/workflows/android-smoke-test.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,6 @@ jobs:
     needs: [smoke-test-create]
     secrets: inherit
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    name: ${{ matrix.unity-version }} Build Android Smoke Test
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +247,6 @@ jobs:
     needs: [android-smoke-test-build]
     secrets: inherit
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    name: ${{ matrix.unity-version }} ${{ matrix.init-type }} Compile Android Smoke Test
     strategy:
       fail-fast: false
       matrix:
@@ -263,8 +261,7 @@ jobs:
   android-smoke-test-run:
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [android-smoke-test-compile]
-    name: ${{ matrix.unity-version }} Android ${{ matrix.api-level }} ${{ matrix.init-type }} Run Smoke Test
-    uses: ./.github/workflows/android-smoke-test.yml
+    uses: ./.github/workflows/android-smoke-test-run.yml
     with:
       unity-version: ${{ matrix.unity-version }}
       api-level: ${{ matrix.api-level }}

--- a/.github/workflows/ios-smoke-test-build.yml
+++ b/.github/workflows/ios-smoke-test-build.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      # - name: Build without Sentry SDK
-      #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
-
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:

--- a/.github/workflows/ios-smoke-test-build.yml
+++ b/.github/workflows/ios-smoke-test-build.yml
@@ -4,11 +4,11 @@ on:
       unity-version:
         required: true
         type: string
-
+  
 defaults:
   run:
     shell: pwsh
-
+  
 jobs:
   build:
     name: ${{ inputs.unity-version }}
@@ -16,25 +16,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: Android
+          - platform: iOS
             check_symbols: false
-            build_platform: Android-Export
+            build_platform: iOS
     env:
       UNITY_PATH: docker exec unity unity-editor
     
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8
-        with:
-          android: true
-          dotnet: false
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: true
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -46,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Start the Unity docker container
-        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'android' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'iOS' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
         shell: bash
 
       # Workaround for missing libMonoPosixHelper.so
@@ -65,8 +55,8 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-    #   - name: Build without Sentry SDK
-    #     run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
+      # - name: Build without Sentry SDK
+      #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
@@ -98,7 +88,7 @@ jobs:
       - name: Upload test app
         uses: actions/upload-artifact@v4
         with:
-          name: testapp-android-${{ inputs.unity-version }}-runtime
+          name: testapp-ios-${{ inputs.unity-version }}-runtime
           if-no-files-found: error
           path: test-app-runtime.tar.gz
           retention-days: 14
@@ -107,7 +97,7 @@ jobs:
         run: |
           $optionsPath = "samples/IntegrationTest/Assets/Scripts/OptionsConfiguration.cs"
           $content = Get-Content $optionsPath -Raw
-          $content = $content -replace 'AndroidNativeInitializationType = NativeInitializationType.Runtime', 'AndroidNativeInitializationType = NativeInitializationType.BuildTime'
+          $content = $content -replace 'IosNativeInitializationType = NativeInitializationType.Runtime', 'IosNativeInitializationType = NativeInitializationType.BuildTime'
           Set-Content $optionsPath $content
 
       - name: Build Project for mobile platforms (build-time initialization)
@@ -123,7 +113,7 @@ jobs:
       - name: Upload test app (build-time initialization)
         uses: actions/upload-artifact@v4
         with:
-          name: testapp-android-${{ inputs.unity-version }}-buildtime
+          name: testapp-ios-${{ inputs.unity-version }}-buildtime
           if-no-files-found: error
           path: test-app-buildtime.tar.gz
           retention-days: 14
@@ -132,7 +122,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: failed-project-android-${{ inputs.unity-version }}
+          name: failed-project-ios-${{ inputs.unity-version }}
           path: |
             samples/IntegrationTest
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame

--- a/.github/workflows/ios-smoke-test-compile.yml
+++ b/.github/workflows/ios-smoke-test-compile.yml
@@ -44,6 +44,10 @@ jobs:
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 
+      - name: List downloaded files
+        run: |
+          Get-ChildItem -Path "samples/IntegrationTest/Build" -Recurse
+          
       - name: Upload app
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ios-smoke-test-compile.yml
+++ b/.github/workflows/ios-smoke-test-compile.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_call:
+    inputs:
+      unity-version:
+        required: true
+        type: string
+      init-type:
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  compile:
+    name: ${{ inputs.unity-version }} ${{ inputs.init-type }}
+    runs-on: 'macos-latest'
+            
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download app project
+        uses: actions/download-artifact@v4
+        with:
+          name: testapp-ios-${{ inputs.unity-version }}-${{ inputs.init-type }}
+
+      - name: Extract app project
+        run: tar -xvzf test-app-${{ inputs.init-type }}.tar.gz
+
+      - name: iOS smoke test
+        run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${{ inputs.unity-version }}" -iOSMinVersion "16.1"
+        timeout-minutes: 10
+    
+      - name: Upload integration-test project on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-project-ios-${{ inputs.unity-version }}-${{ inputs.init-type }}-compiled
+          path: |
+            samples/IntegrationTest
+            !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
+          # Lower retention period - we only need this to retry CI.
+          retention-days: 14
+
+      - name: Upload app
+        uses: actions/upload-artifact@v4
+        with:
+          name: testapp-ios-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
+          # Collect app but ignore the files that are not required for the test.
+          path: |
+            samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator/
+            !**/Release-iphonesimulator/*.dSYM
+            !**/Release-iphonesimulator/UnityFramework.framework/*
+          # Lower retention period - we only need this to retry CI.
+          retention-days: 14

--- a/.github/workflows/ios-smoke-test-run.yml
+++ b/.github/workflows/ios-smoke-test-run.yml
@@ -1,0 +1,56 @@
+on:
+  workflow_call:
+    inputs:
+      unity-version:
+        required: true
+        type: string
+      ios-version:
+        required: true
+        type: string
+      init-type:
+        required: true
+        type: string
+    # Map the workflow outputs to job outputs
+    outputs:
+      status:
+        description: "Smoke test status"
+        value: ${{ jobs.run.outputs.status }}
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  run:
+    name: ${{ inputs.unity-version }} ${{ inputs.init-type }}
+    runs-on: macos-13 # Pinning to get the oldest, supported version of iOS simulator
+    # Map the job outputs to step outputs
+    outputs:
+      status: ${{ steps.smoke-test.outputs.status }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: testapp-iOS-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
+          path: samples/IntegrationTest/Build
+
+      - name: Set Xcode for iOS version ${{ inputs.ios-version }}
+        if: ${{ inputs.ios-version != 'latest'}}
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # pin@v1.6
+        with:
+          xcode-version: '14.1' # to run iOS 16.1 we need Xcode 14.1
+
+      - name: Run iOS Smoke Tests
+        id: smoke-test
+        timeout-minutes: 20
+        run: |
+          $runtime = "${{ inputs.ios-version }}"
+          If ($runtime -ne "latest")
+          {
+            $runtime = "iOS " + $runtime
+          }
+          ./Scripts/smoke-test-ios.ps1 Test "$runtime" -IsIntegrationTest

--- a/.github/workflows/ios-smoke-test-run.yml
+++ b/.github/workflows/ios-smoke-test-run.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Download app artifact
         uses: actions/download-artifact@v4
         with:
-          name: testapp-iOS-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
+          name: testapp-ios-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           path: samples/IntegrationTest/Build
 
       - name: Set Xcode for iOS version ${{ inputs.ios-version }}

--- a/.github/workflows/ios-smoke-test-run.yml
+++ b/.github/workflows/ios-smoke-test-run.yml
@@ -38,6 +38,10 @@ jobs:
           name: testapp-ios-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           path: samples/IntegrationTest/Build
 
+      - name: List downloaded files
+        run: |
+          Get-ChildItem -Path "samples/IntegrationTest/Build" -Recurse
+
       - name: Set Xcode for iOS version ${{ inputs.ios-version }}
         if: ${{ inputs.ios-version != 'latest'}}
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # pin@v1.6

--- a/.github/workflows/smoke-test-create.yml
+++ b/.github/workflows/smoke-test-create.yml
@@ -1,0 +1,50 @@
+name: Create Smoke Test Project
+
+on:
+  workflow_call:
+    inputs:
+      unity-version:
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  create:
+    name: Create Smoke Test - ${{ inputs.unity-version }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
+
+    - name: Docker Login
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }} 
+        password: ${{ secrets.GITHUB_TOKEN }} 
+
+    - name: Start the Unity docker container
+      run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'base' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+      shell: bash
+
+    - name: Create new Project
+      run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "docker exec unity unity-editor"
+
+    # We create tar explicitly because upload-artifact is slow for many files.
+    - name: Create archive
+      run: tar -cvzf test-project.tar.gz samples/IntegrationTest
+
+    - name: Upload project
+      uses: actions/upload-artifact@v4
+      with:
+        name: smoke-test-${{ inputs.unity-version }}
+        if-no-files-found: error
+        path: test-project.tar.gz
+        # Lower retention period - we only need this to retry CI.
+        retention-days: 14 
+            

--- a/.github/workflows/smoke-test-create.yml
+++ b/.github/workflows/smoke-test-create.yml
@@ -15,6 +15,9 @@ jobs:
   create:
     name: Create Smoke Test - ${{ inputs.unity-version }}
     runs-on: ubuntu-latest
+    env:
+      UNITY_PATH: docker exec unity unity-editor
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -33,7 +36,7 @@ jobs:
       shell: bash
 
     - name: Create new Project
-      run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "docker exec unity unity-editor"
+      run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
     # We create tar explicitly because upload-artifact is slow for many files.
     - name: Create archive
@@ -47,4 +50,8 @@ jobs:
         path: test-project.tar.gz
         # Lower retention period - we only need this to retry CI.
         retention-days: 14 
+
+    # TODO: Can we build without Sentry SDK for all platforms here? The rest of the CI run waits for the SDK build to finish anyway
+    # - name: Build without Sentry SDK
+    #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
             

--- a/.github/workflows/smoke-test-create.yml
+++ b/.github/workflows/smoke-test-create.yml
@@ -50,8 +50,3 @@ jobs:
         path: test-project.tar.gz
         # Lower retention period - we only need this to retry CI.
         retention-days: 14 
-
-    # TODO: Can we build without Sentry SDK for all platforms here? The rest of the CI run waits for the SDK build to finish anyway
-    # - name: Build without Sentry SDK
-    #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
-            

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -21,7 +21,7 @@ Write-Host "Args received Action=$Action, SelectedRuntime=$SelectedRuntime, IsIn
 $ProjectName = "Unity-iPhone"
 $XcodeArtifactPath = "samples/IntegrationTest/Build"
 $ArchivePath = "$XcodeArtifactPath/archive"
-$AppPath = "$ArchivePath/$ProjectName/Build/IntegrationTest.app"
+$AppPath = "$XcodeArtifactPath/IntegrationTest.app"
 $AppName = "com.DefaultCompany.IntegrationTest"
 
 Class AppleDevice

--- a/scripts/smoke-test-ios.ps1
+++ b/scripts/smoke-test-ios.ps1
@@ -21,7 +21,7 @@ Write-Host "Args received Action=$Action, SelectedRuntime=$SelectedRuntime, IsIn
 $ProjectName = "Unity-iPhone"
 $XcodeArtifactPath = "samples/IntegrationTest/Build"
 $ArchivePath = "$XcodeArtifactPath/archive"
-$AppPath = "$ArchivePath/$ProjectName/Build/Products/Release-iphonesimulator/IntegrationTest.app"
+$AppPath = "$ArchivePath/$ProjectName/Build/IntegrationTest.app"
 $AppName = "com.DefaultCompany.IntegrationTest"
 
 Class AppleDevice


### PR DESCRIPTION
Addresses the first part of https://github.com/getsentry/sentry-unity/issues/1975

This separates the jobs that were targeting multiple platforms into individual workflows, responsible for a singular purpose. I.e. 
1. `platform-smoke-test-build`
2. `platform-smoke-test-compile`
3. `platform-smoke-test-run`

The restructuring of jobs also netted a nice speed increase from `55` down to about `30` minutes.
I.e. 
- Creating the empty smoke test project right from the beginning
- Having the job that installs the sentry package go through all of the setup required and then only wait for the UPM to be available to download while the SDK is building.

#skip-changelog