### PR TITLE
Revert "ci: use envs in GHAs and pin versions"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,6 @@ env:
   LOWEST_SUPPORTED_UNITY_VERSION: 2019
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
-  GITHUB_ACTOR: ${{ github.actor }}
-  GITHUB_SHA: ${{ github.sha }}
-  UNITY_VERSION: ${{ inputs.unity-version }}
 
 defaults:
   run:
@@ -24,19 +21,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
 
       - name: Checkout submodules
         run: git submodule update --init --recursive src/sentry-dotnet
 
       - name: Load env
         id: env
-        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${env:UNITY_VERSION}")" >> $env:GITHUB_OUTPUT
+        run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ inputs.unity-version }}")" >> $env:GITHUB_OUTPUT
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
       - name: Restore Unity Packages
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3
+        uses: actions/cache@v3
         with:
           path: |
             samples/unity-of-bugs/Library/Packages
@@ -47,41 +44,41 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
         with:
           registry: ghcr.io
-          username: ${{ env.GITHUB_ACTOR }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }} 
+          password: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Start the Unity docker container
-        run: ./scripts/ci-docker.sh "${UNITY_VERSION}" 'ios' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'ios' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
         shell: bash
 
       - name: Install .NET SDK
         if: runner.os != 'Windows'
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        uses: actions/setup-dotnet@v4
         with:
           global-json-file: src/sentry-dotnet/global.json
         
       - name: Install Android dotnet workflow
-        run: dotnet workload install android --temp-dir "${env:RUNNER_TEMP}"
+        run: dotnet workload install android --temp-dir "${{ runner.temp }}"
 
       - name: Download CLI
         run: ./scripts/download-sentry-cli.ps1
 
       - name: Download Android SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
           name: Android-sdk
           path: package-dev/Plugins/Android
           wait-timeout: 3600
 
       - name: Download Linux SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
           name: Linux-sdk
           path: package-dev/Plugins/Linux
           wait-timeout: 3600
 
       - name: Download Windows SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
           name: Windows-sdk
           path: package-dev/Plugins/Windows
@@ -100,16 +97,16 @@ jobs:
         run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
 
       - name: Package for release
-        if: ${{ env.UNITY_VERSION == env.LOWEST_SUPPORTED_UNITY_VERSION }}
+        if: ${{ inputs.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
         run: |
           docker exec unity dotnet msbuild /t:UnityConfigureSentryOptions /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
           ./scripts/pack.ps1
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ env.UNITY_VERSION == env.LOWEST_SUPPORTED_UNITY_VERSION }}
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.unity-version == env.LOWEST_SUPPORTED_UNITY_VERSION }}
         with:
-          name: ${{ env.GITHUB_SHA }}
+          name: ${{ github.sha }}
           if-no-files-found: error
           path: |
             package-release.zip
@@ -120,16 +117,16 @@ jobs:
           docker exec unity dotnet msbuild /t:UnityPlayModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Tests
 
       - name: Upload test artifacts (playmode)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: Test results (playmode) - ${{ env.UNITY_VERSION }}
+          name: Test results (playmode) - ${{inputs.unity-version}}
           path: artifacts/test/playmode
 
       - name: Run Unity tests (editmode)
         run: docker exec unity dotnet msbuild /t:UnityEditModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Editor.Tests
 
       - name: Upload test artifacts (editmode)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: Test results (editmode) - ${{ env.UNITY_VERSION }}
+          name: Test results (editmode) - ${{inputs.unity-version}}
           path: artifacts/test/editmode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
           name: ${{ github.sha }}
           wait-timeout: 3600
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0
+        uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8
         with:
           android: true
           dotnet: false
@@ -149,7 +149,7 @@ jobs:
           docker exec --user root unity apt-get -y -q install mono-devel
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
           name: smoke-test-${{ matrix.unity-version }}
 
@@ -157,10 +157,10 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       # - name: Build without Sentry SDK
-      #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${env:UNITY_PATH}" -Platform "${{ matrix.platform }}"
+      #   run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "${{ matrix.platform }}"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
           name: ${{ github.sha }}
           wait-timeout: 3600
