### PR TITLE
fix: `Append` builds for iOS respect CLI option changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes 
 
-- Then targeting iOS, the SDK now correctly updates the Sentry CLI options used for debug symbol upload when appending builds ([#2146](https://github.com/getsentry/sentry-unity/pull/2146))
-- When targeting Desktop Platforms, Sentry-CLI now respects the SDK's debug logging verbosity ([#2138](https://github.com/getsentry/sentry-unity/pull/2138)) 
+- When targeting iOS, the SDK now correctly updates the Sentry CLI options used for debug symbol upload when appending builds ([#2146](https://github.com/getsentry/sentry-unity/pull/2146))
+- When targeting Desktop Platforms, Sentry CLI now respects the SDK's debug logging verbosity ([#2138](https://github.com/getsentry/sentry-unity/pull/2138)) 
 - When targeting iOS and setting `IgnoreCliErrors = true`, the Xcode build will now succeed even if the symbol upload itself failed. This is aimed to allow users to unblock themselves ([#2136](https://github.com/getsentry/sentry-unity/pull/2136)) 
 - Sentry CLI no longer requires the 'Organisation' option, and they have been removed from the configuration window. If you're providing an Organisation right now, nothing changes. Fresh setups will have the option omitted  ([#2137](https://github.com/getsentry/sentry-unity/pull/2137))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes 
 
+- Then targeting iOS, the SDK now correctly updates the Sentry CLI options used for debug symbol upload when appending builds ([#2146](https://github.com/getsentry/sentry-unity/pull/2146))
 - When targeting Desktop Platforms, Sentry-CLI now respects the SDK's debug logging verbosity ([#2138](https://github.com/getsentry/sentry-unity/pull/2138)) 
 - When targeting iOS and setting `IgnoreCliErrors = true`, the Xcode build will now succeed even if the symbol upload itself failed. This is aimed to allow users to unblock themselves ([#2136](https://github.com/getsentry/sentry-unity/pull/2136)) 
 - Sentry CLI no longer requires the 'Organisation' option, and they have been removed from the configuration window. If you're providing an Organisation right now, nothing changes. Fresh setups will have the option omitted  ([#2137](https://github.com/getsentry/sentry-unity/pull/2137))

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -167,8 +167,15 @@ public static class BuildPostProcess
         SentryCli.CreateSentryProperties(pathToProject, cliOptions, options);
         SentryCli.SetupSentryCli(pathToProject, RuntimePlatform.OSXEditor);
 
-        using var sentryXcodeProject = SentryXcodeProject.Open(pathToProject, logger);
-        sentryXcodeProject.AddBuildPhaseSymbolUpload(cliOptions);
+        try
+        {
+            using var sentryXcodeProject = SentryXcodeProject.Open(pathToProject, logger);
+            sentryXcodeProject.AddBuildPhaseSymbolUpload(cliOptions);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to add the debug symbol upload build phase.");
+        }
     }
 
     internal static void CopyFramework(string sourcePath, string targetPath, IDiagnosticLogger? logger)

--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -42,22 +42,6 @@ public static class BuildPostProcess
         return true;
     }
 
-    internal static bool IsDebugSymbolUploadEnabled(SentryCliOptions? cliOptions, IDiagnosticLogger logger)
-    {
-        if (cliOptions is null)
-        {
-            logger.LogInfo("The CLI options are not found Skipping debug symbol upload.");
-            return false;
-        }
-
-        if (!cliOptions.IsValid(logger, EditorUserBuildSettings.development))
-        {
-            return false;
-        }
-
-        return true;
-    }
-
     internal static void AddSentryToXcodeProject(SentryUnityOptions? options,
         SentryCliOptions? cliOptions,
         IDiagnosticLogger logger,

--- a/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/BuildPostProcessorTests.cs
@@ -174,7 +174,7 @@ public class BuildPostProcessorTests
         var options = new SentryUnityOptions();
         var testLogger = new TestLogger();
 
-        BuildPostProcess.SetupSentry(options, null, testLogger, _outputProjectPath);
+        BuildPostProcess.SetupSentry(options, testLogger, _outputProjectPath);
 
         var bridgePath = Path.Combine(_outputProjectPath, "Libraries", SentryPackageInfo.GetName(),
             SentryXcodeProject.BridgeName);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1973

There are a couple of limitations with the [PBXProject API](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/iOS.Xcode.PBXProject.html), namely the ability to remove or overwrite an existing shell script in the build phase. When building via `append` this caused CLI options to not get copied over and respected by Xcode.

Instead of hardcoding arguments the shell script is now controlled by build settings that can be modified when building.

<img width="639" alt="Screenshot 2025-05-07 at 16 32 48" src="https://github.com/user-attachments/assets/8f77aebf-493a-441b-af17-8d4ebfb95ece" />
