### PR TITLE
Add debug symbol uploads for Win32 and MacOS Mono builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - The SDK's build logs when targeting Android are not a lot less noisy. The SDK will also no longer omit the sentry-cli logs from the gradle build output. ([#1995](https://github.com/getsentry/sentry-unity/pull/1995))
 - When targeting iOS and disabling native support, the SDK no longer causes builds to fail with an `Undefined symbol: _SentryNativeBridgeIsEnabled` error. ([#1983](https://github.com/getsentry/sentry-unity/pull/1983))
-- The SDK will no longer skip uploading debugging symbols if native support isn't enabled for a build. ([#2021](https://github.com/getsentry/sentry-unity/pull/2021))
+- The SDK will now upload debugging symbols without native support being enabled, and uploads debugging files for MacOS mono builds. ([#2021](https://github.com/getsentry/sentry-unity/pull/2021))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - The SDK's build logs when targeting Android are not a lot less noisy. The SDK will also no longer omit the sentry-cli logs from the gradle build output. ([#1995](https://github.com/getsentry/sentry-unity/pull/1995))
 - When targeting iOS and disabling native support, the SDK no longer causes builds to fail with an `Undefined symbol: _SentryNativeBridgeIsEnabled` error. ([#1983](https://github.com/getsentry/sentry-unity/pull/1983))
+- The SDK will no longer skip uploading debugging symbols if native support isn't enabled for a build. ([#2021](https://github.com/getsentry/sentry-unity/pull/2021))
 
 ### Dependencies
 

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -147,6 +147,7 @@ public static class BuildPostProcess
 
         switch (target)
         {
+            case BuildTarget.StandaloneWindows:
             case BuildTarget.StandaloneWindows64:
                 addPath("UnityPlayer.dll");
                 addPath(Path.GetFileNameWithoutExtension(executableName) + "_Data/Plugins/x86_64/sentry.dll");
@@ -196,7 +197,17 @@ public static class BuildPostProcess
                 addPath(Path.GetFullPath($"Packages/{SentryPackageInfo.GetName()}/Plugins/macOS/Sentry/Sentry.dylib.dSYM"));
 
                 if (isMono)
-                { }
+                { 
+                    addFilesMatching(buildOutputDir, new[] { "*.pdb" });
+
+                    // Unity stores the .pdb files in './Library/ScriptAssemblies/' and starting with 2020 in
+                    // './Temp/ManagedSymbols/'. We want the one in 'Temp/ManagedSymbols/' specifically.
+                    var managedSymbolsDirectory = $"{projectDir}/Temp/ManagedSymbols";
+                    if (Directory.Exists(managedSymbolsDirectory))
+                    {
+                        addFilesMatching(managedSymbolsDirectory, new[] { "*.pdb" });
+                    }
+                }
                 else // IL2CPP
                 {
                     addPath(Path.GetFileNameWithoutExtension(executableName) + "_BackUpThisFolder_ButDontShipItWithYourGame");

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -29,6 +29,9 @@ public static class BuildPostProcess
         var isMono = PlayerSettings.GetScriptingBackend(targetGroup) == ScriptingImplementation.Mono2x;
 #pragma warning restore CS0618
 
+        var buildOutputDir = Path.GetDirectoryName(executablePath);
+        var executableName = Path.GetFileName(executablePath);
+
         try
         {
             if (options is null)
@@ -52,15 +55,16 @@ public static class BuildPostProcess
 
             logger.LogDebug("Adding native support.");
 
-            var buildOutputDir = Path.GetDirectoryName(executablePath);
-            var executableName = Path.GetFileName(executablePath);
             AddCrashHandler(logger, target, buildOutputDir, executableName);
-            UploadDebugSymbols(logger, target, buildOutputDir, executableName, options, cliOptions, isMono);
         }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to add the Sentry native integration to the built application");
             throw new BuildFailedException("Sentry Native BuildPostProcess failed");
+        }
+        finally
+        {
+            UploadDebugSymbols(logger, target, buildOutputDir, executableName, options, cliOptions, isMono);
         }
     }
 


### PR DESCRIPTION
Moves the debug symbols upload into a `finally` so it's done regardless of what happens with the native support handling.

Also adds cases to upload win32 debug files and the `*.pdb` files from MacOS Mono builds.