### PR TITLE
Feat: Adds an option to disable capturing Debug.LogError as events

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/EnrichmentTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/EnrichmentTab.cs
@@ -63,6 +63,10 @@ internal static class EnrichmentTab
         EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
         EditorGUILayout.Space();
 
+        options.CaptureLogErrorEvents = EditorGUILayout.Toggle(
+            new GUIContent("Capture LogError as Event", "Whether the SDK automatically captures events for 'Debug.LogError'."),
+            options.CaptureLogErrorEvents);
+
         GUILayout.Label("Breadcrumbs automatically added for LogType:", EditorStyles.boldLabel);
 
         options.BreadcrumbsForLogs = EditorGUILayout.Toggle(

--- a/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
@@ -70,7 +70,7 @@ internal class UnityApplicationLoggingIntegration : ISdkIntegration
             }
         }
 
-        if (logType is LogType.Error)
+        if (logType is LogType.Error && _options?.CaptureLogErrorEvents is true)
         {
             if (_options?.AttachStacktrace is true && !string.IsNullOrEmpty(stacktrace))
             {

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -63,6 +63,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
     [field: SerializeField] public bool BreadcrumbsForAsserts { get; set; } = true;
     [field: SerializeField] public bool BreadcrumbsForErrors { get; set; } = true;
     [field: SerializeField] public bool BreadcrumbsForExceptions { get; set; } = true;
+    [field: SerializeField] public bool CaptureLogErrorEvents { get; set; } = true;
 
     [field: SerializeField] public int MaxBreadcrumbs { get; set; } = SentryConstants.DefaultMaxBreadcrumbs;
 
@@ -169,6 +170,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
             // need to set it here directly.
             Debug = ShouldDebug(application.IsEditor && !isBuilding),
             DiagnosticLevel = DiagnosticLevel,
+            CaptureLogErrorEvents = CaptureLogErrorEvents,
             AnrTimeout = TimeSpan.FromMilliseconds(AnrTimeout),
             CaptureFailedRequests = CaptureFailedRequests,
             FilterBadGatewayExceptions = FilterBadGatewayExceptions,

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -130,6 +130,11 @@ public sealed class SentryUnityOptions : SentryOptions
     public int ScreenshotCompression { get; set; } = 75;
 
     /// <summary>
+    /// Whether the SDK automatically captures events for 'Debug.LogError'.
+    /// </summary>
+    public bool CaptureLogErrorEvents { get; set; } = true;
+
+    /// <summary>
     /// Whether the SDK should automatically add breadcrumbs per LogType
     /// </summary>
     public Dictionary<LogType, bool> AddBreadcrumbsForLogType { get; set; }


### PR DESCRIPTION
Currently, the SDK captures any logs sent with `Debug.LogError` as an event. There are some ways to mitigate this, such as by using a `BeforeSend` callback, but the filtering risks over (or under) filtration, and isn't completely clear on how to accomplish this. 

Since there are already options to enable/disable breadcrumb capturing, I've added one to enable/disable the functionality for events too. 