### PR TITLE
fix: retry curl dotnet-install.sh

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -73,10 +73,12 @@ jobs:
 
       - name: Installing Linux Dependencies
         if: ${{ inputs.target == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
         run: |
           apt-get update
           apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev build-essential cmake curl
-          curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --install-dir /usr/share/dotnet
+          set -eo pipefail
+          curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --install-dir /usr/share/dotnet
           echo "/usr/share/dotnet" >> $GITHUB_PATH
         env:
           DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
After merging #2118, the [first job](https://github.com/getsentry/sentry-unity/actions/runs/14514115192/job/40719231256) in the main branch failed like this:

- Installing Linux Dependencies
  ```
  curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to dot.net:443 
  ```

- Build
  ```
  /__w/_temp/997abeb5-d2d0-41eb-ad62-073478c13323.sh: 2: dotnet: not found
  ```

This tweak makes it more robust by a) allowing curl to retry a few times should there be any network hiccups, and b) ensuring the dependency installation step fails as appropriate instead of quietly ignoring the error and proceeding to the build step.

#skip-changelog