### PR TITLE
feat: Add support for Nintendo Switch

### DIFF
--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -5,6 +5,8 @@
 #define SENTRY_NATIVE_ANDROID
 #elif UNITY_64 && (UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX)
 #define SENTRY_NATIVE
+#elif UNITY_SWITCH
+#define SENTRY_NATIVE
 #elif UNITY_WEBGL
 #define SENTRY_WEBGL
 #endif
@@ -325,6 +327,8 @@ namespace Sentry.Unity
                     return options.MacosNativeSupportEnabled;
                 case RuntimePlatform.LinuxPlayer:
                     return options.LinuxNativeSupportEnabled;
+                case RuntimePlatform.Switch:
+                    return true;
 #if UNITY_2021_3_OR_NEWER
                 case RuntimePlatform.WindowsServer:
                     return options.WindowsNativeSupportEnabled;

--- a/src/Sentry.Unity.Android/SentryNative.cs
+++ b/src/Sentry.Unity.Android/SentryNative.cs
@@ -27,7 +27,7 @@ public static class SentryNative
     public static void ReinstallBackend() => ReinstallSentryNativeBackendStrategy();
 
     // libsentry.io
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_reinstall_backend();
 
     // Testing

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -18,10 +18,10 @@ public static class BuildPostProcess
     public static void OnPostProcessBuild(BuildTarget target, string executablePath)
     {
         var targetGroup = BuildPipeline.GetBuildTargetGroup(target);
-        if (targetGroup is not BuildTargetGroup.Standalone)
-        {
-            return;
-        }
+        // if (targetGroup is not BuildTargetGroup.Standalone)
+        // {
+        //     return;
+        // }
 
         var (options, cliOptions) = SentryScriptableObject.ConfiguredBuildTimeOptions();
         var logger = options?.DiagnosticLogger ?? new UnityLogger(options ?? new SentryUnityOptions());
@@ -220,7 +220,7 @@ public static class BuildPostProcess
                 }
                 break;
             default:
-                logger.LogError($"Symbol upload for '{target}' is currently not supported.");
+                // logger.LogError($"Symbol upload for '{target}' is currently not supported.");
                 break;
         }
 

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -28,11 +28,11 @@ public static class SentryNative
 
         Logger?.LogInfo("Attempting to configure native support via the Native SDK");
 
-        if (!sentryUnityInfo.IsNativeSupportEnabled(options, ApplicationAdapter.Instance.Platform))
-        {
-            Logger?.LogDebug("Native support is disabled for '{0}'.", ApplicationAdapter.Instance.Platform);
-            return;
-        }
+        // if (!sentryUnityInfo.IsNativeSupportEnabled(options, ApplicationAdapter.Instance.Platform))
+        // {
+        //     Logger?.LogDebug("Native support is disabled for '{0}'.", ApplicationAdapter.Instance.Platform);
+        //     return;
+        // }
 
         try
         {

--- a/src/Sentry.Unity.Native/SentryNativeBridge.cs
+++ b/src/Sentry.Unity.Native/SentryNativeBridge.cs
@@ -55,7 +55,7 @@ public static class SentryNativeBridge
         if (ApplicationAdapter.Instance.Platform is RuntimePlatform.WindowsPlayer)
         {
             options.DiagnosticLogger?.LogDebug("Setting CacheDirectoryPath on Windows: {0}", dir);
-            sentry_options_set_database_pathw(cOptions, dir);
+            // sentry_options_set_database_pathw(cOptions, dir);
         }
         else
         {
@@ -106,37 +106,37 @@ public static class SentryNativeBridge
     internal static void ReinstallBackend() => sentry_reinstall_backend();
 
     // libsentry.so
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern IntPtr sentry_options_new();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_dsn(IntPtr options, string dsn);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_release(IntPtr options, string release);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_debug(IntPtr options, int debug);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_environment(IntPtr options, string environment);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_sample_rate(IntPtr options, double rate);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_database_path(IntPtr options, string path);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_database_pathw(IntPtr options, [MarshalAs(UnmanagedType.LPWStr)] string path);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_auto_session_tracking(IntPtr options, int debug);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl, SetLastError = true)]
     private delegate void sentry_logger_function_t(int level, IntPtr message, IntPtr argsAddress, IntPtr userData);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_options_set_logger(IntPtr options, sentry_logger_function_t logger, IntPtr userData);
 
     // The logger we should forward native messages to. This is referenced by nativeLog() which in turn for.
@@ -266,18 +266,18 @@ public static class SentryNativeBridge
             action(ptr);
         });
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern int sentry_init(IntPtr options);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern int sentry_close();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern int sentry_get_crashed_last_run();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern int sentry_clear_crashed_last_run();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern void sentry_reinstall_backend();
 }

--- a/src/Sentry.Unity/NativeUtils/CFunctions.cs
+++ b/src/Sentry.Unity/NativeUtils/CFunctions.cs
@@ -77,78 +77,78 @@ internal static class C
         return null;
     }
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_object();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_null();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_bool(int value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_double(double value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_int32(int value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_string(string value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_new_breadcrumb(string? type, string? message);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern int sentry_value_set_by_key(sentry_value_t value, string k, sentry_value_t v);
 
     internal static bool IsNull(sentry_value_t value) => sentry_value_is_null(value) != 0;
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern int sentry_value_is_null(sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern int sentry_value_as_int32(sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern double sentry_value_as_double(sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern IntPtr sentry_value_as_string(sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern UIntPtr sentry_value_get_length(sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_get_by_index(sentry_value_t value, UIntPtr index);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern sentry_value_t sentry_value_get_by_key(sentry_value_t value, string key);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_set_context(string key, sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_add_breadcrumb(sentry_value_t breadcrumb);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_set_tag(string key, string value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_remove_tag(string key);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_set_user(sentry_value_t user);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_remove_user();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_set_extra(string key, sentry_value_t value);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_remove_extra(string key);
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_set_trace(string traceId, string parentSpanId);
 
     internal static readonly Lazy<IEnumerable<DebugImage>> DebugImages = new(LoadDebugImages);
@@ -202,10 +202,10 @@ internal static class C
 
     // Returns a new reference to an immutable, frozen list.
     // The reference must be released with `sentry_value_decref`.
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     private static extern sentry_value_t sentry_get_modules_list();
 
-    [DllImport("sentry")]
+    [DllImport("__Internal")]
     internal static extern void sentry_value_decref(sentry_value_t value);
 
     // native union sentry_value_u/t


### PR DESCRIPTION
We'll need to find a way to deal with statically built sentry-native.

Follow up on fixing the installation instructions in https://github.com/getsentry/sentry-switch/pull/26

Todos:

- [x] Import sentry-switch
- [x] Load static lib
- [ ] `AnalyticsSessionInfo::get_userId` is not valid
- [ ] Log Forwarder throws with: `Unable to load 'msvcrt'`
- [ ] Cannot start network transport because `network_connect_func option is not set`
- [ ] No support for IL2CPP line numbers: stacktrace length does not match
- [ ] Debug symbol upload? There is this `.nss` file
- [ ] Add `capture_message` to the native samples
- [ ] 