### PR TITLE
feat: Adding the game's name to the app context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- The SDK now reports the game's name as part of the app context ([2083](https://github.com/getsentry/sentry-unity/pull/2083))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.45.0 to v8.48.0 ([#2063](https://github.com/getsentry/sentry-unity/pull/2063), [#2071](https://github.com/getsentry/sentry-unity/pull/2071))

--- a/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
@@ -66,6 +66,7 @@ internal class UnityScopeUpdater
 
     private void PopulateApp(App app)
     {
+        app.Name = _application.ProductName;
         app.StartTime = MainThreadData.StartTime;
         var isDebugBuild = MainThreadData.IsDebugBuild;
         app.BuildType = isDebugBuild is null ? null : (isDebugBuild.Value ? "debug" : "release");

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -256,6 +256,7 @@ public sealed class UnityEventProcessorTests
     public void AppProtocol_Assigned()
     {
         // arrange
+        _testApplication = new TestApplication(productName: "TestGame");
         var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
         var scope = new Scope(_sentryOptions);
 
@@ -263,8 +264,24 @@ public sealed class UnityEventProcessorTests
         sut.ConfigureScope(scope);
 
         // assert
+        Assert.IsNotNull(scope.Contexts.App.Name);
         Assert.IsNotNull(scope.Contexts.App.StartTime);
         Assert.IsNotNull(scope.Contexts.App.BuildType);
+    }
+
+    [Test]
+    public void AppProtocol_AppNameIsApplicationName()
+    {
+        // arrange
+        _testApplication = new TestApplication(productName: "TestGame");
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
+        var scope = new Scope(_sentryOptions);
+
+        // act
+        sut.ConfigureScope(scope);
+
+        // assert
+        Assert.AreEqual(scope.Contexts.App.Name, _testApplication.ProductName);
     }
 
     [Test]


### PR DESCRIPTION
Adding the game's name to the app context. This should be especially helpful in case of UaaL.

![Screenshot 2025-03-27 at 15 16 26](https://github.com/user-attachments/assets/ff41a78b-1c89-4c34-a1c9-9fececcbf0c9)
