### PR TITLE
fix: CI Unity 2020 Android API level

### DIFF
--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -86,6 +86,12 @@ public class Builder
             Debug.Log($"Builder: Creating output directory at '{outputDir}'");
             Directory.CreateDirectory(outputDir);
 
+#if UNITY_2020_3
+            // The default for 2020.3 is 19. There will be no further updates to 2020.3.
+            Debug.Log("Builder: Raising the minSdkVersion to 21");
+            PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel21;
+#endif
+            
             Debug.Log("Builder: Enabling minify");
 #if UNITY_2020_1_OR_NEWER
             PlayerSettings.Android.minifyDebug = PlayerSettings.Android.minifyRelease = true;


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-unity/pull/2231 - This slipped through when updating the `Builder.cs`

The default API level in Unity 2020 is 19, leading to the following error

```
  10:41:30.915 | /sentry-unity/samples/IntegrationTest/Temp/gradleOut/launcher/src/main/AndroidManifest.xml Error:
  10:41:30.915 | 	uses-sdk:minSdkVersion 19 cannot be smaller than version 21 declared in library [:sentry-android-ndk-release:] /home/gh/.gradle/caches/transforms-2/files-2.1/8d26493c05c6c8bf9a67a4b46bd75e75/sentry-android-ndk-release/AndroidManifest.xml as the library might be using APIs not available in 19
  10:41:30.916 | 	Suggestion: use a compatible library with a minSdk of at most 19,
  10:41:30.916 | 		or increase this project's minSdk version to at least 21,
  10:41:30.916 | 		or use tools:overrideLibrary="io.sentry.android.ndk" to force usage (may lead to runtime failures)
```

#skip-changelog