### PR TITLE
chore: Name CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
-name: Build Unity SDK
-
+name: "Build Unity SDK"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: CI
-
+name: "CI"
 on:
   push:
     paths-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 
-  android-smoke-test-build:
+  smoke-test-build-android:
     name: Build Android ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [smoke-test-create]
@@ -211,15 +211,15 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-    uses: ./.github/workflows/android-smoke-test-build.yml
+    uses: ./.github/workflows/smoke-test-build-android.yml
     with:
       unity-version: ${{ matrix.unity-version }}
 
-  android-smoke-test-run:
+  smoke-test-run-android:
     name: Run Android ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [android-smoke-test-build]
-    uses: ./.github/workflows/android-smoke-test-run.yml
+    needs: [smoke-test-build-android]
+    uses: ./.github/workflows/smoke-test-run-android.yml
     with:
       unity-version: ${{ matrix.unity-version }}
       api-level: ${{ matrix.api-level }}
@@ -231,7 +231,7 @@ jobs:
         init-type: ["runtime", "buildtime"]
         unity-version: ["2019", "2022", "6000"]
 
-  ios-smoke-test-build:
+  smoke-test-build-ios:
     name: Build iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
     needs: [smoke-test-create]
@@ -240,30 +240,30 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
-    uses: ./.github/workflows/ios-smoke-test-build.yml
+    uses: ./.github/workflows/smoke-test-build-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
 
-  ios-smoke-test-compile:
+  smoke-test-compile-ios:
     name: Compile iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [ios-smoke-test-build]
+    needs: [smoke-test-build-ios]
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
         unity-version: ["2019", "2022", "6000"]
         init-type: ["runtime", "buildtime"]
-    uses: ./.github/workflows/ios-smoke-test-compile.yml
+    uses: ./.github/workflows/smoke-test-compile-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
       init-type: ${{ matrix.init-type }}
 
-  ios-smoke-test-run:
+  smoke-test-run-ios:
     name: Run iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [ios-smoke-test-compile]
-    uses: ./.github/workflows/ios-smoke-test-run.yml
+    needs: [smoke-test-compile-ios]
+    uses: ./.github/workflows/smoke-test-run-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
       ios-version: ${{ matrix.ios-version }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,5 +1,4 @@
-name: Danger
-
+name: "Danger"
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,4 +1,4 @@
-name: format code
+name: "Format Code"
 on:
   pull_request:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
-name: Release
-
+name: "Release"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,3 +1,4 @@
+name: "Build native SDKs"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke-test-build-android.yml
+++ b/.github/workflows/smoke-test-build-android.yml
@@ -1,3 +1,4 @@
+name: "SmokeTest: Build Android"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke-test-build-ios.yml
+++ b/.github/workflows/smoke-test-build-ios.yml
@@ -1,3 +1,4 @@
+name: "SmokeTest: Build iOS"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke-test-compile-ios.yml
+++ b/.github/workflows/smoke-test-compile-ios.yml
@@ -1,3 +1,4 @@
+name: "SmokeTest: Compile iOS"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke-test-create.yml
+++ b/.github/workflows/smoke-test-create.yml
@@ -1,5 +1,4 @@
 name: "SmokeTest: Create Project"
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke-test-create.yml
+++ b/.github/workflows/smoke-test-create.yml
@@ -1,4 +1,4 @@
-name: Create Smoke Test Project
+name: "SmokeTest: Create Project"
 
 on:
   workflow_call:

--- a/.github/workflows/smoke-test-run-android.yml
+++ b/.github/workflows/smoke-test-run-android.yml
@@ -1,3 +1,4 @@
+name: "SmokeTest: Run Android"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke-test-run-ios.yml
+++ b/.github/workflows/smoke-test-run-ios.yml
@@ -1,3 +1,4 @@
+name: "SmokeTest: Run iOS"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,5 +1,4 @@
-name: Update Dependencies
-
+name: "Update Dependencies"
 on:
   # Run every day on multiple occasions, with each job running at a different time to limit license-acquisition issues.
   schedule:


### PR DESCRIPTION
This fixes the messy list of available workflows on the Actions tab by giving each workflow an appropriate name.

![Screenshot 2025-04-24 at 15 31 51](https://github.com/user-attachments/assets/0501ab86-7d32-4726-ba7e-b456b60b77e2)

#skip-changelog