### PR TITLE
feat: Added active scene's name to unity context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- The SDK now reports the active scene's name as part of the `Unity Context` ([2084](https://github.com/getsentry/sentry-unity/pull/2084))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.45.0 to v8.48.0 ([#2063](https://github.com/getsentry/sentry-unity/pull/2063), [#2071](https://github.com/getsentry/sentry-unity/pull/2071))

--- a/src/Sentry.Unity/Integrations/ISceneManager.cs
+++ b/src/Sentry.Unity/Integrations/ISceneManager.cs
@@ -15,6 +15,7 @@ internal interface ISceneManager
     public event Action<SceneAdapter, LoadSceneMode> SceneLoaded;
     public event Action<SceneAdapter> SceneUnloaded;
     public event Action<SceneAdapter, SceneAdapter> ActiveSceneChanged;
+    public SceneAdapter GetActiveScene();
 }
 
 internal sealed class SceneManagerAdapter : ISceneManager
@@ -40,4 +41,6 @@ internal sealed class SceneManagerAdapter : ISceneManager
                 new SceneAdapter(sceneTo.name));
         };
     }
+
+    public SceneAdapter GetActiveScene() => new(SceneManager.GetActiveScene().name);
 }

--- a/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
@@ -3,7 +3,6 @@ using Sentry.Protocol;
 using Sentry.Reflection;
 using Sentry.Integrations;
 using Sentry.Unity.Integrations;
-using UnityEngine.SceneManagement;
 using OperatingSystem = Sentry.Protocol.OperatingSystem;
 
 namespace Sentry.Unity;

--- a/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityScopeIntegration.cs
@@ -3,6 +3,7 @@ using Sentry.Protocol;
 using Sentry.Reflection;
 using Sentry.Integrations;
 using Sentry.Unity.Integrations;
+using UnityEngine.SceneManagement;
 using OperatingSystem = Sentry.Protocol.OperatingSystem;
 
 namespace Sentry.Unity;
@@ -34,11 +35,13 @@ internal class UnityScopeUpdater
 {
     private readonly SentryUnityOptions _options;
     private readonly IApplication _application;
+    private readonly ISceneManager _sceneManager;
 
-    public UnityScopeUpdater(SentryUnityOptions options, IApplication application)
+    public UnityScopeUpdater(SentryUnityOptions options, IApplication application, ISceneManager? sceneManager = null)
     {
         _options = options;
         _application = application;
+        _sceneManager = sceneManager ?? SceneManagerAdapter.Instance;
     }
 
     public void ConfigureScope(Scope scope)
@@ -139,6 +142,7 @@ internal class UnityScopeUpdater
         unity.TargetFrameRate = MainThreadData.TargetFrameRate;
         unity.CopyTextureSupport = MainThreadData.CopyTextureSupport;
         unity.RenderingThreadingMode = MainThreadData.RenderingThreadingMode;
+        unity.ActiveSceneName = _sceneManager.GetActiveScene().Name;
     }
 
     private void PopulateTags(Action<string, string> setTag)

--- a/src/Sentry.Unity/Protocol/Unity.cs
+++ b/src/Sentry.Unity/Protocol/Unity.cs
@@ -53,11 +53,8 @@ public sealed class Unity : ISentryJsonSerializable
     public string? TargetFrameRate { get; set; }
 
     /// <summary>
-    /// Application install mode.
+    /// The active scene's name
     /// </summary>
-    /// <example>
-    /// Unknown, Store, DeveloperBuild, Adhoc, Enterprise, Editor
-    /// </example>
     public string? ActiveSceneName { get; set; }
 
     internal Unity Clone()

--- a/src/Sentry.Unity/Protocol/Unity.cs
+++ b/src/Sentry.Unity/Protocol/Unity.cs
@@ -52,13 +52,22 @@ public sealed class Unity : ISentryJsonSerializable
     /// </summary>
     public string? TargetFrameRate { get; set; }
 
