### PR TITLE
fix: Safe Execute on JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Dependencies
 
+- Bump .NET SDK from v5.7.0-beta.0 to v5.10.0 ([#2154](https://github.com/getsentry/sentry-unity/pull/2154), [#2188](https://github.com/getsentry/sentry-unity/pull/2188))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#5100)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/5.7.0-beta.0...5.10.0)
 - Bump Java SDK from v8.11.1 to v8.14.0 ([#2155](https://github.com/getsentry/sentry-unity/pull/2155), [#2199](https://github.com/getsentry/sentry-unity/pull/2199))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8140)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.11.1...8.14.0)
-- Bump .NET SDK from v5.7.0-beta.0 to v5.7.0 ([#2154](https://github.com/getsentry/sentry-unity/pull/2154))
-  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#570)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/5.7.0-beta.0...5.7.0)
 - Bump Cocoa SDK from v8.50.1 to v8.51.0 ([#2160](https://github.com/getsentry/sentry-unity/pull/2160), [#2166](https://github.com/getsentry/sentry-unity/pull/2166))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8510)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.50.1...8.51.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The SDK no longer attaches screenshots when capturing errors in the Unity Editor. ([#2163](https://github.com/getsentry/sentry-unity/pull/2163))
 
+### Fixes
+
+- When targeting Android, the SDK no longer causes `SIGABORT` crashes due to `attempting to detach while still running code`. ([#2215](https://github.com/getsentry/sentry-unity/pull/2215))
+
 ### Dependencies
 
 - Bump .NET SDK from v5.7.0-beta.0 to v5.10.0 ([#2154](https://github.com/getsentry/sentry-unity/pull/2154), [#2188](https://github.com/getsentry/sentry-unity/pull/2188))

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -1,9 +1,6 @@
 using System;
-<<<<<<< Updated upstream
-=======
 using System.Runtime.CompilerServices;
 using System.Threading;
->>>>>>> Stashed changes
 using Sentry.Extensibility;
 using UnityEngine;
 
@@ -55,12 +52,8 @@ internal interface ISentryJava
 internal class SentryJava : ISentryJava
 {
     private readonly IAndroidJNI _androidJNI;
-<<<<<<< Updated upstream
-    private IDiagnosticLogger? _logger;
-=======
     private readonly IDiagnosticLogger? _logger;
 
->>>>>>> Stashed changes
     private static AndroidJavaObject GetInternalSentryJava() => new AndroidJavaClass("io.sentry.android.core.InternalSentrySdk");
     protected virtual AndroidJavaObject GetSentryJava() => new AndroidJavaClass("io.sentry.Sentry");
 
@@ -348,20 +341,6 @@ internal class SentryJava : ISentryJava
         isMainThread ??= MainThreadData.IsMainThread();
         if (isMainThread is true)
         {
-<<<<<<< Updated upstream
-            _androidJNI.AttachCurrentThread();
-        }
-    }
-
-    internal void HandleJniThreadDetachment(bool? isMainThread = null)
-    {
-        isMainThread ??= MainThreadData.IsMainThread();
-        if (isMainThread is false)
-        {
-            _androidJNI.DetachCurrentThread();
-        }
-    }
-=======
             action.Invoke();
         }
         else
@@ -386,7 +365,6 @@ internal class SentryJava : ISentryJava
             }, (_androidJNI, _logger, actionName));
         }
     }
->>>>>>> Stashed changes
 }
 
 internal static class AndroidJavaObjectExtension

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -328,7 +328,6 @@ internal class SentryJava : ISentryJava
                 javaUser?.Dispose();
             }
         });
-
     }
 
     public void UnsetUser()

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -1,4 +1,9 @@
 using System;
+<<<<<<< Updated upstream
+=======
+using System.Runtime.CompilerServices;
+using System.Threading;
+>>>>>>> Stashed changes
 using Sentry.Extensibility;
 using UnityEngine;
 
@@ -50,7 +55,12 @@ internal interface ISentryJava
 internal class SentryJava : ISentryJava
 {
     private readonly IAndroidJNI _androidJNI;
+<<<<<<< Updated upstream
     private IDiagnosticLogger? _logger;
+=======
+    private readonly IDiagnosticLogger? _logger;
+
+>>>>>>> Stashed changes
     private static AndroidJavaObject GetInternalSentryJava() => new AndroidJavaClass("io.sentry.android.core.InternalSentrySdk");
     protected virtual AndroidJavaObject GetSentryJava() => new AndroidJavaClass("io.sentry.Sentry");
 
@@ -62,7 +72,10 @@ internal class SentryJava : ISentryJava
 
     public bool? IsEnabled()
     {
-        HandleJniThreadAttachment();
+        if (MainThreadData.IsMainThread())
+        {
+            //
+        }
 
         try
         {
@@ -73,18 +86,12 @@ internal class SentryJava : ISentryJava
         {
             _logger?.LogError(e, "Calling 'SentryJava.IsEnabled' failed.");
         }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
 
         return null;
     }
 
     public void Init(SentryUnityOptions options)
     {
-        HandleJniThreadAttachment();
-
         try
         {
             using var sentry = new AndroidJavaClass("io.sentry.android.core.SentryAndroid");
@@ -130,16 +137,10 @@ internal class SentryJava : ISentryJava
         {
             _logger?.LogError(e, "Calling 'SentryJava.Init' failed.");
         }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
     }
 
     public string? GetInstallationId()
     {
-        HandleJniThreadAttachment();
-
         try
         {
             using var sentry = GetSentryJava();
@@ -150,10 +151,6 @@ internal class SentryJava : ISentryJava
         catch (Exception e)
         {
             _logger?.LogError(e, "Calling 'SentryJava.GetInstallationId' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
         }
 
         return null;
@@ -171,8 +168,6 @@ internal class SentryJava : ISentryJava
     /// </returns>
     public bool? CrashedLastRun()
     {
-        HandleJniThreadAttachment();
-
         try
         {
             using var sentry = GetSentryJava();
@@ -183,18 +178,12 @@ internal class SentryJava : ISentryJava
         {
             _logger?.LogError(e, "Calling 'SentryJava.CrashedLastRun' failed.");
         }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
 
         return null;
     }
 
     public void Close()
     {
-        HandleJniThreadAttachment();
-
         try
         {
             using var sentry = GetSentryJava();
@@ -203,10 +192,6 @@ internal class SentryJava : ISentryJava
         catch (Exception e)
         {
             _logger?.LogError(e, "Calling 'SentryJava.Close' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
         }
     }
 
@@ -227,9 +212,7 @@ internal class SentryJava : ISentryJava
         bool? GpuMultiThreadedRendering,
         string? GpuGraphicsShaderLevel)
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var gpu = new AndroidJavaObject("io.sentry.protocol.Gpu");
             gpu.SetIfNotNull("name", GpuName);
@@ -247,15 +230,7 @@ internal class SentryJava : ISentryJava
                 using var contexts = scope.Call<AndroidJavaObject>("getContexts");
                 contexts.Call("setGpu", gpu);
             }));
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.WriteScope' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     public bool IsSentryJavaPresent()
@@ -274,9 +249,7 @@ internal class SentryJava : ISentryJava
 
     public void AddBreadcrumb(Breadcrumb breadcrumb)
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var sentry = GetSentryJava();
             using var javaBreadcrumb = new AndroidJavaObject("io.sentry.Breadcrumb");
@@ -286,137 +259,77 @@ internal class SentryJava : ISentryJava
             using var javaLevel = breadcrumb.Level.ToJavaSentryLevel();
             javaBreadcrumb.Set("level", javaLevel);
             sentry.CallStatic("addBreadcrumb", javaBreadcrumb, null);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.AddBreadcrumb' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     public void SetExtra(string key, string? value)
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var sentry = GetSentryJava();
             sentry.CallStatic("setExtra", key, value);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.SetExtra' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     public void SetTag(string key, string? value)
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var sentry = GetSentryJava();
             sentry.CallStatic("setTag", key, value);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.SetTag' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     public void UnsetTag(string key)
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var sentry = GetSentryJava();
             sentry.CallStatic("removeTag", key);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.UnsetTag' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     public void SetUser(SentryUser user)
     {
-        HandleJniThreadAttachment();
-        AndroidJavaObject? javaUser = null;
+        RunJniSafe(() =>
+        {
+            AndroidJavaObject? javaUser = null;
 
-        try
-        {
-            javaUser = new AndroidJavaObject("io.sentry.protocol.User");
-            javaUser.Set("email", user.Email);
-            javaUser.Set("id", user.Id);
-            javaUser.Set("username", user.Username);
-            javaUser.Set("ipAddress", user.IpAddress);
-            using var sentry = GetSentryJava();
-            sentry.CallStatic("setUser", javaUser);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.SetUser' failed.");
-        }
-        finally
-        {
-            javaUser?.Dispose();
-            HandleJniThreadDetachment();
-        }
+            try
+            {
+                javaUser = new AndroidJavaObject("io.sentry.protocol.User");
+                javaUser.Set("email", user.Email);
+                javaUser.Set("id", user.Id);
+                javaUser.Set("username", user.Username);
+                javaUser.Set("ipAddress", user.IpAddress);
+                using var sentry = GetSentryJava();
+                sentry.CallStatic("setUser", javaUser);
+            }
+            finally
+            {
+                javaUser?.Dispose();
+            }
+        });
+
     }
 
     public void UnsetUser()
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var sentry = GetSentryJava();
             sentry.CallStatic("setUser", null);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.UnsetUser' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     public void SetTrace(SentryId traceId, SpanId spanId)
     {
-        HandleJniThreadAttachment();
-
-        try
+        RunJniSafe(() =>
         {
             using var sentry = GetInternalSentryJava();
             // We have to explicitly cast to `(Double?)`
             sentry.CallStatic("setTrace", traceId.ToString(), spanId.ToString(), (Double?)null, (Double?)null);
-        }
-        catch (Exception e)
-        {
-            _logger?.LogError(e, "Calling 'SentryJava.SetTrace' failed.");
-        }
-        finally
-        {
-            HandleJniThreadDetachment();
-        }
+        });
     }
 
     // https://github.com/getsentry/sentry-java/blob/db4dfc92f202b1cefc48d019fdabe24d487db923/sentry/src/main/java/io/sentry/SentryLevel.java#L4-L9
@@ -430,11 +343,12 @@ internal class SentryJava : ISentryJava
         _ => "DEBUG"
     };
 
-    internal void HandleJniThreadAttachment(bool? isMainThread = null)
+    internal void RunJniSafe(Action action, [CallerMemberName] string actionName = "", bool? isMainThread = null)
     {
         isMainThread ??= MainThreadData.IsMainThread();
-        if (isMainThread is false)
+        if (isMainThread is true)
         {
+<<<<<<< Updated upstream
             _androidJNI.AttachCurrentThread();
         }
     }
@@ -447,6 +361,32 @@ internal class SentryJava : ISentryJava
             _androidJNI.DetachCurrentThread();
         }
     }
+=======
+            action.Invoke();
+        }
+        else
+        {
+            ThreadPool.QueueUserWorkItem(state =>
+            {
+                var (androidJNI, logger, name) = ((IAndroidJNI, IDiagnosticLogger?, string))state;
+
+                androidJNI.AttachCurrentThread();
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception)
+                {
+                    logger?.LogError("Calling '{0}' failed.", name);
+                }
+                finally
+                {
+                    androidJNI.DetachCurrentThread();
+                }
+            }, (_androidJNI, _logger, actionName));
+        }
+    }
+>>>>>>> Stashed changes
 }
 
 internal static class AndroidJavaObjectExtension

