### PR TITLE
fix: Moved late option mutation into `Init`

### DIFF
--- a/src/Sentry.Unity/Il2CppEventProcessor.cs
+++ b/src/Sentry.Unity/Il2CppEventProcessor.cs
@@ -17,12 +17,15 @@ internal class UnityIl2CppEventExceptionProcessor : ISentryEventExceptionProcess
     private static ISentryUnityInfo UnityInfo = null!; // private static will be initialized in the constructor
     private readonly Il2CppMethods _il2CppMethods;
 
-    public UnityIl2CppEventExceptionProcessor(SentryUnityOptions options, ISentryUnityInfo unityInfo)
+    public UnityIl2CppEventExceptionProcessor(SentryUnityOptions options)
     {
         Options = options;
-        UnityInfo = unityInfo;
-        _il2CppMethods = unityInfo.Il2CppMethods ?? throw new ArgumentNullException(nameof(unityInfo.Il2CppMethods),
-            "Unity IL2CPP methods are not available.");
+
+        // We're throwing here but this should never happen. We're validating UnityInfo before adding the processor.
+        UnityInfo = SentryPlatformServices.UnityInfo
+                    ?? throw new ArgumentNullException(nameof(SentryPlatformServices.UnityInfo), "UnityInfo is null");
+        _il2CppMethods = UnityInfo.Il2CppMethods
+                    ?? throw new ArgumentNullException(nameof(UnityInfo.Il2CppMethods), "Unity IL2CPP methods are not available.");
 
         Options.SdkIntegrationNames.Add("IL2CPPLineNumbers");
     }

--- a/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
+++ b/src/Sentry.Unity/ScriptableSentryUnityOptions.cs
@@ -136,7 +136,7 @@ public class ScriptableSentryUnityOptions : ScriptableObject
     {
         application ??= ApplicationAdapter.Instance;
 
-        var options = new SentryUnityOptions(isBuilding, application, unityInfo)
+        var options = new SentryUnityOptions(isBuilding, application, unityInfo, SentryMonoBehaviour.Instance)
         {
             Enabled = Enabled,
             Dsn = Dsn,
@@ -186,6 +186,12 @@ public class ScriptableSentryUnityOptions : ScriptableObject
             PerformanceAutoInstrumentationEnabled = AutoAwakeTraces,
         };
 
+        // By default, the cacheDirectoryPath gets set on known platforms. The option is enabled by default
+        if (!EnableOfflineCaching)
+        {
+            options.CacheDirectoryPath = null;
+        }
+
         if (!string.IsNullOrWhiteSpace(ReleaseOverride))
         {
             options.Release = ReleaseOverride;
@@ -227,64 +233,17 @@ public class ScriptableSentryUnityOptions : ScriptableObject
         // Without setting up here we might miss out on logs between option-loading (now) and Init - i.e. native configuration
         options.SetupUnityLogging();
 
-        if (options.AttachViewHierarchy)
-        {
-            options.AddEventProcessor(new ViewHierarchyEventProcessor(options));
-        }
-        if (options.AttachScreenshot)
-        {
-            options.AddEventProcessor(new ScreenshotEventProcessor(options));
-        }
-
-        if (!application.IsEditor && options.Il2CppLineNumberSupportEnabled && unityInfo is not null)
-        {
-            options.AddIl2CppExceptionProcessor(unityInfo);
-        }
-
-        HandlePlatformRestrictedOptions(options, unityInfo, application);
+        // ExceptionFilters are added by default to the options.
         HandleExceptionFilter(options);
 
+        // The AnrDetectionIntegration is added by default. Since it is a ScriptableUnityOptions-only property we have to
+        // remove the integration when creating the options through here
         if (!AnrDetectionEnabled)
         {
             options.DisableAnrIntegration();
         }
 
         return options;
-    }
-
-    internal void HandlePlatformRestrictedOptions(SentryUnityOptions options, ISentryUnityInfo? unityInfo, IApplication application)
-    {
-        if (unityInfo?.IsKnownPlatform() == false)
-        {
-            options.DisableFileWrite = true;
-
-            // This is only provided on a best-effort basis for other than the explicitly supported platforms.
-            if (options.BackgroundWorker is null)
-            {
-                options.DiagnosticLogger?.LogDebug("Platform support for background thread execution is unknown: using WebBackgroundWorker.");
-                options.BackgroundWorker = new WebBackgroundWorker(options, SentryMonoBehaviour.Instance);
-            }
-
-            // Disable offline caching regardless whether it was enabled or not.
-            options.CacheDirectoryPath = null;
-            if (EnableOfflineCaching)
-            {
-                options.DiagnosticLogger?.LogDebug("Platform support for offline caching is unknown: disabling.");
-            }
-
-            // Requires file access, see https://github.com/getsentry/sentry-unity/issues/290#issuecomment-1163608988
-            if (options.AutoSessionTracking)
-            {
-                options.DiagnosticLogger?.LogDebug("Platform support for automatic session tracking is unknown: disabling.");
-                options.AutoSessionTracking = false;
-            }
-
-            return;
-        }
-
-        // Only assign the cache directory path if we're on a "known" platform. Accessing `Application.persistentDataPath`
-        // implicitly creates a directory and leads to crashes i.e. on the Switch.
-        options.CacheDirectoryPath = EnableOfflineCaching ? application.PersistentDataPath : null;
     }
 
     private void HandleExceptionFilter(SentryUnityOptions options)

--- a/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
+++ b/src/Sentry.Unity/SentryUnityOptionsExtensions.cs
@@ -63,18 +63,6 @@ public static class SentryUnityOptionsExtensions
         }
     }
 
