### PR TITLE
added asset store integration

### DIFF
--- a/src/Sentry.Unity/Integrations/SentryUnityAssetStoreIntegration.cs
+++ b/src/Sentry.Unity/Integrations/SentryUnityAssetStoreIntegration.cs
@@ -1,0 +1,14 @@
+using Sentry.Integrations;
+
+namespace Sentry.Unity.Integrations;
+
+public class SentryUnityAssetStoreIntegration : ISdkIntegration
+{
+    public void Register(IHub hub, SentryOptions options)
+    {
+        if (options is SentryUnityOptions unityOptions)
+        {
+            unityOptions.SdkIntegrationNames.Add("IL2CPPLineNumbers");
+        }
+    }
+}


### PR DESCRIPTION
Releasing to the Unity Asset Store requires manual import of the package and upload through the Editor. This means we do have access to the actual source that is getting shipped and enables us to add

```
options.AddIntegration(new SentryUnityAssetStoreIntegration());
```

to the `SentryIntegrations`
https://github.com/getsentry/sentry-unity/blob/6484482bfa9946d2514579eec0371003884e6f42/package-dev/Runtime/SentryIntegrations.cs#L18-L20
that is getting shipped with the package and compiled with the game.