### PR TITLE
fix: Fixed `setup-unity` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
         run: echo "unityVersion=$(./scripts/ci-env.ps1 "unity${{ matrix.unity-version }}")" >> $env:GITHUB_OUTPUT
 
       - name: Setup Unity
-        uses: getsentry/setup-unity@78c18fa766b6ddb9b70e3b24919e806d168671f6
+        uses: getsentry/setup-unity@3bdc8c022b6d30ecf2d21d12a564bfa55a54fa2e
         with:
           unity-version: ${{ steps.env.outputs.unityVersion }}
           unity-modules: ${{ matrix.unity-modules }}


### PR DESCRIPTION
The hub changed the message printed when prompted to return installed editor versions. This bump contains the fix.

#skip-changelog