### PR TITLE
feat: Propagate `--allow-failure` to all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- The `Ignore CLI Errors` checkbox in the Debug Symbols tab now applies to all supported platforms. ([#2008](https://github.com/getsentry/sentry-unity/pull/2008))
 - The SDK now provides stacktraces when capturing events created via `Debug.LogError`. Note, that the SDK is currently not able to provide line numbers for these events. ([#1965](https://github.com/getsentry/sentry-unity/pull/1965))
 
 ### Fixes

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -169,6 +169,12 @@ echo ""Uploading debug symbols and bcsymbolmaps.""
         {
             uploadDifArguments += " --include-sources";
         }
+
+        if (sentryCliOptions.IgnoreCliErrors)
+        {
+            uploadDifArguments += " --allow-failure";
+        }
+
         var uploadScript = string.Format(_uploadScript, SentryCli.SentryCliMacOS, uploadDifArguments);
 
         _pbxProjectType.GetMethod("AddShellScriptBuildPhase", new[] { typeof(string), typeof(string), typeof(string), typeof(string) })

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -212,6 +212,10 @@ public static class BuildPostProcess
         {
             cliArgs += "--include-sources ";
         }
+        if (cliOptions.IgnoreCliErrors)
+        {
+            cliArgs += "--allow-failure";
+        }
         cliArgs += paths;
 
         // Configure the process using the StartInfo properties.


### PR DESCRIPTION
Previously, this was only applying to Android.