### PR TITLE
fix: Fixed sentry-cli logging levels when building for Desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes 
+
+- When targeting Desktop Platforms, Sentry-CLI now respects the SDK's debug logging verbosity ([#2138](https://github.com/getsentry/sentry-unity/pull/2138)) 
+
 ### Dependencies
 
 - Bump CLI from v2.43.0 to v2.43.1 ([#2133](https://github.com/getsentry/sentry-unity/pull/2133))

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -265,7 +265,7 @@ public static class BuildPostProcess
                 {
                     var msg = e.Data.Trim();
                     var msgLower = msg.ToLowerInvariant();
-                    var level = SentryLevel.Info;
+                    var level = SentryLevel.Debug;
                     if (msgLower.StartsWith("error"))
                     {
                         level = SentryLevel.Error;
@@ -273,6 +273,10 @@ public static class BuildPostProcess
                     else if (msgLower.StartsWith("warn"))
                     {
                         level = SentryLevel.Warning;
+                    }
+                    else if (msgLower.StartsWith("info"))
+                    {
+                        level = SentryLevel.Info;
                     }
 
                     // Remove the level and timestamp from the beginning of the message.


### PR DESCRIPTION
Previously, everything was `info`. Now, the logged levels correspond with the actual level and respect the verbosity set in the options.