### PR TITLE
fix: Fixed false positive ANR events on `WebGL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fixed false positive ANR events on `WebGL`, i.e. when switching tabs, or unfocusing the player ([#2306](https://github.com/getsentry/sentry-unity/pull/2306))
 - The SDK now automatically picks up previously missing debug symbols - i.e. `BurstDebugInformation`, by passing the 
   target directory path to Sentry CLI. Sentry CLI then automatically and recursively picks up any not yet uploaded symbols. ([#2298](https://github.com/getsentry/sentry-unity/pull/2298))
 - The check used to verify whether the current thread is the main-thread now includes `JobsUtility.IsExecutingJob` to support running in Burst. ([#2226](https://github.com/getsentry/sentry-unity/pull/2226))

--- a/src/Sentry.Unity/Integrations/AnrIntegration.cs
+++ b/src/Sentry.Unity/Integrations/AnrIntegration.cs
@@ -177,7 +177,9 @@ internal class AnrWatchDogSingleThreaded : AnrWatchDog
     internal AnrWatchDogSingleThreaded(IDiagnosticLogger? logger, SentryMonoBehaviour monoBehaviour, TimeSpan detectionTimeout)
         : base(logger, monoBehaviour, detectionTimeout)
     {
-        // Check the UI status periodically by running a coroutine on the UI thread and checking the elapsed time
+        // Check the UI status periodically by running a coroutine on the UI thread and checking the elapsed time.
+        // On WebGL, the coroutine keeps executing even after `ApplicationPausing` got invoked. The pause check in
+        // `Report` prevents ANR events from being reported from paused/inactive games.
         _watch.Start();
         MonoBehaviour.StartCoroutine(UpdateUiStatus());
     }


### PR DESCRIPTION
### Problem Description

The ANR (Application Not Responding) detection system was reporting false positives when Unity applications lose and regain focus with "Run In Background" disabled.

<img width="311" height="109" alt="Screenshot 2025-09-08 at 14 19 09" src="https://github.com/user-attachments/assets/bd6af850-1a9c-4763-a71a-c7fa2f2c5df3" />

#### Reproduction Steps

1. Uncheck "Run In Background" in Unity Project Settings
2. Start the application with ANR detection enabled
3. Application loses focus (e.g., user switches to another window)
4. Unity sets Application.runInBackground = false and pauses the application
5. Time continues to elapse while app is paused
6. Application regains focus and resumes
7. ANR watchdog checks elapsed time and incorrectly detects an ANR
8. False positive ANR event gets reported to Sentry

### Root Cause

The single-threaded ANR detection implementation (`AnrWatchDogSingleThreaded`) uses timestamp-based monitoring via a coroutine. When the application is paused, the coroutine stops executing but the Stopwatch continues counting elapsed time. Upon resume, the accumulated "paused time" triggers a false ANR detection.

### Solution Implemented

1. Added pause/resume event handling: The watchdog now subscribes to `MonoBehaviour.ApplicationPausing` and `MonoBehaviour.ApplicationResuming` events
2. Coroutine lifecycle management:
    - On Pause: Stops the Stopwatch and terminates the ANR detection coroutine
    - On Resume: Restarts the Stopwatch and creates a new ANR detection coroutine