### PR TITLE
fix: `Organisation` no longer required for Sentry CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Sentry CLI no longer requires the 'Organisation' option, and they have been removed from the configuration window. If you're providing an Organisation right now, nothing changes. Fresh setups will have the option omitted  ([#2137](https://github.com/getsentry/sentry-unity/pull/2137))
+
 ### Dependencies
 
 - Bump CLI from v2.43.0 to v2.43.1 ([#2133](https://github.com/getsentry/sentry-unity/pull/2133))

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
@@ -35,12 +35,15 @@ internal static class DebugSymbolsTab
                 "The authorization token from your user settings in Sentry"),
             cliOptions.Auth);
 
-        cliOptions.Organization = EditorGUILayout.TextField(
-            new GUIContent(
-                "Org Slug",
-                cliOptions.UploadSymbols && string.IsNullOrWhiteSpace(cliOptions.Organization) ? SentryWindow.ErrorIcon : null,
-                "The organization slug in Sentry"),
-            cliOptions.Organization);
+        if (!string.IsNullOrEmpty(cliOptions.Organization))
+        {
+            cliOptions.Organization = EditorGUILayout.TextField(
+                new GUIContent(
+                    "Org Slug",
+                    cliOptions.UploadSymbols && string.IsNullOrWhiteSpace(cliOptions.Organization) ? SentryWindow.ErrorIcon : null,
+                    "The organization slug in Sentry"),
+                cliOptions.Organization);
+        }
 
         cliOptions.Project = EditorGUILayout.TextField(
             new GUIContent(

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/DebugSymbolsTab.cs
@@ -35,15 +35,26 @@ internal static class DebugSymbolsTab
                 "The authorization token from your user settings in Sentry"),
             cliOptions.Auth);
 
