### PR TITLE
fix: Return success during Cocoa SDK init on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- When targeting macOS, the SDK no longer fails to sync the scope to native events ([#2104](https://github.com/getsentry/sentry-unity/pull/2104))
+
 ### Features
 
 - The SDK now reports the game's name as part of the app context ([2083](https://github.com/getsentry/sentry-unity/pull/2083))

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -72,14 +72,22 @@ void SentryNativeBridgeOptionsSetInt(const void *options, const char *name, int3
     dictOptions[[NSString stringWithUTF8String:name]] = [NSNumber numberWithInt:value];
 }
 
-void SentryNativeBridgeStartWithOptions(const void *options)
+int SentryNativeBridgeStartWithOptions(const void *options)
 {
     NSMutableDictionary *dictOptions = (__bridge_transfer NSMutableDictionary *)options;
+    NSError *error = nil;
+
     id sentryOptions = [[SentryOptions alloc]
         performSelector:@selector(initWithDict:didFailWithError:)
-        withObject:dictOptions withObject:nil];
+        withObject:dictOptions withObject:&error];
+
+    if (error != nil)
+    {
+        return 0;
+    }
 
     [SentrySDK performSelector:@selector(startWithOptions:) withObject:sentryOptions];
+    return 1;
 }
 
 void SentryConfigureScope(void (^callback)(id))


### PR DESCRIPTION
This bug got introduced with https://github.com/getsentry/sentry-unity/pull/1924
The iOS bridge received an update to report back the success of calling init. This was missing on the macOS bridge. The SDK still gets initialized and it captures crashes, but the scope sync is missing.

I'll address the missing integration tests as part or follow up on https://github.com/getsentry/sentry-unity/issues/2099