--- a/test/Sentry.Unity.Android.Tests/SentryJavaTests.cs
+++ b/test/Sentry.Unity.Android.Tests/SentryJavaTests.cs
@@ -17,6 +17,7 @@ public class SentryJavaTests
         _sut = new SentryJava(_logger, _androidJni);
     }
 
+<<<<<<< Updated upstream
     [Test]
     [TestCase(true, false, Description = "main thread = should attach")]
     [TestCase(false, true, Description = "non main thread = should not attach")]
@@ -41,6 +42,8 @@ public class SentryJavaTests
         Assert.AreEqual(shouldAttach, _androidJni.DetachCalled);
     }
 
+=======
+>>>>>>> Stashed changes
     internal class TestAndroidJNI : IAndroidJNI
     {
         public bool AttachCalled { get; private set; }

--- a/test/Sentry.Unity.Android.Tests/SentryJavaTests.cs
+++ b/test/Sentry.Unity.Android.Tests/SentryJavaTests.cs
@@ -17,33 +17,6 @@ public class SentryJavaTests
         _sut = new SentryJava(_logger, _androidJni);
     }
 
-<<<<<<< Updated upstream
-    [Test]
-    [TestCase(true, false, Description = "main thread = should attach")]
-    [TestCase(false, true, Description = "non main thread = should not attach")]
-    public void HandleJniThreadAttachment_AttachesIfMainThread(bool isMainThread, bool shouldAttach)
-    {
-        // Act
-        _sut.HandleJniThreadAttachment(isMainThread);
-
-        // Assert
-        Assert.AreEqual(shouldAttach, _androidJni.AttachCalled);
-    }
-
-    [Test]
-    [TestCase(true, false, Description = "main thread = should detach")]
-    [TestCase(false, true, Description = "non main thread = should not detach")]
-    public void HandleJniThreadDetachment_DetachesIfMainThread(bool isMainThread, bool shouldAttach)
-    {
-        // Act
-        _sut.HandleJniThreadDetachment(isMainThread);
-
-        // Assert
-        Assert.AreEqual(shouldAttach, _androidJni.DetachCalled);
-    }
-
-=======
->>>>>>> Stashed changes
     internal class TestAndroidJNI : IAndroidJNI
     {
         public bool AttachCalled { get; private set; }

--- a/test/Sentry.Unity.Android.Tests/SentryJavaTests.cs
+++ b/test/Sentry.Unity.Android.Tests/SentryJavaTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using Sentry.Unity.Tests.SharedClasses;
 
@@ -15,6 +18,118 @@ public class SentryJavaTests
         _logger = new TestLogger();
         _androidJni = new TestAndroidJNI();
         _sut = new SentryJava(_logger, _androidJni);
+    }
+
+    [Test]
+    public void RunJniSafe_OnMainThread_ExecutesActionWithoutAttachingDetaching()
+    {
+        // Arrange
+        var actionExecuted = false;
+        var action = new Action(() => actionExecuted = true);
+
+        // Act
+        _sut.RunJniSafe(action, isMainThread: true);
+
+        // Assert
+        Assert.That(actionExecuted, Is.True);
+        Assert.That(_androidJni.AttachCalled, Is.False); // Sanity Check
+        Assert.That(_androidJni.DetachCalled, Is.False); // Sanity Check
+    }
+
+    [Test]
+    public void RunJniSafe_NotMainThread_ExecutesOnThreadPool()
+    {
+        // Arrange
+        var actionExecuted = false;
+        var resetEvent = new ManualResetEvent(false);
+        var action = new Action(() =>
+        {
+            actionExecuted = true;
+            resetEvent.Set();
+        });
+
+        // Act
+        _sut.RunJniSafe(action, isMainThread: false);
+
+        // Assert
+        Assert.That(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), Is.True, "Action should execute within timeout");
+        Assert.That(actionExecuted, Is.True);
+        Assert.That(_androidJni.AttachCalled, Is.True);
+        Assert.That(_androidJni.DetachCalled, Is.True);
+    }
+
+    [Test]
+    public void RunJniSafe_ActionThrows_CatchesExceptionAndLogsError()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Test exception");
+        var resetEvent = new ManualResetEvent(false);
+        var action = new Action(() =>
+        {
+            try
+            {
+                throw exception;
+            }
+            finally
+            {
+                resetEvent.Set();
+            }
+        });
+
+        // Act
+        _sut.RunJniSafe(action, "TestAction", isMainThread: false);
+
+        // Assert
+        Assert.That(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), Is.True, "Action should execute within timeout");
+        Assert.That(_androidJni.AttachCalled, Is.True);
+        Assert.That(_androidJni.DetachCalled, Is.True);
+        Assert.IsTrue(_logger.Logs.Any(log =>
+            log.logLevel == SentryLevel.Error &&
+            log.message.Contains("Calling 'TestAction' failed.")));
+    }
+
+    [Test]
+    public void RunJniSafe_ActionThrowsOnMainThread_DoesNotCatchException()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Test exception");
+        var action = new Action(() => throw exception);
+
+        // Act
+        _sut.RunJniSafe(action, "TestAction", isMainThread: true);
+
+        Assert.That(_androidJni.AttachCalled, Is.False);
+        Assert.That(_androidJni.DetachCalled, Is.False);
+        Assert.IsTrue(_logger.Logs.Any(log =>
+            log.logLevel == SentryLevel.Error &&
+            log.message.Contains("Calling 'TestAction' failed.")));
+    }
+
+    [Test]
+    public void RunJniSafe_ActionThrowsOnNonMainThread_DetachIsAlwaysCalled()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Test exception");
+        var resetEvent = new ManualResetEvent(false);
+        var action = new Action(() =>
+        {
+            try
+            {
+                throw exception;
+            }
+            finally
+            {
+                resetEvent.Set();
+            }
+        });
+
+        // Act
+        _sut.RunJniSafe(action, isMainThread: false);
+
+        // Assert
+        Assert.That(resetEvent.WaitOne(TimeSpan.FromSeconds(5)), Is.True, "Action should execute within timeout");
+        Assert.That(_androidJni.AttachCalled, Is.True);
+        Assert.That(_androidJni.DetachCalled, Is.True, "DetachCurrentThread should always be called");
     }
 
     internal class TestAndroidJNI : IAndroidJNI