-    internal static void AddIl2CppExceptionProcessor(this SentryUnityOptions options, ISentryUnityInfo unityInfo)
-    {
-        if (unityInfo.Il2CppMethods is not null)
-        {
-            options.AddExceptionProcessor(new UnityIl2CppEventExceptionProcessor(options, unityInfo));
-        }
-        else
-        {
-            options.DiagnosticLogger?.LogWarning("Failed to find required IL2CPP methods - Skipping line number support");
-        }
-    }
-
     /// <summary>
     /// Disables the capture of errors through <see cref="UnityLogHandlerIntegration"/>.
     /// </summary>

--- a/test/Sentry.Unity.Tests/ContextWriterTests.cs
+++ b/test/Sentry.Unity.Tests/ContextWriterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using NUnit.Framework;
+using Sentry.Unity.NativeUtils;
 using Sentry.Unity.Tests.SharedClasses;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
@@ -66,7 +67,7 @@ public sealed class ContextWriterTests
 
         };
         var context = new MockContextWriter();
-        var options = new SentryUnityOptions(_sentryMonoBehaviour, _testApplication, false)
+        var options = new SentryUnityOptions(false, _testApplication, SentryPlatformServices.UnityInfo, _sentryMonoBehaviour)
         {
             Dsn = "http://publickey@localhost/12345",
             Enabled = true,

--- a/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/ScriptableSentryUnityOptionsTests.cs
@@ -128,18 +128,6 @@ public class ScriptableSentryUnityOptionsTests
     }
 
     [Test]
-    public void ToSentryUnityOptions_UnknownPlatforms_DoesNotAccessDisk()
-    {
-        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
-        _fixture.UnityInfo = new TestUnityInfo(false);
-
-        var options = scriptableOptions.ToSentryUnityOptions(false, _fixture.UnityInfo, _fixture.Application);
-
-        Assert.IsNull(options.CacheDirectoryPath);
-        Assert.IsFalse(options.AutoSessionTracking);
-    }
-
-    [Test]
     public void ToSentryUnityOptions_WebExceptionFilterAdded()
     {
         var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
@@ -176,42 +164,6 @@ public class ScriptableSentryUnityOptionsTests
         var exceptionFiltersPropertyInfo = typeof(SentryOptions).GetProperty("ExceptionFilters", BindingFlags.NonPublic | BindingFlags.Instance);
         var filters = exceptionFiltersPropertyInfo.GetValue(options) as List<IExceptionFilter>;
         Assert.True(filters.OfType<UnityBadGatewayExceptionFilter>().Any());
-    }
-
-    [Test]
-    public void HandlePlatformRestrictedOptions_UnknownPlatform_SetsRestrictedOptions()
-    {
-        _fixture.UnityInfo = new TestUnityInfo(false);
-
-        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
-        scriptableOptions.EnableOfflineCaching = true;
-
-        var options = new SentryUnityOptions
-        {
-            DisableFileWrite = false,
-            CacheDirectoryPath = "some/path",
-            AutoSessionTracking = true
-        };
-
-        scriptableOptions.HandlePlatformRestrictedOptions(options, _fixture.UnityInfo, _fixture.Application);
-
-        Assert.IsTrue(options.DisableFileWrite);
-        Assert.IsNull(options.CacheDirectoryPath);
-        Assert.IsFalse(options.AutoSessionTracking);
-        Assert.IsTrue(options.BackgroundWorker is WebBackgroundWorker);
-    }
-
-    [Test]
-    public void HandlePlatformRestrictedOptions_KnownPlatform_SetsRestrictedOptions()
-    {
-        var scriptableOptions = ScriptableObject.CreateInstance<ScriptableSentryUnityOptions>();
-        scriptableOptions.EnableOfflineCaching = true;
-
-        var options = new SentryUnityOptions();
-
-        scriptableOptions.HandlePlatformRestrictedOptions(options, _fixture.UnityInfo, _fixture.Application);
-
-        Assert.AreEqual(options.CacheDirectoryPath, _fixture.Application.PersistentDataPath);
     }
 
     public static void AssertOptions(SentryUnityOptions expected, SentryUnityOptions actual)

--- a/test/Sentry.Unity.Tests/SentryUnityOptionsTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityOptionsTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Sentry.Unity.NativeUtils;
 using Sentry.Unity.Tests.Stubs;
 
 namespace Sentry.Unity.Tests;
