### PR TITLE
fix: Make fetching scene name run on IL2CPP only

### DIFF
--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -185,6 +185,8 @@ public class ScriptableSentryUnityOptions : ScriptableObject
             PerformanceAutoInstrumentationEnabled = AutoAwakeTraces,
         };
 
+        options.AddIntegration(new UnityScopeIntegration(application, unityInfo));
+
         if (!string.IsNullOrWhiteSpace(ReleaseOverride))
         {
             options.Release = ReleaseOverride;

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -315,7 +315,6 @@ public sealed class SentryUnityOptions : SentryOptions
         this.AddIntegration(new UnityLogHandlerIntegration(this));
         this.AddIntegration(new UnityApplicationLoggingIntegration());
         this.AddIntegration(new AnrIntegration(behaviour));
-        this.AddIntegration(new UnityScopeIntegration(application));
         this.AddIntegration(new UnityBeforeSceneLoadIntegration());
         this.AddIntegration(new SceneManagerIntegration());
         this.AddIntegration(new SessionIntegration(behaviour));

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -430,7 +430,9 @@ public sealed class UnityEventProcessorTests
     }
 
     [Test]
-    public void UnityProtocol_Assigned()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void UnityProtocol_Assigned(bool isIL2CPP)
     {
         var sceneManager = new SceneManagerIntegrationTests.FakeSceneManager { ActiveSceneName = "TestScene" };
         var systemInfo = new TestSentrySystemInfo
@@ -441,10 +443,11 @@ public sealed class UnityEventProcessorTests
             CopyTextureSupport = new Lazy<string>(() => "Basic, Copy3D, DifferentTypes, TextureToRT, RTToTexture"),
             RenderingThreadingMode = new Lazy<string>(() => "MultiThreaded")
         };
+        var testUnityInfo = new TestUnityInfo { IL2CPP = isIL2CPP };
         MainThreadData.SentrySystemInfo = systemInfo;
         MainThreadData.CollectData();
 
-        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication, sceneManager);
+        var sut = new UnityScopeUpdater(_sentryOptions, _testApplication, testUnityInfo, sceneManager);
         var scope = new Scope(_sentryOptions);
 
         // act
@@ -459,7 +462,7 @@ public sealed class UnityEventProcessorTests
         Assert.AreEqual(systemInfo.TargetFrameRate!.Value, unityProtocol.TargetFrameRate);
         Assert.AreEqual(systemInfo.CopyTextureSupport!.Value, unityProtocol.CopyTextureSupport);
         Assert.AreEqual(systemInfo.RenderingThreadingMode!.Value, unityProtocol.RenderingThreadingMode);
-        Assert.AreEqual(sceneManager.GetActiveScene().Name, unityProtocol.ActiveSceneName);
+        Assert.AreEqual(isIL2CPP ? sceneManager.GetActiveScene().Name : null, unityProtocol.ActiveSceneName);
     }
 
     [Test]


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2181