### PR TITLE
chore: Specify what CI runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
-      - "**.txt"      
+      - "**.txt"
   workflow_dispatch: # e.g. to manually trigger on foreign PRs
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: "CI"
 on:
   push:
+    branches:
+      - main
+      - release/*
+  pull_request:
     paths-ignore:
       - "**.md"
-      - "**.txt"
+      - "**.txt"      
   workflow_dispatch: # e.g. to manually trigger on foreign PRs
 
 env:


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/1845

The CI run described in the issue is not a branch but the `tag` created during releasing. Specifying the branches  should automatically exclude tags.

#skip-changelog