### PR TITLE
fix: Building the SDK on `Windows`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -211,8 +211,12 @@ Expected to exist:
       Command="curl -L https://github.com/getsentry/sentry-cocoa/releases/download/$(CocoaVersion)/Sentry-Dynamic.xcframework.zip -o $(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip" />
 
     <Exec
-      Condition="!Exists('$(SentryCocoaCache)Sentry-Dynamic.xcframework')"
+      Condition="!Exists('$(SentryCocoaCache)Sentry-Dynamic.xcframework') AND !$([MSBuild]::IsOSPlatform('Windows'))"
       Command="unzip -o $(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip -d $(SentryCocoaCache)" />
+
+    <Exec
+      Condition="!Exists('$(SentryCocoaCache)Sentry-Dynamic.xcframework') AND $([MSBuild]::IsOSPlatform('Windows'))"
+      Command="powershell -Command &quot;Expand-Archive -Path '$(SentryCocoaCache)Sentry-Dynamic-$(CocoaVersion).xcframework.zip' -DestinationPath '$(SentryCocoaCache)' -Force&quot;" />
 
     <!-- Set up the iOS support -->
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2070