### PR TITLE
meta: fix default labels of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: 🐞 Bug Report
 about: Report a bug in this repo
-labels: ["Platform: Unity", "Type: Bug"]
+labels: ["Unity", "Bug"]
 ---
 
 ### Environment

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: 💡 Feature Request
 about: Tell us about a problem our SDK could solve but doesn't.
-labels: ["Platform: Unity", "Type: Feature Request"]
+labels: ["Unity", "Feature"]
 ---
 
 What problem could Sentry solve that it doesn't?


### PR DESCRIPTION
@stephanie-anderson noted that the default labels from our issue templates in `sentry-dotnet` are no longer conforming with our current usage:
- see getsentry/sentry-dotnet#4270

This PR changes the default labels of `sentry-unity`'s _Issue Templates_ equivalently.

#skip-changelog