### PR TITLE
chore: Clean `package-release` before repacking

### DIFF
--- a/scripts/repack.ps1
+++ b/scripts/repack.ps1
@@ -1,12 +1,10 @@
 # Clean up previous release artifacts
 if (Test-Path "package-release") {
     Remove-Item -Path "package-release" -Recurse -Force
-    Write-Host "Removed package-release directory"
 }
 
 if (Test-Path "package-release.zip") {
     Remove-Item -Path "package-release.zip" -Force
-    Write-Host "Removed package-release.zip file"
 }
 
 assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"

--- a/scripts/repack.ps1
+++ b/scripts/repack.ps1
@@ -1,3 +1,14 @@
+# Clean up previous release artifacts
+if (Test-Path "package-release") {
+    Remove-Item -Path "package-release" -Recurse -Force
+    Write-Host "Removed package-release directory"
+}
+
+if (Test-Path "package-release.zip") {
+    Remove-Item -Path "package-release.zip" -Force
+    Write-Host "Removed package-release.zip file"
+}
+
 assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
 assemblyalias --target-directory "package-dev/Editor" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;Mono.Cecil*"
 


### PR DESCRIPTION
I'm running repack to manually update the `.snapshot` and it keeps getting stuck if the `package-release` stuff already exists. Well, not any longer it doesn't!

#skip-changelog