### PR TITLE
Fix/android logging

### DIFF
--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -70,7 +70,7 @@ public static class SentryNativeAndroid
         options.EnableScopeSync = true;
         options.CrashedLastRun = () =>
         {
-            options.DiagnosticLogger?.LogDebug("Checking for `CrashedLastRun`");
+            options.DiagnosticLogger?.LogDebug("Checking for 'CrashedLastRun'");
 
             var crashedLastRun = SentryJava.CrashedLastRun(JniExecutor);
             if (crashedLastRun is null)
@@ -83,8 +83,7 @@ public static class SentryNativeAndroid
             }
             else
             {
-                options.DiagnosticLogger?
-                    .LogDebug("Native Android SDK reported: 'crashedLastRun': '{0}'", crashedLastRun);
+                options.DiagnosticLogger?.LogDebug("Native SDK reported: 'crashedLastRun': '{0}'", crashedLastRun);
             }
 
             return crashedLastRun.Value;

--- a/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
+++ b/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
@@ -56,9 +56,10 @@ public static class SentryNativeCocoa
         options.EnableScopeSync = true;
         options.CrashedLastRun = () =>
         {
+            options.DiagnosticLogger?.LogDebug("Checking for 'CrashedLastRun'");
+
             var crashedLastRun = SentryCocoaBridgeProxy.CrashedLastRun() == 1;
-            options.DiagnosticLogger?
-                .LogDebug("Native SDK reported: 'crashedLastRun': '{0}'", crashedLastRun);
+            options.DiagnosticLogger?.LogDebug("Native SDK reported: 'crashedLastRun': '{0}'", crashedLastRun);
 
             return crashedLastRun;
         };


### PR DESCRIPTION
Synchronizing log messages in `native` inits so it's easier to ask users regarding log messaged.

#skip-changelog