@@ -187,7 +187,7 @@ jobs:
 
       # Upload runtime initialization build
       - name: Upload test app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}-runtime
           if-no-files-found: error
@@ -196,7 +196,7 @@ jobs:
           
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: failed-project-${{ matrix.platform }}-${{ matrix.unity-version }}
           path: |
@@ -302,7 +302,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download test app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: testapp-${{ matrix.platform }}-${{ matrix.unity-version }}-runtime
@@ -345,7 +345,7 @@ jobs:
           #   unity-config-path: /Library/Application Support/Unity/config/
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
 
       - name: Load env
         id: env
@@ -365,7 +365,7 @@ jobs:
           Set-Content -Path '${{ matrix.unity-config-path }}services-config.json' -Value '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
           name: smoke-test-${{ matrix.unity-version }}
 
@@ -373,10 +373,10 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Build without Sentry SDK
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${env:UNITY_PATH}"
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Download UPM package
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
           name: ${{ github.sha }}
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
 
       - name: Prepare release ${{ github.event.inputs.version }}
-        uses: getsentry/action-prepare-release@3cea80dc3938c0baf5ec4ce752ecb311f8780cdc # v1
+        uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -16,18 +16,15 @@ on:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
-  TARGET: ${{ inputs.target }}
-  CONTAINER: ${{ inputs.container }}
-  RUNS_ON: ${{ inputs.runsOn }}
 
 jobs:
   build:
-    runs-on: ${{ env.RUNS_ON }}
-    container: ${{ env.CONTAINER }}
+    runs-on: ${{ inputs.runsOn }}
+    container: ${{ inputs.container }}
     timeout-minutes: 30
     steps:
       - name: Set up Git in container
-        if: ${{ env.CONTAINER != '' }}
+        if: ${{ inputs.container != '' }}
         # ubuntu:20.04 does not have git installed by default. Make it available
         # for actions/checkout to get a proper clone instead of downloading a
         # tarball using the GitHub REST API. This ensures that git submodule
@@ -43,13 +40,13 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v3
 
       - name: Select submodules
         id: env
         shell: bash
         run: |
-          if [[ "${TARGET}" == "Android" ]]; then
+          if [[ "${{ inputs.target }}" == "Android" ]]; then
             submodules="modules/sentry-java"
           else
             submodules="modules/sentry-native"
@@ -61,11 +58,11 @@ jobs:
       - name: Get submodule status
         run: git submodule status --cached ${{ steps.env.outputs.submodules }} | tee submodules-status
 
-      - run: cp -r package-dev/Plugins/${TARGET} sdk-static || echo "never mind, no files checked in..."
+      - run: cp -r package-dev/Plugins/${{ inputs.target }} sdk-static || echo "never mind, no files checked in..."
         shell: bash
 
       - name: Restore from cache
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3
+        uses: actions/cache@v3
         id: cache
         with:
           # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
@@ -73,10 +70,10 @@ jobs:
           # hash of package/package.json for cache busting on release builds (version bump)
           path: |
             package-dev/Plugins
-          key: sdk=${{ env.TARGET }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
+          key: sdk=${{ inputs.target }}-${{ hashFiles('submodules-status', 'package/package.json', 'Directory.Build.targets', 'sdk-static/**') }}
 
       - name: Installing Linux Dependencies
-        if: ${{ env.TARGET == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ inputs.target == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           apt-get update
@@ -91,19 +88,19 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           git submodule update --init --recursive ${{ steps.env.outputs.submodules }}
-          dotnet msbuild /t:Build${TARGET}SDK /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
+          dotnet msbuild /t:Build${{ inputs.target }}SDK /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
 
       - name: Upload build logs on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ steps.env.outputs.submodulesPath }}/build.log
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.TARGET }}-sdk
-          path: package-dev/Plugins/${{ env.TARGET }}
+          name: ${{ inputs.target }}-sdk
+          path: package-dev/Plugins/${{ inputs.target }}
           # Lower retention period - we only need this to retry CI.
           retention-days: 14

