### PR TITLE
fix: Ignor CLI errors when targeting `iOS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- When targeting iOS and setting `IgnoreCliErrors = true`, the Xcode build will now succeed even if the symbol upload itself failed. This is aimed to allow users to unblock themselves ([#2136](https://github.com/getsentry/sentry-unity/pull/2136)) 
+
 ## 3.2.0
 
 ### Fixes

--- a/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
+++ b/src/Sentry.Unity.Editor.iOS/SentryXcodeProject.cs
@@ -25,6 +25,7 @@ internal class SentryXcodeProject : IDisposable
     private readonly string _uploadScript = @"
 export SENTRY_PROPERTIES=sentry.properties
 echo ""Uploading debug symbols and bcsymbolmaps.""
+echo ""Writing logs to './sentry-symbols-upload.log'""
 ./{0} debug-files upload {1} $BUILT_PRODUCTS_DIR {2}
 ";
 

--- a/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/SentryXcodeProjectTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Sentry.Unity.Tests.SharedClasses;
+using UnityEngine;
 
 namespace Sentry.Unity.Editor.iOS.Tests;
 
@@ -163,5 +164,35 @@ public class SentryXcodeProjectTests
             log.logLevel == SentryLevel.Debug &&
             log.message.Contains("already added."))); // Sanity check
         Assert.AreEqual(expectedBuildPhaseOccurence, actualBuildPhaseOccurence);
+    }
+
+    [Test]
+    public void AddBuildPhaseSymbolUpload_IgnoreCliErrorsFalse_UsesLogAndPrintArgs()
+    {
+        var xcodeProject = _fixture.GetSut();
+        xcodeProject.ReadFromProjectFile();
+
+        var sentryCliOptions = ScriptableObject.CreateInstance<SentryCliOptions>();
+        sentryCliOptions.IgnoreCliErrors = false;
+
+        xcodeProject.AddBuildPhaseSymbolUpload(sentryCliOptions);
+
+        StringAssert.DoesNotContain("--allow-failure", xcodeProject.ProjectToString()); // sanity check
+        StringAssert.Contains(SentryXcodeProject.LogAndPrintArg, xcodeProject.ProjectToString());
+    }
+
+    [Test]
+    public void AddBuildPhaseSymbolUpload_IgnoreCliErrorsTrue_UsesLogOnlyArgs()
+    {
+        var xcodeProject = _fixture.GetSut();
+        xcodeProject.ReadFromProjectFile();
+
+        var sentryCliOptions = ScriptableObject.CreateInstance<SentryCliOptions>();
+        sentryCliOptions.IgnoreCliErrors = true;
+
+        xcodeProject.AddBuildPhaseSymbolUpload(sentryCliOptions);
+
+        StringAssert.Contains("--allow-failure", xcodeProject.ProjectToString());
+        StringAssert.Contains(SentryXcodeProject.LogOnlyArg, xcodeProject.ProjectToString());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2057

In my opinion, this flag is supposed to allow users to unblock themselves. I.e. automated build systems somewhere, local dev environment and is accessible via the configure cli options callback. 
Since the user explicitly opted in to ignoring CLI errors, I think it's fine to simply log into a file.

The difference might seem minor but the build no longer errors with 
```
Command PhaseScriptExecution emitted errors but did not return a nonzero exit code to indicate failure
```

Before:
![Screenshot 2025-04-30 at 17 51 17](https://github.com/user-attachments/assets/233ebd31-62a4-4c2b-acfc-a785e205e964)

After:
![Screenshot 2025-04-30 at 17 50 29](https://github.com/user-attachments/assets/668c9f69-fdde-43ce-acce-9ed9b68cdccc)