--- a/test/Sentry.Unity.Tests/Stubs/TestHub.cs
+++ b/test/Sentry.Unity.Tests/Stubs/TestHub.cs
@@ -83,6 +83,15 @@ internal sealed class TestHub : IHub
     public void ConfigureScope(Action<Scope> configureScope) => _configureScopeCalls.Add(configureScope);
 
     public Task ConfigureScopeAsync(Func<Scope, Task> configureScope) => Task.CompletedTask;
+    public void SetTag(string key, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void UnsetTag(string key)
+    {
+        throw new NotImplementedException();
+    }
 
     public void BindClient(ISentryClient client)
     {


### PR DESCRIPTION
Basically a followup on the scope sync changes in https://github.com/getsentry/sentry-unity/pull/2107
Fixes https://github.com/getsentry/sentry-unity/issues/2164

## Problem

The issue originates from the following scenario:

1. User/plugin code runs on a background thread
2. That thread attaches to the JVM to do some work
3. It triggers a scope sync
4. We end up in the SDK, on the same thread
5. Since it's not on the main thread it attaches/detaches for the scope sync with the Android SDK
6. The thread executing user/plugin code was detached prematurely, causing a crash with `attempting to detach while still running code`

## The fix

Since we cannot verify whether the current thread is already attached or not we "have" to do the scope sync on a thread we actually control, so we can safely attach/detach.  We **only** have to do that when not running on the main thread and we only do that on fire&forget scope sync calls. The rest of `SentryJava` is currently guaranteed - and now required - to run on the main thread.

## Alternative attempts

I could not find a way to check whether the current thread is already attached to the JVM that works for all supported versions of Unity. 

### Check `GetVersion`
In versions `2022_and_newer` it's possible to call `AndroidJNI.GetVersion()` which returns 
- When not attached: `0`
- When attached: the actual version

On older versions of Unity `GetVersion` always returns the actual version, creating a false positive.

### Try-Catch AndroidException
I tried an approach by accessing AndroidObjects while not attached to capture the resulting AndroidException which again, worked on `2022_and_newer` but straight up crashes the game on older versions.