### PR TITLE
chore: Changelog and tests for `Debug.LogError` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Added option to enable/disable automatic capture of `Debug.LogError` as event. ([#2009](https://github.com/getsentry/sentry-unity/pull/2009))
 - The `Ignore CLI Errors` checkbox in the Debug Symbols tab now applies to all supported platforms. ([#2008](https://github.com/getsentry/sentry-unity/pull/2008))
 - The SDK now provides stacktraces when capturing events created via `Debug.LogError`. Note, that the SDK is currently not able to provide line numbers for these events. ([#1965](https://github.com/getsentry/sentry-unity/pull/1965))
 

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/EnrichmentTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/EnrichmentTab.cs
@@ -63,26 +63,31 @@ internal static class EnrichmentTab
         EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
         EditorGUILayout.Space();
 
+        GUILayout.Label("Automatically capture and send events for:", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
+
         options.CaptureLogErrorEvents = EditorGUILayout.Toggle(
-            new GUIContent("Capture LogError as Event", "Whether the SDK automatically captures events for 'Debug.LogError'."),
+            new GUIContent("Debug.LogError", "Whether the SDK automatically captures events for 'Debug.LogError'."),
             options.CaptureLogErrorEvents);
 
-        GUILayout.Label("Breadcrumbs automatically added for LogType:", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
+        GUILayout.Label("Automatically create breadcrumbs for:", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
 
         options.BreadcrumbsForLogs = EditorGUILayout.Toggle(
-            new GUIContent("Log", "Whether the SDK automatically adds breadcrumbs 'Debug.Log'."),
+            new GUIContent("Debug.Log", "Whether the SDK automatically adds breadcrumbs 'Debug.Log'."),
             options.BreadcrumbsForLogs);
         options.BreadcrumbsForWarnings = EditorGUILayout.Toggle(
-            new GUIContent("Warning", "Whether the SDK automatically adds breadcrumbs for 'Debug.LogWarning'."),
+            new GUIContent("Debug.Warning", "Whether the SDK automatically adds breadcrumbs for 'Debug.LogWarning'."),
             options.BreadcrumbsForWarnings);
         options.BreadcrumbsForAsserts = EditorGUILayout.Toggle(
-            new GUIContent("Assert", "Whether the SDK automatically adds breadcrumbs for 'Debug.Assert'."),
+            new GUIContent("Debug.Assert", "Whether the SDK automatically adds breadcrumbs for 'Debug.Assert'."),
             options.BreadcrumbsForAsserts);
         options.BreadcrumbsForErrors = EditorGUILayout.Toggle(
-            new GUIContent("Error", "Whether the SDK automatically adds breadcrumbs for 'Debug.LogError'."),
+            new GUIContent("Debug.Error", "Whether the SDK automatically adds breadcrumbs for 'Debug.LogError'."),
             options.BreadcrumbsForErrors);
         options.BreadcrumbsForExceptions = EditorGUILayout.Toggle(
-            new GUIContent("Exception", "Whether the SDK automatically adds breadcrumbs for exceptions and 'Debug.LogException'."),
+            new GUIContent("Debug.Exception", "Whether the SDK automatically adds breadcrumbs for exceptions and 'Debug.LogException'."),
             options.BreadcrumbsForExceptions);
 
         EditorGUILayout.Space();

--- a/test/Sentry.Unity.Tests/UnityApplicationLoggingIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/UnityApplicationLoggingIntegrationTests.cs
@@ -46,16 +46,26 @@ namespace Sentry.Unity.Tests
         }
 
         [Test]
-        public void OnLogMessageReceived_LogTypeError_CaptureEvent()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OnLogMessageReceived_LogTypeError_CaptureEvent(bool captureLogErrorEvents)
         {
+            _fixture.SentryOptions.CaptureLogErrorEvents = captureLogErrorEvents;
             var sut = _fixture.GetSut();
             var message = TestContext.CurrentContext.Test.Name;
 
             sut.OnLogMessageReceived(message, string.Empty, LogType.Error);
 
-            Assert.AreEqual(1, _fixture.Hub.CapturedEvents.Count);
-            Assert.NotNull(_fixture.Hub.CapturedEvents[0].Message);
-            Assert.AreEqual(message, _fixture.Hub.CapturedEvents[0].Message!.Message);
+            if (captureLogErrorEvents)
+            {
+                Assert.AreEqual(1, _fixture.Hub.CapturedEvents.Count);
+                Assert.NotNull(_fixture.Hub.CapturedEvents[0].Message);
+                Assert.AreEqual(message, _fixture.Hub.CapturedEvents[0].Message!.Message);
+            }
+            else
+            {
+                Assert.AreEqual(0, _fixture.Hub.CapturedEvents.Count);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Followup for https://github.com/getsentry/sentry-unity/pull/2009
- Facelifted for the presentation on the Enrichment tab
- Added changelog entry
- Updated test

![Screenshot 2025-02-10 at 15 47 40](https://github.com/user-attachments/assets/ab28d49b-2a40-452a-ad67-3705e1d77b2c)

#skip-changelog