### PR TITLE
Bumped from 16 to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,14 +271,14 @@ jobs:
         unity-version: ["2020.3", "2022.3", "6000.0", "6000.1"]
         # Check https://support.apple.com/en-us/HT201222 for the latest minor version for a given major one.
         # https://developer.apple.com/support/app-store/ shows that of all iOS devices
-        # - `iOS 17`: 86 %
-        # - `iOS 16`: 11 %
-        # - the rest:  3 %
-        # as of October, 2024. Therefore, let's stick to testing iOS 16 and `latest` for now.
+        # - `iOS 18`: 88 %
+        # - `iOS 17`: 17 %
+        # - the rest:  4 %
+        # as of August, 2025. Therefore, let's stick to testing iOS 17 and `latest` for now.
         # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
         # Also make sure to match the versions available here:
-        #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-        ios-version: ["16.1", latest] # last updated October 2024
+        #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
+        ios-version: ["17.0", latest] # updated August 2025 to match available simulators
         init-type: ["runtime", "buildtime"]
 
   smoke-test-run:

--- a/.github/workflows/smoke-test-compile-ios.yml
+++ b/.github/workflows/smoke-test-compile-ios.yml
@@ -34,7 +34,7 @@ jobs:
         run: tar -xvzf test-app-${env:INIT_TYPE}.tar.gz
 
       - name: iOS smoke test
-        run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${env:UNITY_VERSION}" -iOSMinVersion "16.1"
+        run: ./scripts/smoke-test-ios.ps1 Build -IsIntegrationTest -UnityVersion "${env:UNITY_VERSION}" -iOSMinVersion "17.0"
         timeout-minutes: 20
     
       - name: Upload integration-test project on failure

--- a/.github/workflows/smoke-test-run-ios.yml
+++ b/.github/workflows/smoke-test-run-ios.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   run:
     name: ${{ inputs.unity-version }} ${{ inputs.ios-version }} ${{ inputs.init-type }}
-    runs-on: macos-13 # Pinning to get the oldest, supported version of iOS simulator
+    runs-on: macos-14 # Pinning to get the oldest, supported version of iOS simulator
     # Map the job outputs to step outputs
     outputs:
       status: ${{ steps.smoke-test.outputs.status }}
@@ -51,7 +51,7 @@ jobs:
         if: ${{ env.IOS_VERSION != 'latest'}}
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # pin@v1.6
         with:
-          xcode-version: '14.1' # to run iOS 16.1 we need Xcode 14.1
+          xcode-version: '15.0' # to run iOS 17.0 we need Xcode 15.0
 
       - name: Run iOS Smoke Tests
         id: smoke-test


### PR DESCRIPTION
Usage has changed and needs updating. Pinning to macos-14 see [readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md).


#skip-changelog