### PR TITLE
feat: Added `Cysharp` and `DG.Tweening` to `InAppExclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- The SDK now automatically marks stack frames from `Cysharp` and `DG.Tweening` as non in-app. 
+  This highly improves the resulting stack trace quality in the issues details. ([#2285](https://github.com/getsentry/sentry-unity/pull/2285))
+
 ### Fixes
 
 - For targeting iOS, the Unity SDK now brings an iOS-only `.xcframework`, reducing package size. ([#2264](https://github.com/getsentry/sentry-unity/pull/2264))

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -322,6 +322,7 @@ public sealed class SentryUnityOptions : SentryOptions
         AddInAppExclude("UnityEngine");
         AddInAppExclude("UnityEditor");
         AddInAppExclude("Cysharp");
+        AddInAppExclude("DG.Tweening");
 
         var processor = new UnityEventProcessor(this);
         AddEventProcessor(processor);

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -321,6 +321,8 @@ public sealed class SentryUnityOptions : SentryOptions
 
         AddInAppExclude("UnityEngine");
         AddInAppExclude("UnityEditor");
+        AddInAppExclude("Cysharp");
+
         var processor = new UnityEventProcessor(this);
         AddEventProcessor(processor);
         AddTransactionProcessor(processor);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-unity/issues/2269

The SDK should mark known third party tools and libraries to `InAppExclude` so that the stacktrace highlights the really relevant bits - the user's code.

### Cysharp

**Before:**
<img width="760" height="840" alt="Screenshot 2025-08-13 at 13 48 55" src="https://github.com/user-attachments/assets/7a107dc7-d578-4cbb-b541-232501a9e5e1" />


**After:**
<img width="805" height="839" alt="Screenshot 2025-08-13 at 14 07 59" src="https://github.com/user-attachments/assets/b3715dfb-9340-4468-b823-cc5adf13e7ee" />

### DG.Tweening

**Before:**
<img width="840" height="643" alt="Screenshot 2025-08-13 at 14 46 35" src="https://github.com/user-attachments/assets/d165c358-f3cf-4fb3-8b0b-f0f55c3e875e" />


**After:**
<img width="831" height="477" alt="Screenshot 2025-08-13 at 14 50 47" src="https://github.com/user-attachments/assets/535f9672-647b-4b3b-b7f2-239866c86012" />
