### PR TITLE
fix: Collect `MainThreadData` first thing in `Init`

### DIFF
--- a/package-dev/Runtime/SentryInitialization.cs
+++ b/package-dev/Runtime/SentryInitialization.cs
@@ -57,8 +57,8 @@ namespace Sentry.Unity
 #endif
         private static void Init()
         {
-            // We're setting up `UnityInfo` and the platform specific configure callbacks as the very first thing.
-            // These are required to be available during initialization.
+            // We're setting up platform specific configuration as the very first thing.
+            // These are required to be available during initialization, i.e. UnityInfo and MainThreadData.
             SetUpPlatformServices();
 
             // Loading the options invokes the ScriptableOption`Configure` callback. Users can disable the SDK via code.
@@ -81,6 +81,7 @@ namespace Sentry.Unity
 
         private static void SetUpPlatformServices()
         {
+            SentryPlatformServices.CollectMainThreadData();
             SentryPlatformServices.UnityInfo = new SentryUnityInfo();
 
 #if SENTRY_NATIVE_COCOA

--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -22,8 +22,6 @@ public static class SentryNativeAndroid
     /// <param name="options">The Sentry Unity options to use.</param>
     public static void Configure(SentryUnityOptions options)
     {
-        MainThreadData.CollectData();
-
         options.DiagnosticLogger?.LogInfo("Attempting to configure native support via the Android SDK");
 
         if (!options.AndroidNativeSupportEnabled)

--- a/src/Sentry.Unity/NativeUtils/SentryPlatformServices.cs
+++ b/src/Sentry.Unity/NativeUtils/SentryPlatformServices.cs
@@ -4,8 +4,9 @@ namespace Sentry.Unity.NativeUtils;
 
 /// <summary>
 /// These are SDK's services that are only available at runtime and cannot be baked into the SDK. The
-/// <c>SentryInitialization.cs</c> is provided as <c>.cs</c> and gets compiled with the game. It sets <c>IUnityInfo</c>
-/// and the <c>PlatformConfiguration</c> callback during the game's startup so that they are available during initializtion.
+/// <c>SentryInitialization.cs</c> is provided as <c>.cs</c> and gets compiled with the game.
+/// It sets <c>IUnityInfo</c> and the <c>PlatformConfiguration</c> callback during the game's startup, as well as collecting
+/// the MainThreadData. These are then available during both auto and manual initialization.
 /// </summary>
 /// <remarks>Consider this <c>internal</c>.</remarks>
 public static class SentryPlatformServices
@@ -31,4 +32,10 @@ public static class SentryPlatformServices
     /// The PlatformConfiguration callback is responsible for configuring the native SDK and setting up scope sync.
     /// </summary>
     public static Action<SentryUnityOptions>? PlatformConfiguration { get; set; }
+
+    /// <summary>
+    /// Collects comprehensive system and device information that must be accessed on Unity's main thread.
+    /// This includes hardware specs (CPU, GPU, memory), device details, graphics capabilities,
+    /// </summary>
+    public static void CollectMainThreadData() => MainThreadData.CollectData();
 }

--- a/src/Sentry.Unity/SentrySdk.cs
+++ b/src/Sentry.Unity/SentrySdk.cs
@@ -36,6 +36,9 @@ public static partial class SentrySdk
             options.LogWarning("The SDK has already been initialized. Skipping initialization.");
         }
 
+        // Some native SDKs (i.e. Android) rely on `MainThreadData` to be collected
+        MainThreadData.CollectData();
+
         try
         {
             // Since this mutates the options (i.e. adding scope observer) we have to invoke before initializing the SDK

--- a/src/Sentry.Unity/SentrySdk.cs
+++ b/src/Sentry.Unity/SentrySdk.cs
@@ -36,9 +36,6 @@ public static partial class SentrySdk
             options.LogWarning("The SDK has already been initialized. Skipping initialization.");
         }
 
-        // Some native SDKs (i.e. Android) rely on `MainThreadData` to be collected
-        MainThreadData.CollectData();
-
         try
         {
             // Since this mutates the options (i.e. adding scope observer) we have to invoke before initializing the SDK

--- a/src/Sentry.Unity/SentryUnitySdk.cs
+++ b/src/Sentry.Unity/SentryUnitySdk.cs
@@ -28,8 +28,6 @@ internal class SentryUnitySdk
             return null;
         }
 
-        MainThreadData.CollectData();
-
         // Some integrations are controlled through a flag and opt-in. Adding these integrations late so we have equal
         // behaviour whether the options got created through the ScriptableObject or the SDK gets manually initialized
         AddIntegrations(options);

--- a/test/Sentry.Unity.Tests/ContextWriterTests.cs
+++ b/test/Sentry.Unity.Tests/ContextWriterTests.cs
@@ -63,7 +63,6 @@ public sealed class ContextWriterTests
             CopyTextureSupport = new(() => "CopyTextureSupport"),
             RenderingThreadingMode = new(() => "RenderingThreadingMode"),
             StartTime = new(() => DateTimeOffset.UtcNow),
-
         };
         var context = new MockContextWriter();
         var options = new SentryUnityOptions(application: _testApplication, behaviour: _sentryMonoBehaviour)
@@ -79,6 +78,8 @@ public sealed class ContextWriterTests
 
         // act
         MainThreadData.SentrySystemInfo = sysInfo;
+        MainThreadData.CollectData(); // In an actual game, this happens outside and before Init()
+
         SentrySdk.Init(options);
         Assert.IsTrue(context.SyncFinished.WaitOne(TimeSpan.FromSeconds(10)));
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2247

Since the native configuration now gets called from within the SDK it does not need to be pulled out into `Android.Configure` and can universally be the first thing the SDK does.

This works because Init is getting automatically called in `SentryInitialization.cs` https://github.com/getsentry/sentry-unity/blob/c46352d4a286e22e6e1fef6d84a2a69fc77e2cd7/package-dev/Runtime/SentryInitialization.cs#L58-L71

#skip-changelog