-        if (!string.IsNullOrEmpty(cliOptions.Organization))
+        // Org tokens have a `sntrys` prefix and do not require an organisation
+        var isOrgAuthToken = cliOptions.IsOrgAuthToken();
+        if (isOrgAuthToken)
         {
-            cliOptions.Organization = EditorGUILayout.TextField(
+            EditorGUILayout.HelpBox(
+                "Organization Auth Token detected. The token's embedded 'org slug' will be used during " +
+                "symbol upload.",
+                MessageType.Info);
+        }
+
+        EditorGUI.BeginDisabledGroup(isOrgAuthToken);
+
+        cliOptions.Organization = EditorGUILayout.TextField(
                 new GUIContent(
                     "Org Slug",
-                    cliOptions.UploadSymbols && string.IsNullOrWhiteSpace(cliOptions.Organization) ? SentryWindow.ErrorIcon : null,
+                    cliOptions.UploadSymbols && string.IsNullOrWhiteSpace(cliOptions.Organization) && !isOrgAuthToken ? SentryWindow.ErrorIcon : null,
                     "The organization slug in Sentry"),
                 cliOptions.Organization);
-        }
+
+        EditorGUI.EndDisabledGroup();
 
         cliOptions.Project = EditorGUILayout.TextField(
             new GUIContent(

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -95,7 +95,6 @@ public class SentryWindow : EditorWindow
         options.Dsn = config.Dsn;
         cliOptions.UploadSymbols = !string.IsNullOrWhiteSpace(config.Token);
         cliOptions.Auth = config.Token;
-        cliOptions.Organization = config.OrgSlug;
         cliOptions.Project = config.ProjectSlug;
 
         EditorUtility.SetDirty(options);

--- a/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/Wizard.cs
@@ -120,7 +120,6 @@ internal class Wizard : EditorWindow
                     {
                         Token = Response.apiKeys!.token,
                         Dsn = project.keys.First().dsn!.@public,
-                        OrgSlug = project.organization!.slug,
                         ProjectSlug = project.slug,
                     };
                 }
@@ -223,7 +222,6 @@ internal class WizardConfiguration
 {
     public string? Token { get; set; }
     public string? Dsn { get; set; }
-    public string? OrgSlug { get; set; }
     public string? ProjectSlug { get; set; }
 }
 

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -265,7 +265,7 @@ public static class BuildPostProcess
                 {
                     var msg = e.Data.Trim();
                     var msgLower = msg.ToLowerInvariant();
-                    var level = SentryLevel.Info;
+                    var level = SentryLevel.Debug;
                     if (msgLower.StartsWith("error"))
                     {
                         level = SentryLevel.Error;
@@ -273,6 +273,10 @@ public static class BuildPostProcess
                     else if (msgLower.StartsWith("warn"))
                     {
                         level = SentryLevel.Warning;
+                    }
+                    else if (msgLower.StartsWith("info"))
+                    {
+                        level = SentryLevel.Info;
                     }
 
                     // Remove the level and timestamp from the beginning of the message.

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -265,7 +265,7 @@ public static class BuildPostProcess
                 {
                     var msg = e.Data.Trim();
                     var msgLower = msg.ToLowerInvariant();
-                    var level = SentryLevel.Debug;
+                    var level = SentryLevel.Info;
                     if (msgLower.StartsWith("error"))
                     {
                         level = SentryLevel.Error;
@@ -273,10 +273,6 @@ public static class BuildPostProcess
                     else if (msgLower.StartsWith("warn"))
                     {
                         level = SentryLevel.Warning;
-                    }
-                    else if (msgLower.StartsWith("info"))
-                    {
-                        level = SentryLevel.Info;
                     }
 
                     // Remove the level and timestamp from the beginning of the message.

--- a/src/Sentry.Unity.Editor/SentryCli.cs
+++ b/src/Sentry.Unity.Editor/SentryCli.cs
@@ -25,7 +25,11 @@ internal static class SentryCli
             properties.WriteLine($"defaults.url={urlOverride}");
         }
 
-        properties.WriteLine($"defaults.org={cliOptions.Organization}");
+        if (!string.IsNullOrEmpty(cliOptions.Organization))
+        {
+            properties.WriteLine($"defaults.org={cliOptions.Organization}");
+        }
+
         properties.WriteLine($"defaults.project={cliOptions.Project}");
         properties.WriteLine($"auth.token={cliOptions.Auth}");
         properties.WriteLine("dif.max_item_size=10485760"); // 10 MiB

--- a/src/Sentry.Unity/SentryCliOptions.cs
+++ b/src/Sentry.Unity/SentryCliOptions.cs
@@ -52,12 +52,6 @@ public sealed class SentryCliOptions : ScriptableObject
             validated = false;
         }
 
-        if (string.IsNullOrWhiteSpace(Organization))
-        {
-            MissingFieldWarning(logger, "Organization");
-            validated = false;
-        }
-
         if (string.IsNullOrWhiteSpace(Project))
         {
             MissingFieldWarning(logger, "Project");

--- a/src/Sentry.Unity/SentryCliOptions.cs
+++ b/src/Sentry.Unity/SentryCliOptions.cs
@@ -31,6 +31,8 @@ public sealed class SentryCliOptions : ScriptableObject
     private static void MissingFieldWarning(IDiagnosticLogger? logger, string name) =>
         logger?.LogWarning("{0} missing. Please set it under {1}", name, EditorMenuPath);
 
+    public bool IsOrgAuthToken() => Auth is not null && Auth.StartsWith("sntrys_");
+
     public bool IsValid(IDiagnosticLogger? logger, bool isDevelopmentBuild)
     {
         if (!UploadSymbols)

--- a/test/Sentry.Unity.Editor.Tests/SentryCliTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/SentryCliTests.cs
@@ -64,7 +64,6 @@ public class SentryCliTests
 
         var sentryCliTestOptions = ScriptableObject.CreateInstance<SentryCliOptions>();
         sentryCliTestOptions.Auth = Guid.NewGuid().ToString();
-        sentryCliTestOptions.Organization = Guid.NewGuid().ToString();
         sentryCliTestOptions.Project = Guid.NewGuid().ToString();
         sentryCliTestOptions.UrlOverride = urlOverride;
 
@@ -73,12 +72,38 @@ public class SentryCliTests
         var properties = File.ReadAllText(Path.Combine(propertiesDirectory, "sentry.properties"));
 
         StringAssert.Contains(sentryCliTestOptions.Auth, properties);
-        StringAssert.Contains(sentryCliTestOptions.Organization, properties);
         StringAssert.Contains(sentryCliTestOptions.Project, properties);
 
         if (!string.IsNullOrEmpty(sentryCliTestOptions.UrlOverride))
         {
             StringAssert.Contains(urlOverride, properties);
+        }
+
+        Directory.Delete(propertiesDirectory, true);
+    }
+
+    [Test]
+    [TestCase("")]
+    [TestCase("testorg")]
+    public void CreateSentryProperties_OrgProvided_PropertyFileCreatedAndContainsOrg(string org)
+    {
+        var propertiesDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(propertiesDirectory);
+
+        var sentryCliTestOptions = ScriptableObject.CreateInstance<SentryCliOptions>();
+        sentryCliTestOptions.Organization = org;
+
+        SentryCli.CreateSentryProperties(propertiesDirectory, sentryCliTestOptions, new());
+
+        var properties = File.ReadAllText(Path.Combine(propertiesDirectory, "sentry.properties"));
+
+        if (!string.IsNullOrEmpty(sentryCliTestOptions.Organization))
+        {
+            StringAssert.Contains(org, properties);
+        }
+        else
+        {
+            StringAssert.DoesNotContain("defaults.org=", properties);
         }
 
         Directory.Delete(propertiesDirectory, true);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2058

This PR made the SDK respect `Organisation tokens`. Users using the the wizard going forward, won't have the `Organisation` set on the options as the org-slug will be taken from the embeddings of the token.

In case on non-organisation tokens (i.e. user tokens), the organisation can still be provided and will be used.
![Screenshot 2025-05-02 at 13 05 34](https://github.com/user-attachments/assets/3c72208e-2e66-4801-aef9-88a7123e3242)
![Screenshot 2025-05-02 at 13 05 56](https://github.com/user-attachments/assets/39fb573d-4c60-41a0-bc16-57102246c960)

The relevant changes to tokens and sentry-cli are
- https://github.com/getsentry/rfcs/pull/91
- https://github.com/getsentry/sentry-cli/pull/1673