### PR TITLE
fix: Android device crash tests

### DIFF
--- a/.github/workflows/android-smoke-test-run.yml
+++ b/.github/workflows/android-smoke-test-run.yml
@@ -80,7 +80,7 @@ jobs:
             adb wait-for-device
             adb shell input keyevent 82
             adb devices -l
-            pwsh ./scripts/smoke-test-android.ps1 -IsIntegrationTest -WarnIfFlaky
+            pwsh ./scripts/smoke-test-android.ps1 -WarnIfFlaky
 
       - name: Upload artifacts on failure
         if: ${{ failure() }}

--- a/scripts/smoke-test-android.ps1
+++ b/scripts/smoke-test-android.ps1
@@ -332,8 +332,8 @@ function RunTest([string] $Name, [string] $SuccessString, [string] $FailureStrin
         $logCache = ProcessNewLogs -newLogs $newLogs -lastLogCount ([ref]$lastLogCount) -logCache $logCache
 
         # The SmokeTester logs "SmokeTester is quitting." in OnApplicationQuit() to reliably inform when tests finish running.
-        # For crash tests, we expect to see a native crash log "terminating with uncaught exception of type char const*".
-        if (($newLogs | Select-String "SmokeTester is quitting.") -or ($newLogs | Select-String "terminating with uncaught exception of type char const*"))
+        # For crash tests, we're checking for `sentry-native` logging "crash has been captured" to reliably inform when tests finished running.
+        if (($newLogs | Select-String "SmokeTester is quitting.") -or ($newLogs | Select-String "crash has been captured"))
         {
             Write-Host "Process finished marker detected. Finish waiting for tests to run."
             $processFinished = $true

--- a/scripts/smoke-test-android.ps1
+++ b/scripts/smoke-test-android.ps1
@@ -66,8 +66,8 @@ else
 $TestActivityName = "$ProcessName/com.unity3d.player.UnityPlayerActivity"
 $FallBackTestActivityName = "$ProcessName/com.unity3d.player.UnityPlayerGameActivity"
 
-$_ArtifactsPath = ((Test-Path env:ARTIFACTS_PATH) ? $env:ARTIFACTS_PATH : "./$BuildDir/../test-artifacts/") `
-    + $(Get-Date -Format "HHmmss")
+$_ArtifactsPath = (Test-Path env:ARTIFACTS_PATH) ? $env:ARTIFACTS_PATH : (Join-Path $BuildDir "../test-artifacts/" $(Get-Date -Format "HHmmss"))
+
 function ArtifactsPath
 {
     if (-not (Test-Path $_ArtifactsPath))

--- a/scripts/smoke-test-android.ps1
+++ b/scripts/smoke-test-android.ps1
@@ -22,47 +22,9 @@ Write-Host "#  |___/_|  |_|\___/|_|\_\___| |_| |___|___/  |_|   #"
 Write-Host "#                                                   #"
 Write-Host "#####################################################"
 
-if ($IsIntegrationTest)
-{
-    $BuildDir = $(GetNewProjectBuildPath)
-    $ApkFileName = "test.apk"
-    $ProcessName = "com.DefaultCompany.$(GetNewProjectName)"
-
-    if ($Action -eq "Build")
-    {
-        $buildCallback = {
-            Write-Host "::group::Gradle build $BuildDir"
-            Push-Location $BuildDir
-            try
-            {
-                MakeExecutable "./gradlew"
-                & ./gradlew --info --no-daemon assembleRelease | ForEach-Object {
-                    Write-Host "  $_"
-                }
-                if (-not $?)
-                {
-                    throw "Gradle execution failed"
-                }
-                Copy-Item -Path launcher/build/outputs/apk/release/launcher-release.apk -Destination $ApkFileName
-            }
-            finally
-            {
-                Pop-Location
-                Write-Host "::endgroup::"
-            }
-        }
-
-        $symbolServerOutput = RunWithSymbolServer -Callback $buildCallback
-        CheckSymbolServerOutput 'Android' $symbolServerOutput $UnityVersion
-        return;
-    }
-}
-else
-{
-    $BuildDir = "samples/artifacts/builds/Android"
-    $ApkFileName = "IL2CPP_Player.apk"
-    $ProcessName = "io.sentry.samples.unityofbugs"
-}
+$BuildDir = $(GetNewProjectBuildPath)
+$ApkFileName = "test.apk"
+$ProcessName = "com.DefaultCompany.$(GetNewProjectName)"
 $TestActivityName = "$ProcessName/com.unity3d.player.UnityPlayerActivity"
 $FallBackTestActivityName = "$ProcessName/com.unity3d.player.UnityPlayerGameActivity"
 

--- a/test/Scripts.Integration.Test/integration-test.ps1
+++ b/test/Scripts.Integration.Test/integration-test.ps1
@@ -82,18 +82,16 @@ If (-not(Test-Path -Path "$(GetNewProjectPath)"))
     ./test/Scripts.Integration.Test/configure-sentry.ps1 "$UnityPath" -Platform $Platform -CheckSymbols
 }
 
+# Support rebuilding the integration test project. I.e. if you make changes to the SmokeTester.cs during
 If ($Rebuild -or -not(Test-Path -Path $(GetNewProjectBuildPath)))
 {
     Write-Host "Building Project"
 
-    If (("iOS", "Android-Export") -contains $Platform)
+    If ("iOS" -eq $Platform)
     {
-        # Workaround for having `exportAsGoogleAndroidProject` remain `false` in Unity 6 on first build
+        # We're exporting an Xcode project and building that in a separate step.
         ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$UnityPath" -UnityVersion $UnityVersion -Platform $Platform
-        Remove-Item -Path $(GetNewProjectBuildPath) -Recurse -Force -Confirm:$false
-
-        ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$UnityPath" -UnityVersion $UnityVersion -Platform $Platform
-        & "./scripts/smoke-test-$($Platform -eq 'iOS' ? 'ios' : 'android').ps1" Build -IsIntegrationTest -UnityVersion $UnityVersion
+        & "./scripts/smoke-test-ios.ps1" Build -IsIntegrationTest -UnityVersion $UnityVersion
     }
     Else
     {
@@ -109,9 +107,9 @@ Switch -Regex ($Platform)
     {
         ./test/Scripts.Integration.Test/run-smoke-test.ps1 -Smoke -Crash
     }
-    "^(Android|Android-Export)$"
+    "^(Android)$"
     {
-        ./scripts/smoke-test-android.ps1 -IsIntegrationTest
+        ./scripts/smoke-test-android.ps1
     }
     "^iOS$"
     {


### PR DESCRIPTION
## Fixes
I'm not exactly sure when or with which version this changes but the crash log switches between 
```
terminating with uncaught exception of type char const*
``` 
and 
```
terminating due to uncaught exception of type char const*
```
Replacing the `with` with `due to`.

Instead of relying on the exact wording from the logs from somewhere within Unity, we're relying on the ones from `sentry-native` (so we can blame ourselves if this breaks in the future).

## Cleanup

With the separation into workflows in https://github.com/getsentry/sentry-unity/pull/1989 we're also no longer exporting a Gradle project that we're then building in a dedicated step. The `IsIntegrationTest` is a remnant from there.

#skip-changelog.