### PR TITLE
chore: Specify `Cocoa SDK` upload in CI

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -115,8 +115,8 @@ jobs:
         with:
           name: ${{ env.TARGET }}-sdk
           path: |
-            package-dev/Plugins/iOS
-            package-dev/Plugins/macOS
+            package-dev/Plugins/iOS/Sentry.xcframework~
+            package-dev/Plugins/macOS/Sentry
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 


### PR DESCRIPTION
This is mostly a local development issue.
The `package-dev/Plugins/iOS` contains more than just the `.xcframework~` -  see [here](https://github.com/getsentry/sentry-unity/tree/main/package-dev/Plugins/iOS)

This causes the local bridge and `.m` files to be overwritten.

#skip-changelog