+    /// <summary>
+    /// Application install mode.
+    /// </summary>
+    /// <example>
+    /// Unknown, Store, DeveloperBuild, Adhoc, Enterprise, Editor
+    /// </example>
+    public string? ActiveSceneName { get; set; }
+
     internal Unity Clone()
         => new()
         {
             InstallMode = InstallMode,
             CopyTextureSupport = CopyTextureSupport,
             RenderingThreadingMode = RenderingThreadingMode,
-            TargetFrameRate = TargetFrameRate
+            TargetFrameRate = TargetFrameRate,
+            ActiveSceneName = ActiveSceneName
         };
 
     public void WriteTo(Utf8JsonWriter writer, IDiagnosticLogger? logger)
@@ -92,6 +101,11 @@ public sealed class Unity : ISentryJsonSerializable
             writer.WriteString("target_frame_rate", TargetFrameRate);
         }
 
+        if (!string.IsNullOrWhiteSpace(ActiveSceneName))
+        {
+            writer.WriteString("active_scene_name", ActiveSceneName);
+        }
+
         writer.WriteEndObject();
     }
 
@@ -102,7 +116,8 @@ public sealed class Unity : ISentryJsonSerializable
             InstallMode = json.GetPropertyOrNull("install_mode")?.GetString(),
             CopyTextureSupport = json.GetPropertyOrNull("copy_texture_support")?.GetString(),
             RenderingThreadingMode = json.GetPropertyOrNull("rendering_threading_mode")?.GetString(),
-            TargetFrameRate = json.GetPropertyOrNull("target_frame_rate")?.GetString()
+            TargetFrameRate = json.GetPropertyOrNull("target_frame_rate")?.GetString(),
+            ActiveSceneName = json.GetPropertyOrNull("active_scene_name")?.GetString()
         };
 
     public string ToJsonString(IDiagnosticLogger? logger = null)

--- a/test/Sentry.Unity.Tests/Protocol/UnityTests.cs
+++ b/test/Sentry.Unity.Tests/Protocol/UnityTests.cs
@@ -22,7 +22,8 @@ public sealed class UnityTests
             InstallMode = "DeveloperBuild",
             CopyTextureSupport = "Copy3D",
             RenderingThreadingMode = "MultiThreaded",
-            TargetFrameRate = "30"
+            TargetFrameRate = "30",
+            ActiveSceneName = "TestScene",
         };
 
         var actual = sut.ToJsonString();
@@ -32,7 +33,8 @@ public sealed class UnityTests
             "\"install_mode\":\"DeveloperBuild\"," +
             "\"copy_texture_support\":\"Copy3D\"," +
             "\"rendering_threading_mode\":\"MultiThreaded\"," +
-            "\"target_frame_rate\":\"30\"}",
+            "\"target_frame_rate\":\"30\"," +
+            "\"active_scene_name\":\"TestScene\"}",
             actual);
     }
 
@@ -44,7 +46,8 @@ public sealed class UnityTests
             InstallMode = "DeveloperBuild",
             CopyTextureSupport = "Copy3D",
             RenderingThreadingMode = "MultiThreaded",
-            TargetFrameRate = "30"
+            TargetFrameRate = "30",
+            ActiveSceneName = "TestScene"
         };
 
         var clone = sut.Clone();
@@ -53,6 +56,7 @@ public sealed class UnityTests
         Assert.AreEqual(sut.CopyTextureSupport, clone.CopyTextureSupport);
         Assert.AreEqual(sut.RenderingThreadingMode, clone.RenderingThreadingMode);
         Assert.AreEqual(sut.TargetFrameRate, clone.TargetFrameRate);
+        Assert.AreEqual(sut.ActiveSceneName, clone.ActiveSceneName);
     }
 
     [TestCaseSource(nameof(TestCases))]
@@ -69,6 +73,7 @@ public sealed class UnityTests
         new object[] { (new Unity.Protocol.Unity { InstallMode = "Adhoc" }, "{\"type\":\"unity\",\"install_mode\":\"Adhoc\"}") },
         new object[] { (new Unity.Protocol.Unity { CopyTextureSupport = "TextureToRT" }, "{\"type\":\"unity\",\"copy_texture_support\":\"TextureToRT\"}") },
         new object[] { (new Unity.Protocol.Unity { RenderingThreadingMode = "NativeGraphicsJobs" }, "{\"type\":\"unity\",\"rendering_threading_mode\":\"NativeGraphicsJobs\"}") },
