### PR TITLE
fix: Desktop symbol upload

### DIFF
--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -62,7 +62,6 @@ public static class BuildPostProcess
 
         try
         {
-            logger.LogDebug("Adding the crash-handler.");
             AddCrashHandler(logger, target, buildOutputDir, executableName);
         }
         catch (Exception e)
@@ -87,6 +86,7 @@ public static class BuildPostProcess
         {
             case BuildTarget.StandaloneWindows:
             case BuildTarget.StandaloneWindows64:
+                logger.LogDebug("Adding crashpad.");
                 CopyHandler(logger, buildOutputDir, Path.Combine("Windows", "Sentry", "crashpad_handler.exe"));
                 CopyHandler(logger, buildOutputDir, Path.Combine("Windows", "Sentry", "crashpad_wer.dll"));
                 break;

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -71,7 +71,7 @@ public static class BuildPostProcess
         }
         finally
         {
-            // We always want to end up with the debug symbols being uploadde
+            // We always want to end up with the debug symbols being uploaded
             UploadDebugSymbols(logger, target, buildOutputDir, executableName, options, cliOptions, isMono);
         }
     }

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -69,8 +69,11 @@ public static class BuildPostProcess
             logger.LogError(e, "Failed to add the Sentry native integration to the built application");
             throw new BuildFailedException("Sentry Native BuildPostProcess failed");
         }
-
-        UploadDebugSymbols(logger, target, buildOutputDir, executableName, options, cliOptions, isMono);
+        finally
+        {
+            // We always want to end up with the debug symbols being uploadde
+            UploadDebugSymbols(logger, target, buildOutputDir, executableName, options, cliOptions, isMono);
+        }
     }
 
     private static bool IsEnabledForPlatform(BuildTarget target, SentryUnityOptions options) => target switch


### PR DESCRIPTION
Followup on https://github.com/getsentry/sentry-unity/pull/2021

In this PR I
- Moved option validation outside of `try-catch` block to bail early
- Symbol upload now happens regardless of native-support settings - to provide line numbers
- Improved logging

#skip-changelog