@@ -7,6 +8,7 @@ public sealed class SentryUnityOptionsTests
 {
     class Fixture
     {
+        public TestUnityInfo UnityInfo { get; set; } = new();
         public TestApplication Application { get; set; } = new(
             productName: "TestApplication",
             version: "0.1.0",
@@ -14,7 +16,7 @@ public sealed class SentryUnityOptionsTests
             persistentDataPath: "test/persistent/data/path");
         public bool IsBuilding { get; set; }
 
-        public SentryUnityOptions GetSut() => new SentryUnityOptions(IsBuilding, Application);
+        public SentryUnityOptions GetSut() => new(IsBuilding, Application, UnityInfo, SentryMonoBehaviour.Instance);
     }
 
     [SetUp]
@@ -37,7 +39,17 @@ public sealed class SentryUnityOptionsTests
     }
 
     [Test]
-    public void Ctor_CacheDirectoryPath_IsNull() => Assert.IsNull(_fixture.GetSut().CacheDirectoryPath);
+    [TestCase(true, "some/path", "some/path")]
+    [TestCase(false, "some/path", null)]
+    public void Ctor_IfPlatformIsKnown_SetsCacheDirectoryPath(bool isKnownPlatform, string applicationDataPath, string? expectedCacheDirectoryPath)
+    {
+        _fixture.UnityInfo = new TestUnityInfo(isKnownPlatform: isKnownPlatform);
+        _fixture.Application.PersistentDataPath = applicationDataPath;
+
+        var sut = _fixture.GetSut();
+
+        Assert.AreEqual(sut.CacheDirectoryPath, expectedCacheDirectoryPath);
+    }
 
     [Test]
     public void Ctor_IsGlobalModeEnabled_IsTrue() => Assert.IsTrue(_fixture.GetSut().IsGlobalModeEnabled);

--- a/test/Sentry.Unity.Tests/SentryUnityTests.cs
+++ b/test/Sentry.Unity.Tests/SentryUnityTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Debug = UnityEngine.Debug;
 using Sentry.Extensibility;
 using Sentry.Unity.Tests.SharedClasses;
+using Sentry.Unity.Tests.Stubs;
 
 namespace Sentry.Unity.Tests;
 
@@ -172,5 +173,22 @@ public class SentryUnitySelfInitializationTests
 
         // Assert
         Assert.AreEqual(SentrySdk.CrashedLastRun.Unknown, result);
+    }
+
+    [Test]
+    public void HandlePlatformRestrictedOptions_UnknownPlatform_SetsRestrictedOptions()
+    {
+        var unityInfo = new TestUnityInfo(false);
+        var options = new SentryUnityOptions
+        {
+            DisableFileWrite = false,
+            AutoSessionTracking = true
+        };
+
+        SentryUnitySdk.HandlePlatformRestrictedOptions(options, unityInfo);
+
+        Assert.IsTrue(options.DisableFileWrite);
+        Assert.IsFalse(options.AutoSessionTracking);
+        Assert.IsTrue(options.BackgroundWorker is WebBackgroundWorker);
     }
 }

--- a/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
+++ b/test/Sentry.Unity.Tests/UnityEventScopeTests.cs
@@ -113,7 +113,7 @@ public sealed class UnityEventProcessorThreadingTests
             RenderingThreadingMode = new Lazy<string>(() => "MultiThreaded"),
             StartTime = new(() => DateTimeOffset.UtcNow),
         };
-        var options = new SentryUnityOptions(_sentryMonoBehaviour, _testApplication, false, new TestUnityInfo { IL2CPP = true })
+        var options = new SentryUnityOptions(false, _testApplication, new TestUnityInfo { IL2CPP = true }, _sentryMonoBehaviour)
         {
             Dsn = "https://b8fd848b31444e80aa102e96d2a6a648@o510466.ingest.sentry.io/5606182",
             Enabled = true,

--- a/test/SharedClasses/TestApplication.cs
+++ b/test/SharedClasses/TestApplication.cs
@@ -32,7 +32,7 @@ public sealed class TestApplication : IApplication
     public string Version { get; }
     public string BuildGUID { get; }
     public string UnityVersion { get; set; }
-    public string PersistentDataPath { get; }
+    public string PersistentDataPath { get; set; }
     public RuntimePlatform Platform { get; set; }
     private void OnQuitting() => Quitting?.Invoke();
 


### PR DESCRIPTION
This is a follow-up on https://github.com/getsentry/sentry-unity/pull/2227 as this was getting already kinda big.

## Goal

This PR moves adding integrations that depend on certain flags into the `Init` call to be added "late" to keep the SDKs behavious consistent between self and manual initialization.

## Context

There are two ways `SentryUnityOptions` gets created:
- Self-Initializing: The SDK reads the `.asset` and creates new options from the ScriptableObject
- Manual-Initialization: User code initializes the SDK

In both cases, changes to the options need to be made at the same time. This leaves either the constructor or right before initialization.

## Note

One could point out the inconsistency how integrations get controlled and added, i.e. `AnrIntegration`, `ScreenshotProcessor` and `ViewHierarchyProcessor`. We could make changes to this but we'd require users to update from
```
options.AttachScreenshot = true;
```
to
```
options.AddEventProcessor(new ViewHierarchyEventProcessor(options));
```
which is not all that much better.