### PR TITLE
fix: Rename internal `SetupLogging` to `SetupUnityLogging`

### DIFF
--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -224,7 +224,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
 
         // We need to set up logging here because the configure callback might have changed the debug options.
         // Without setting up here we might miss out on logs between option-loading (now) and Init - i.e. native configuration
-        options.SetupLogging();
+        options.SetupUnityLogging();
 
         if (options.AttachViewHierarchy)
         {

--- a/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
+++ b/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
@@ -47,7 +47,7 @@ public static class SentryUnityOptionsExtensions
         return true;
     }
 
-    internal static void SetupLogging(this SentryUnityOptions options)
+    internal static void SetupUnityLogging(this SentryUnityOptions options)
     {
         if (options.Debug)
         {

--- a/src/Sentry.Unity/SentryUnitySDK.cs
+++ b/src/Sentry.Unity/SentryUnitySDK.cs
@@ -22,7 +22,7 @@ internal class SentryUnitySdk
     {
         var unitySdk = new SentryUnitySdk(options);
 
-        options.SetupLogging();
+        options.SetupUnityLogging();
         if (!options.ShouldInitializeSdk())
         {
             return null;


### PR DESCRIPTION
This PR renames the `internal` extension-method `SetupLogging` to `SetupUnityLogging` on the `SentryUnityOptions`.

### Context
With https://github.com/getsentry/sentry-dotnet/pull/4026 and release `5.5.0` the Sentry .NET SDK made its internals visible to the Unity SDK. This causes the extension method to get skipped and instead of 
https://github.com/getsentry/sentry-unity/blob/3e0263498974a12dbc5e41cbc738062d4b13810f/src/Sentry.Unity/SentryUnityOptionsExtensions.cs#L50
the actual [`SetupLogging`](https://github.com/getsentry/sentry-dotnet/blob/a2011af2c2a7d65862329269e0c03a377393bdff/src/Sentry/SentryOptions.cs#L1781) on the `SentryOptions` gets called, creating a `ConsoleLogger` instead.

#skip-changelog