### PR TITLE
fix: Roll forward for `Assembly Alias`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         run: docker exec unity dotnet build -c Release
 
       - name: Install assemblyalias
-        run: docker exec unity dotnet tool install --global Alias --version 0.4.3
+        run: docker exec unity dotnet tool install --global Alias --version 0.4.3 --allow-roll-forward
 
       - name: Alias editor assemblies
         run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"


### PR DESCRIPTION
Running [`Assembly Alias`](https://github.com/getsentry/dotnet-assembly-alias) currently fails in CI. This is due to .NET 6 not being available anymore and the tool targeting .NET 6 specifically.

```
The following frameworks were found:
  8.0.18 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
  9.0.4 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
  9.0.6 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```

To unblock ourselves we make use of [`--allow-rollforward`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install). Ideally, this would be done by the package itself. See https://github.com/getsentry/dotnet-assembly-alias/issues/20

#skip-changelog