### PR TITLE
fix: Update debug symbol upload for Desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixes
 
+- The SDK now automatically picks up previously missing debug symbols - i.e. `BurstDebugInformation`, by passing the 
+  target directory path to Sentry CLI. Sentry CLI then automatically and recursively picks up any not yet uploaded symbols. ([#2298](https://github.com/getsentry/sentry-unity/pull/2298))
 - The check used to verify whether the current thread is the main-thread now includes `JobsUtility.IsExecutingJob` to support running in Burst. ([#2226](https://github.com/getsentry/sentry-unity/pull/2226))
 - For targeting iOS, the Unity SDK now brings an iOS-only `.xcframework`, reducing package size. ([#2264](https://github.com/getsentry/sentry-unity/pull/2264))
 

--- a/samples/unity-of-bugs/Assets/Scenes/1_BugFarm.unity
+++ b/samples/unity-of-bugs/Assets/Scenes/1_BugFarm.unity
@@ -1081,7 +1081,7 @@ MonoBehaviour:
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
-        m_CallState: 2
+        m_CallState: 1
 --- !u!114 &655484394
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs
+++ b/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs
@@ -19,7 +19,7 @@ public class BugFarmButtons : MonoBehaviour
 
     public void ThrowUnhandledException()
     {
-        Debug.Log("Throwing a unhandled 🕷 exception!");
+        Debug.Log("Throwing an unhandled 🕷 exception!");
         DoSomeWorkHere();
     }
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/656, https://github.com/getsentry/sentry-unity/issues/1602

With this change Sentry CLI will now pick up debug symbols from within `Burst` and `_DoNotShip` directories automatically.