### PR TITLE
fix: Deduplicate trace generation during startup and scene loading

### DIFF
--- a/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs
@@ -35,24 +35,12 @@ public class SceneManagerTracingAPI : SceneManagerAPI
     public SceneManagerTracingAPI(IDiagnosticLogger? logger) =>
         _logger = logger;
 
-    protected override UnityEngine.AsyncOperation LoadSceneAsyncByNameOrIndex(string sceneName, int sceneBuildIndex, LoadSceneParameters parameters, bool mustCompleteNextFrame)
+    protected override AsyncOperation LoadSceneAsyncByNameOrIndex(string sceneName, int sceneBuildIndex, LoadSceneParameters parameters, bool mustCompleteNextFrame)
     {
         _logger?.LogInfo("Creating '{0}' transaction for '{1}'.", TransactionOperation, sceneName);
 
         var transaction = SentrySdk.StartTransaction("scene.loading", TransactionOperation);
-        SentrySdk.ConfigureScope(scope =>
-        {
-            if (scope.Transaction is not null)
-            {
-                Debug.Log("HUEHUEHUE");
-            }
-            else
-            {
-                Debug.Log("SADADADADAD");
-            }
-
-            scope.Transaction = transaction;
-        });
+        SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
 
         _logger?.LogDebug("Creating '{0}' span.", SpanOperation);
         var span = SentrySdk.GetSpan()?.StartChild(SpanOperation, sceneName ?? $"buildIndex:{sceneBuildIndex}");

--- a/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs
@@ -1,5 +1,6 @@
 using Sentry.Extensibility;
 using Sentry.Integrations;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace Sentry.Unity;
@@ -39,7 +40,19 @@ public class SceneManagerTracingAPI : SceneManagerAPI
         _logger?.LogInfo("Creating '{0}' transaction for '{1}'.", TransactionOperation, sceneName);
 
         var transaction = SentrySdk.StartTransaction("scene.loading", TransactionOperation);
-        SentrySdk.ConfigureScope(scope => scope.Transaction = transaction);
+        SentrySdk.ConfigureScope(scope =>
+        {
+            if (scope.Transaction is not null)
+            {
+                Debug.Log("HUEHUEHUE");
+            }
+            else
+            {
+                Debug.Log("SADADADADAD");
+            }
+
+            scope.Transaction = transaction;
+        });
 
         _logger?.LogDebug("Creating '{0}' span.", SpanOperation);
         var span = SentrySdk.GetSpan()?.StartChild(SpanOperation, sceneName ?? $"buildIndex:{sceneBuildIndex}");

--- a/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs
@@ -1,6 +1,5 @@
 using Sentry.Extensibility;
 using Sentry.Integrations;
-using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace Sentry.Unity;
@@ -35,7 +34,7 @@ public class SceneManagerTracingAPI : SceneManagerAPI
     public SceneManagerTracingAPI(IDiagnosticLogger? logger) =>
         _logger = logger;
 
-    protected override AsyncOperation LoadSceneAsyncByNameOrIndex(string sceneName, int sceneBuildIndex, LoadSceneParameters parameters, bool mustCompleteNextFrame)
+    protected override UnityEngine.AsyncOperation LoadSceneAsyncByNameOrIndex(string sceneName, int sceneBuildIndex, LoadSceneParameters parameters, bool mustCompleteNextFrame)
     {
         _logger?.LogInfo("Creating '{0}' transaction for '{1}'.", TransactionOperation, sceneName);
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2235

The flow differs from Editor vs actual build since not all RuntimeInitialization attributes get triggered.

1. Init gets triggered by `RuntimeInitialization SubsystemRegistration` https://github.com/getsentry/sentry-unity/blob/dbbb63c2086bc21055c79825c28888cbeeb37f6e/package-dev/Runtime/SentryInitialization.cs#L68
2. The `SentryUnitySdk` initializes the .NET SDK https://github.com/getsentry/sentry-unity/blob/dbbb63c2086bc21055c79825c28888cbeeb37f6e/src/Sentry.Unity/SentryUnitySdk.cs#L38
3. All integrations get registered
    - **NEW** The `TraceGenerationIntegration` refrains from regenerating any traces that would be covered by other integrations
4. The `StartupTracingIntegration` creates a transaction and it's child spans https://github.com/getsentry/sentry-unity/blob/dbbb63c2086bc21055c79825c28888cbeeb37f6e/src/Sentry.Unity/SentryUnitySdk.cs#L42
5. The first scene loads. 
    - Note: For the first scene, the [SceneManagerTracingIntegration](https://github.com/getsentry/sentry-unity/blob/dbbb63c2086bc21055c79825c28888cbeeb37f6e/src/Sentry.Unity/Integrations/SceneManagerTracingIntegration.cs) is not getting invoked. This happens outside of the `SceneManagerAPI`.
    - This means there is no need to deduplicate between `StartupTracing` and `SceneManagerTracing`
6. For all subsequent scene loading, the `SceneManagerTracingIntegration` is solely responsible for generating a transaction. Finishing the transaction generates a new trace implicitely.