### PR TITLE
fix: Android debug symbol upload logging

### DIFF
--- a/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
+++ b/src/Sentry.Unity.Editor/Android/DebugSymbolUpload.cs
@@ -46,39 +46,23 @@ internal class DebugSymbolUpload
             stringBuilder.AppendLine("afterEvaluate {");
             stringBuilder.AppendLine("task sentryUploadSymbols {");
             stringBuilder.AppendLine("    doLast {");
-            if (_isExporting)
+            stringBuilder.AppendLine("        println 'Uploading symbols to Sentry.'");
+
+            if (!_isExporting && _ignoreCliErrors)
             {
-                stringBuilder.AppendLine("        println 'Uploading symbols to Sentry.'");
-            }
-            else
-            {
-                var logsDir = $"{ConvertSlashes(_unityProjectPath)}/Logs";
-                Directory.CreateDirectory(logsDir);
-                stringBuilder.AppendLine("        println 'Uploading symbols to Sentry. You can find the full log in ./Logs/sentry-symbols-upload.log (the file content may not be strictly sequential because it\\'s a merge of two streams).'");
-                stringBuilder.AppendLine($"        def logFilePath = '{logsDir}/{SymbolUploadLogName}'");
-                stringBuilder.AppendLine("        def sentryLogFile = new FileOutputStream(logFilePath)");
-                if (_ignoreCliErrors)
-                {
-                    stringBuilder.AppendLine("        try {");
-                }
+                stringBuilder.AppendLine("        try {");
             }
 
             stringBuilder.AppendLine("        exec {");
             stringBuilder.AppendLine("            environment 'SENTRY_PROPERTIES', './sentry.properties'");
             stringBuilder.AppendLine($"            executable '{SentryCliMarker}'");
             stringBuilder.AppendLine($"            args = ['debug-files', 'upload'{UploadArgsMarker}]");
-            if (!_isExporting)
-            {
-                stringBuilder.AppendLine("            standardOutput sentryLogFile");
-                stringBuilder.AppendLine("            errorOutput sentryLogFile");
-            }
-
             stringBuilder.AppendLine("        }");
+
             if (!_isExporting && _ignoreCliErrors)
             {
                 stringBuilder.AppendLine("        } catch (exception) {");
-                stringBuilder.AppendLine("            def file = new File(logFilePath)");
-                stringBuilder.AppendLine("            file.append('===ERROR===' + exception)");
+                stringBuilder.AppendLine("            println '===ERROR===' + exception");
                 stringBuilder.AppendLine("        }");
             }
             CheckMapping(stringBuilder);


### PR DESCRIPTION
Working on improving CI had me scratch my head where the logs went. 

Initially, we had the idea of having them in their own separate logfile to be available for troubleshooting but I don't see the use for special handling that part of the build process anymore.