### PR TITLE
chore: Increase smoke test build timeout for iOS

### DIFF
--- a/.github/workflows/ios-smoke-test-compile.yml
+++ b/.github/workflows/ios-smoke-test-compile.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: iOS smoke test
         run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${{ inputs.unity-version }}" -iOSMinVersion "16.1"
-        timeout-minutes: 10
+        timeout-minutes: 20
     
       - name: Upload integration-test project on failure
         if: ${{ failure() }}


### PR DESCRIPTION
The build currently takes `~10` minutes and fails due to timeouts. There was no special reasoning behind `10` minutes other than "fail faster" when updating the action last.

#skip-changelog