### PR TITLE
meta: replace default blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.md
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank Issue
+about: Blank Issue. Reserved for maintainers.
+labels: ["Unity"]
+---


### PR DESCRIPTION
See also getsentry/sentry-dotnet#4271

Similar to the issue in `sentry-dotnet` above, we want to use the label `"Unity"` for all new issues.

This PR
- disables the default bank issue
- adds an explicit blank issue
  - template copied from `sentry-java`
    - see https://github.com/getsentry/sentry-java/blob/main/.github/ISSUE_TEMPLATE/maintainer-blank.yml

#skip-changelog
