### PR TITLE
fix: MainThread check checks for Job execution

### DIFF
--- a/src/Sentry.Unity/MainThreadData.cs
+++ b/src/Sentry.Unity/MainThreadData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Unity.Jobs.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace Sentry.Unity;
@@ -70,7 +71,7 @@ internal static class MainThreadData
     public static DateTimeOffset? StartTime { get; set; }
 
     public static bool IsMainThread()
-        => MainThreadId.HasValue && Thread.CurrentThread.ManagedThreadId == MainThreadId;
+        => !JobsUtility.IsExecutingJob && MainThreadId.HasValue && Thread.CurrentThread.ManagedThreadId == MainThreadId;
 
     // For testing
     internal static ISentrySystemInfo? SentrySystemInfo { get; set; }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2216

The fix is straight forward: Based on the [Unity docs](https://docs.unity3d.com/ScriptReference/Unity.Jobs.LowLevel.Unsafe.JobsUtility.IsExecutingJob.html) `JobsUtility.IsExecutingJob` allows us to check whether this is getting called from within a job.

Keeping this as draft as I've been unable to reproduce this locally and adding something to the smoke tests would be really nice.