### PR TITLE
feat: Added `GetLastRunState` to the SentryUnity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added `SentryUnity.CrashedLastRun()`. This allows you to check whether the SDK captured a crash the last time the game ran. ([#2049](https://github.com/getsentry/sentry-unity/pull/2049))
+
 ### Fixes
 
 - Fixed a potential race condition in the ANR watchdog integration ([2045](https://github.com/getsentry/sentry-unity/pull/2045))

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -52,7 +52,7 @@ public static class SentryUnity
     /// Represents the crash state of the games's previous run.
     /// Used to determine if the last execution terminated normally or crashed.
     /// </summary>
-    public enum LastRunState
+    public enum CrashedLastRun
     {
         /// <summary>
         /// The LastRunState is unknown. This might be due to the SDK not being initialized, native crash support
@@ -75,14 +75,14 @@ public static class SentryUnity
     /// Retrieves the crash state of the previous application run.
     /// This indicates whether the application terminated normally or crashed.
     /// </summary>
-    /// <returns><see cref="LastRunState"/> indicating the state of the previous run.</returns>
-    public static LastRunState GetLastRunState()
+    /// <returns><see cref="CrashedLastRun"/> indicating the state of the previous run.</returns>
+    public static CrashedLastRun GetLastRunState()
     {
         if (UnitySdk is null)
         {
-            return LastRunState.Unknown;
+            return CrashedLastRun.Unknown;
         }
 
-        return UnitySdk.GetLastRunState();
+        return UnitySdk.CrashedLastRun();
     }
 }

--- a/src/Sentry.Unity/SentryUnity.cs
+++ b/src/Sentry.Unity/SentryUnity.cs
@@ -47,4 +47,42 @@ public static class SentryUnity
         UnitySdk?.Close();
         UnitySdk = null;
     }
+
+    /// <summary>
+    /// Represents the crash state of the games's previous run.
+    /// Used to determine if the last execution terminated normally or crashed.
+    /// </summary>
+    public enum LastRunState
+    {
+        /// <summary>
+        /// The LastRunState is unknown. This might be due to the SDK not being initialized, native crash support
+        /// missing, or being disabled.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// The application did not crash during the last run.
+        /// </summary>
+        DidNotCrash,
+
+        /// <summary>
+        /// The application crashed during the last run.
+        /// </summary>
+        Crashed
+    }
+
+    /// <summary>
+    /// Retrieves the crash state of the previous application run.
+    /// This indicates whether the application terminated normally or crashed.
+    /// </summary>
+    /// <returns><see cref="LastRunState"/> indicating the state of the previous run.</returns>
+    public static LastRunState GetLastRunState()
+    {
+        if (UnitySdk is null)
+        {
+            return LastRunState.Unknown;
+        }
+
+        return UnitySdk.GetLastRunState();
+    }
 }

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Unity.Integrations;
@@ -98,5 +99,19 @@ internal class SentryUnitySdk
             _options.DiagnosticLogger?.Log(SentryLevel.Warning,
                 "Exception while releasing the lockfile on the config directory.", ex);
         }
+    }
+
+    public SentryUnity.LastRunState GetLastRunState()
+    {
+        if (_options.CrashedLastRun is null)
+        {
+            _options.DiagnosticLogger?.LogDebug("The SDK does not have a 'CrashedLastRun' set. " +
+                                                "This might be due to a missing or disabled native integration.");
+            return SentryUnity.LastRunState.Unknown;
+        }
+
+        return _options.CrashedLastRun.Invoke()
+            ? SentryUnity.LastRunState.Crashed
+            : SentryUnity.LastRunState.DidNotCrash;
     }
 }

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -100,17 +100,17 @@ internal class SentryUnitySdk
         }
     }
 
-    public SentryUnity.LastRunState GetLastRunState()
+    public SentryUnity.CrashedLastRun CrashedLastRun()
     {
         if (_options.CrashedLastRun is null)
         {
             _options.DiagnosticLogger?.LogDebug("The SDK does not have a 'CrashedLastRun' set. " +
                                                 "This might be due to a missing or disabled native integration.");
-            return SentryUnity.LastRunState.Unknown;
+            return SentryUnity.CrashedLastRun.Unknown;
         }
 
         return _options.CrashedLastRun.Invoke()
-            ? SentryUnity.LastRunState.Crashed
-            : SentryUnity.LastRunState.DidNotCrash;
+            ? SentryUnity.CrashedLastRun.Crashed
+            : SentryUnity.CrashedLastRun.DidNotCrash;
     }
 }


### PR DESCRIPTION
This PR adds a method `GetLastRunState` to the SentryUnity API to allow users to access whether the SDK detects a crash in the game's previous run.

Sample-Usage:
```
public class CrashDetector : MonoBehaviour
{
    void Start()
    {
        // This assumes that the SDK is already initialized. 
        // The SDK has already set up the native scope sync - it will return `Unknown` otherwise
        var lastRunState = SentryUnity.CrashedLastRun();

        switch (lastRunState)
        {
            case SentryUnity.LastRunState.Crashed:
                Debug.Log("The application crashed during the previous run");
                // Perform recovery actions or show user message.
                break;
                
            case SentryUnity.LastRunState.DidNotCrash:
                Debug.Log("The previous run terminated normally");
                break;
                
            case SentryUnity.LastRunState.Unknown:
                // The SDK was either not initialized or does not have access to the native layer
                Debug.Log("Could not determine the state of the previous run");
                break;
        }
    }
}
```