-        new object[] { (new Unity.Protocol.Unity { TargetFrameRate = "30" }, "{\"type\":\"unity\",\"target_frame_rate\":\"30\"}") }
+        new object[] { (new Unity.Protocol.Unity { TargetFrameRate = "30" }, "{\"type\":\"unity\",\"target_frame_rate\":\"30\"}") },
+        new object[] { (new Unity.Protocol.Unity { ActiveSceneName = "TestScene" }, "{\"type\":\"unity\",\"active_scene_name\":\"TestScene\"}") }
     };
 }

--- a/test/Sentry.Unity.Tests/SceneManagerIntegrationTests.cs
+++ b/test/Sentry.Unity.Tests/SceneManagerIntegrationTests.cs
@@ -119,13 +119,16 @@ public class SceneManagerIntegrationTests
 
     private readonly Fixture _fixture = new();
 
-    private class FakeSceneManager : ISceneManager
+    internal class FakeSceneManager : ISceneManager
     {
+        public string ActiveSceneName { get; set; } = string.Empty;
+
         public event Action<SceneAdapter, LoadSceneMode>? SceneLoaded;
         public event Action<SceneAdapter>? SceneUnloaded;
         public event Action<SceneAdapter, SceneAdapter>? ActiveSceneChanged;
         public void OnSceneLoaded(SceneAdapter scene, LoadSceneMode mode) => SceneLoaded?.Invoke(scene, mode);
         public void OnSceneUnloaded(SceneAdapter scene) => SceneUnloaded?.Invoke(scene);
         public void OnActiveSceneChanged(SceneAdapter fromScene, SceneAdapter toScene) => ActiveSceneChanged?.Invoke(fromScene, toScene);
+        public SceneAdapter GetActiveScene() => new(ActiveSceneName);
     }
 }

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Sentry.Unity.Tests.SharedClasses;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
 // TODO do we need a real (working) DSN in these tests?
@@ -158,6 +159,8 @@ public sealed class UnityEventProcessorThreadingTests
         Assert.AreEqual(systemInfo.TargetFrameRate!.Value, unityContext!.TargetFrameRate);
         Assert.AreEqual(systemInfo.CopyTextureSupport!.Value, unityContext.CopyTextureSupport);
         Assert.AreEqual(systemInfo.RenderingThreadingMode!.Value, unityContext.RenderingThreadingMode);
+        Assert.AreEqual(SceneManager.GetActiveScene().name, unityContext.ActiveSceneName);
+
         Assert.IsNull(@event.ServerName);
     }
 }
@@ -412,6 +415,7 @@ public sealed class UnityEventProcessorTests
     [Test]
     public void UnityProtocol_Assigned()
     {
+        var sceneManager = new SceneManagerIntegrationTests.FakeSceneManager { ActiveSceneName = "TestScene" };
         var systemInfo = new TestSentrySystemInfo
         {
             EditorVersion = "TestEditorVersion2022.3.2f1",
@@ -423,7 +427,7 @@ public sealed class UnityEventProcessorTests
         MainThreadData.SentrySystemInfo = systemInfo;
         MainThreadData.CollectData();
 
-        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication);
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication, sceneManager);
         var scope = new Scope(_sentryOptions);
 
         // act
@@ -438,6 +442,7 @@ public sealed class UnityEventProcessorTests
         Assert.AreEqual(systemInfo.TargetFrameRate!.Value, unityProtocol.TargetFrameRate);
         Assert.AreEqual(systemInfo.CopyTextureSupport!.Value, unityProtocol.CopyTextureSupport);
         Assert.AreEqual(systemInfo.RenderingThreadingMode!.Value, unityProtocol.RenderingThreadingMode);
+        Assert.AreEqual(sceneManager.GetActiveScene().Name, unityProtocol.ActiveSceneName);
     }
 
     [Test]


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry-unity/issues/2073
Adds the active scene's name to the Unity context.

![Screenshot 2025-03-27 at 16 21 50](https://github.com/user-attachments/assets/ebc69914-045d-49b4-8559-ea7bdac82ed8)
