### PR TITLE
fix: Overwrite Android SDK during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- The SDK now ensures that the correct version of the Android SDK gets used during the build. This prevents dependency conflicts and no longer requires "clean" builds to resolve ([#2031](https://github.com/getsentry/sentry-unity/pull/2031))
+
 ## 3.0.1
 
 ### Fixes

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -236,8 +236,7 @@ public class AndroidManifestConfiguration
                 var fileName = Path.GetFileName(file);
                 _logger.LogDebug("Copying '{0}'", fileName);
 
-                var destinationFile = Path.Combine(targetPath, fileName);
-                File.Copy(file, destinationFile, overwrite: true);
+                File.Copy(file, Path.Combine(targetPath, fileName), overwrite: true);
             }
         }
         else

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -228,13 +228,22 @@ public class AndroidManifestConfiguration
                 throw new DirectoryNotFoundException($"Failed to find the Android SDK at '{androidSdkPath}'.");
             }
 
+            Directory.CreateDirectory(targetPath);
+
             _logger.LogInfo("Copying the Android SDK to '{0}'.", gradlePath);
             foreach (var file in Directory.GetFiles(androidSdkPath))
             {
                 var destinationFile = Path.Combine(targetPath, Path.GetFileName(file));
-                if (!File.Exists(destinationFile))
+                
+                try 
                 {
-                    File.Copy(file, destinationFile);
+                    File.Copy(file, destinationFile, overwrite: true);
+                    _logger.LogDebug("Copied SDK file: {0}", Path.GetFileName(file));
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to copy SDK file: {0}", Path.GetFileName(file));
+                    throw;
                 }
             }
         }

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -231,12 +231,13 @@ public class AndroidManifestConfiguration
             Directory.CreateDirectory(targetPath);
 
             _logger.LogInfo("Copying the Android SDK to '{0}'.", gradlePath);
-            foreach (var file in Directory.GetFiles(androidSdkPath))
+            foreach (var sourceFileName in Directory.GetFiles(androidSdkPath))
             {
-                var fileName = Path.GetFileName(file);
-                _logger.LogDebug("Copying '{0}'", fileName);
+                var fileName = Path.GetFileName(sourceFileName);
+                var destFileName = Path.Combine(targetPath, fileName);
+                _logger.LogDebug("Copying '{0}' to '{1}'", fileName, destFileName);
 
-                File.Copy(file, Path.Combine(targetPath, fileName), overwrite: true);
+                File.Copy(sourceFileName, destFileName, overwrite: true);
             }
         }
         else

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -233,18 +233,11 @@ public class AndroidManifestConfiguration
             _logger.LogInfo("Copying the Android SDK to '{0}'.", gradlePath);
             foreach (var file in Directory.GetFiles(androidSdkPath))
             {
-                var destinationFile = Path.Combine(targetPath, Path.GetFileName(file));
-                
-                try 
-                {
-                    File.Copy(file, destinationFile, overwrite: true);
-                    _logger.LogDebug("Copied SDK file: {0}", Path.GetFileName(file));
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(e, "Failed to copy SDK file: {0}", Path.GetFileName(file));
-                    throw;
-                }
+                var fileName = Path.GetFileName(file);
+                _logger.LogDebug("Copying '{0}'", fileName);
+
+                var destinationFile = Path.Combine(targetPath, fileName);
+                File.Copy(file, destinationFile, overwrite: true);
             }
         }
         else

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -421,6 +421,28 @@ public class AndroidManifestTests
         Directory.Delete(fakeProjectPath, true);
     }
 
+    [Test]
+    public void CopyAndroidSdkToGradleProject_SdkAlreadyExists_OverwritesExistingSdk()
+    {
+        var fakeProjectPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var unityProjectPath = Path.Combine(fakeProjectPath, "UnityProject");
+        var gradleProjectPath = Path.Combine(fakeProjectPath, "GradleProject");
+        DebugSymbolUploadTests.SetupFakeProject(fakeProjectPath);
+
+        var targetPath = Path.Combine(gradleProjectPath, "unityLibrary", "libs");
+        Directory.CreateDirectory(targetPath);
+        var existingFile = Path.Combine(targetPath, "androidSdk.jar");
+        File.WriteAllText(existingFile, "original content");
+
+        var sut = _fixture.GetSut();
+        sut.CopyAndroidSdkToGradleProject(unityProjectPath, gradleProjectPath);
+
+        var newContent = File.ReadAllBytes(existingFile);
+        Assert.AreNotEqual("original content", System.Text.Encoding.UTF8.GetString(newContent));
+
+        Directory.Delete(fakeProjectPath, true);
+    }
+
     private string WithAndroidManifest(Action<string> callback)
     {
         var basePath = GetFakeManifestFileBasePath();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1847

These changes make sure that the SDK now overwrites the Android SDK in the generated gradle project - if already present.