--- a/.github/workflows/smoke-test-build-android.yml
+++ b/.github/workflows/smoke-test-build-android.yml
@@ -16,13 +16,10 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     env:
       UNITY_PATH: docker exec unity unity-editor
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_SHA: ${{ github.sha }}
-      UNITY_VERSION: ${{ inputs.unity-version }}
     
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -30,11 +27,11 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
         with:
           registry: ghcr.io
-          username: ${{ env.GITHUB_ACTOR }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }} 
+          password: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Start the Unity docker container
-        run: ./scripts/ci-docker.sh "${UNITY_VERSION}" 'android' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'android' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
         shell: bash
 
       # Workaround for missing libMonoPosixHelper.so
@@ -46,35 +43,35 @@ jobs:
           docker exec --user root unity apt-get -y -q install mono-devel
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
-          name: smoke-test-${{ env.UNITY_VERSION }}
+          name: smoke-test-${{ inputs.unity-version }}
 
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
-          name: ${{ env.GITHUB_SHA }}
+          name: ${{ github.sha }}
           wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
 
       - name: Add Sentry to the project
-        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${env:UNITY_PATH}"
+        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry
-        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${env:UNITY_PATH}" -Platform "Android" -CheckSymbols
+        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "Android" -CheckSymbols
 
       - name: Export APK - Runtime Initialization
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${env:UNITY_PATH}" -Platform "Android" -CheckSymbols:$true -UnityVersion "${env:UNITY_VERSION}"
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "Android" -CheckSymbols:$true -UnityVersion "${{ inputs.unity-version }}"
 
       - name: Upload .apk
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: testapp-android-compiled-${{ env.UNITY_VERSION }}-runtime
+          name: testapp-android-compiled-${{ inputs.unity-version }}-runtime
           path: samples/IntegrationTest/Build/*.apk # Collect app but ignore the files that are not required for the test.
           retention-days: 14 # Lower retention period - we only need this to retry CI.
 
@@ -86,20 +83,20 @@ jobs:
           Set-Content $optionsPath $content
 
       - name: Export APK - Build-Time Initialization
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${env:UNITY_PATH}" -Platform "Android" -CheckSymbols:$true -UnityVersion "${env:UNITY_VERSION}"
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform "Android" -CheckSymbols:$true -UnityVersion "${{ inputs.unity-version }}"
 
       - name: Upload .apk
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: testapp-android-compiled-${{ env.UNITY_VERSION }}-buildtime
+          name: testapp-android-compiled-${{ inputs.unity-version }}-buildtime
           path: samples/IntegrationTest/Build/*.apk # Collect app but ignore the files that are not required for the test.
           retention-days: 14 # Lower retention period - we only need this to retry CI.
           
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: failed-project-android-${{ env.UNITY_VERSION }}
+          name: failed-project-android-${{ inputs.unity-version }}
           path: |
             samples/IntegrationTest
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame

--- a/.github/workflows/smoke-test-build-ios.yml
+++ b/.github/workflows/smoke-test-build-ios.yml
@@ -22,13 +22,10 @@ jobs:
             build_platform: iOS
     env:
       UNITY_PATH: docker exec unity unity-editor
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_SHA: ${{ github.sha }}
-      UNITY_VERSION: ${{ inputs.unity-version }}
     
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
 
       - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -36,11 +33,11 @@ jobs:
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
         with:
           registry: ghcr.io
-          username: ${{ env.GITHUB_ACTOR }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }} 
+          password: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Start the Unity docker container
-        run: ./scripts/ci-docker.sh "${UNITY_VERSION}" 'iOS' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+        run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'iOS' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
         shell: bash
 
       # Workaround for missing libMonoPosixHelper.so
@@ -52,30 +49,30 @@ jobs:
           docker exec --user root unity apt-get -y -q install mono-devel
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
-          name: smoke-test-${{ env.UNITY_VERSION }}
+          name: smoke-test-${{ inputs.unity-version }}
 
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848
         with:
-          name: ${{ env.GITHUB_SHA }}
+          name: ${{ github.sha }}
           wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
 
       - name: Add Sentry to the project
-        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${env:UNITY_PATH}"
+        run: ./test/Scripts.Integration.Test/add-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}"
 
       - name: Configure Sentry
-        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${env:UNITY_PATH}" -Platform ${{ matrix.build_platform }} -CheckSymbols
+        run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols
 
       - name: Build Project
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${env:UNITY_PATH}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${env:UNITY_VERSION}"
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${{ inputs.unity-version }}"
 
       # We create tar explicitly because upload-artifact is slow for many files.
       - name: Create archive
@@ -87,9 +84,9 @@ jobs:
 
       # Upload runtime initialization build
       - name: Upload test app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: testapp-ios-${{ env.UNITY_VERSION }}-runtime
+          name: testapp-ios-${{ inputs.unity-version }}-runtime
           if-no-files-found: error
           path: test-app-runtime.tar.gz
           retention-days: 14
@@ -102,7 +99,7 @@ jobs:
           Set-Content $optionsPath $content
 
       - name: Build Project for mobile platforms (build-time initialization)
-        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${env:UNITY_PATH}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${env:UNITY_VERSION}"
+        run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "${{ env.UNITY_PATH }}" -Platform ${{ matrix.build_platform }} -CheckSymbols:$false -UnityVersion "${{ inputs.unity-version }}"
 
       - name: Create archive (build-time initialization)
         shell: bash
@@ -112,18 +109,18 @@ jobs:
 
       # Upload build-time initialization build
       - name: Upload test app (build-time initialization)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: testapp-ios-${{ env.UNITY_VERSION }}-buildtime
+          name: testapp-ios-${{ inputs.unity-version }}-buildtime
           if-no-files-found: error
           path: test-app-buildtime.tar.gz
           retention-days: 14
           
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: failed-project-ios-${{ env.UNITY_VERSION }}
+          name: failed-project-ios-${{ inputs.unity-version }}
           path: |
             samples/IntegrationTest
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame

--- a/.github/workflows/smoke-test-compile-ios.yml
+++ b/.github/workflows/smoke-test-compile-ios.yml
@@ -17,31 +17,28 @@ jobs:
   compile:
     name: ${{ inputs.unity-version }} ${{ inputs.init-type }}
     runs-on: 'macos-latest'
-    env:
-      UNITY_VERSION: ${{ inputs.unity-version }}
-      INIT_TYPE: ${{ inputs.init-type }}
             
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
 
       - name: Download app project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
-          name: testapp-ios-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
+          name: testapp-ios-${{ inputs.unity-version }}-${{ inputs.init-type }}
 
       - name: Extract app project
-        run: tar -xvzf test-app-${env:INIT_TYPE}.tar.gz
+        run: tar -xvzf test-app-${{ inputs.init-type }}.tar.gz
 
       - name: iOS smoke test
-        run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${env:UNITY_VERSION}" -iOSMinVersion "16.1"
+        run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${{ inputs.unity-version }}" -iOSMinVersion "16.1"
         timeout-minutes: 20
     
       - name: Upload integration-test project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: failed-project-ios-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}-compiled
+          name: failed-project-ios-${{ inputs.unity-version }}-${{ inputs.init-type }}-compiled
           path: |
             samples/IntegrationTest
             !samples/IntegrationTest/Build/*_BackUpThisFolder_ButDontShipItWithYourGame
@@ -53,9 +50,9 @@ jobs:
           Get-ChildItem -Path "samples/IntegrationTest/Build" -Recurse
           
       - name: Upload app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
-          name: testapp-ios-compiled-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
+          name: testapp-ios-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           # Collect app but ignore the files that are not required for the test.
           path: |
             samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator/

--- a/.github/workflows/smoke-test-create.yml
+++ b/.github/workflows/smoke-test-create.yml
@@ -16,12 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       UNITY_PATH: docker exec unity unity-editor
-      GITHUB_ACTOR: ${{ github.actor }}
-      UNITY_VERSION: ${{ inputs.unity-version }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@v3
 
     - run: echo "::add-mask::${{ secrets.LICENSE_SERVER_URL }}"
 
@@ -29,11 +27,11 @@ jobs:
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
       with:
         registry: ghcr.io
-        username: ${{ env.GITHUB_ACTOR }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: ${{ github.actor }} 
+        password: ${{ secrets.GITHUB_TOKEN }} 
 
     - name: Start the Unity docker container
-      run: ./scripts/ci-docker.sh "${UNITY_VERSION}" 'base' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
+      run: ./scripts/ci-docker.sh '${{ inputs.unity-version }}' 'base' '${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}'
       shell: bash
 
     - name: Create new Project
@@ -44,9 +42,9 @@ jobs:
       run: tar -cvzf test-project.tar.gz samples/IntegrationTest
 
     - name: Upload project
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v4
       with:
-        name: smoke-test-${{ env.UNITY_VERSION }}
+        name: smoke-test-${{ inputs.unity-version }}
         if-no-files-found: error
         path: test-project.tar.gz
         # Lower retention period - we only need this to retry CI.

--- a/.github/workflows/smoke-test-run-android.yml
+++ b/.github/workflows/smoke-test-run-android.yml
@@ -34,10 +34,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v4
       
       - name: Download test app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
           name: testapp-android-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           path: samples/IntegrationTest/Build
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload artifacts on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: testapp-android-logs-${{ inputs.api-level }}-${{ inputs.unity-version }}
           path: ${{ env.ARTIFACTS_PATH }}

--- a/.github/workflows/smoke-test-run-ios.yml
+++ b/.github/workflows/smoke-test-run-ios.yml
@@ -28,27 +28,23 @@ jobs:
     # Map the job outputs to step outputs
     outputs:
       status: ${{ steps.smoke-test.outputs.status }}
-    env:
-      UNITY_VERSION: ${{ inputs.unity-version }}
-      IOS_VERSION: ${{ inputs.ios-version }}
-      INIT_TYPE: ${{ inputs.init-type }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@v3
 
       - name: Download app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
-          name: testapp-ios-compiled-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
+          name: testapp-ios-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           path: samples/IntegrationTest/Build
 
       - name: List downloaded files
         run: |
           Get-ChildItem -Path "samples/IntegrationTest/Build" -Recurse
 
-      - name: Set Xcode for iOS version ${{ env.IOS_VERSION }}
-        if: ${{ env.IOS_VERSION != 'latest'}}
+      - name: Set Xcode for iOS version ${{ inputs.ios-version }}
+        if: ${{ inputs.ios-version != 'latest'}}
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # pin@v1.6
         with:
           xcode-version: '14.1' # to run iOS 16.1 we need Xcode 14.1
@@ -57,7 +53,7 @@ jobs:
         id: smoke-test
         timeout-minutes: 20
         run: |
-          $runtime = "${env:IOS_VERSION}"
+          $runtime = "${{ inputs.ios-version }}"
           If ($runtime -ne "latest")
           {
             $runtime = "iOS " + $runtime

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -56,7 +56,7 @@ jobs:
           "version=$($latest.version)" >> $env:GITHUB_OUTPUT
           "changeset=$($latest.shortRevision)" >> $env:GITHUB_OUTPUT
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 


### PR DESCRIPTION
#skip-changelog

Reverts getsentry/sentry-unity#2178

>  Invalid workflow file: .github/workflows/ci.yml#L44
The workflow is not valid. In .github/workflows/ci.yml (Line: 44, Col: 11): Error from called workflow getsentry/sentry-unity/.github/workflows/sdk.yml@11b9e4d2df26168557dba15c752abb810b487cbd (Line: 25, Col: 14): Unrecognized named-value: 'env'. Located at position 1 within expression: env.RUNS_ON In .github/workflows/ci.yml (Line: 44, Col: 11): Error from called workflow getsentry/sentry-unity/.github/workflows/sdk.yml@11b9e4d2df26168557dba15c752abb810b487cbd (Line: 26, Col: 16): Unrecognized named-value: 'env'. Located at position 1 within expression: env.CONTAINER
