### PR TITLE
feat: Unified mechanism for generating user ID

### DIFF
--- a/src/Sentry.Unity.Android/SentryNativeAndroid.cs
+++ b/src/Sentry.Unity.Android/SentryNativeAndroid.cs
@@ -77,8 +77,7 @@ public static class SentryNativeAndroid
             if (crashedLastRun is null)
             {
                 // Could happen if the Android SDK wasn't initialized before the .NET layer.
-                options.DiagnosticLogger?
-                    .LogWarning(
+                options.DiagnosticLogger?.LogWarning(
                         "Unclear from the native SDK if the previous run was a crash. Assuming it was not.");
                 crashedLastRun = false;
             }
@@ -115,10 +114,7 @@ public static class SentryNativeAndroid
             options.DiagnosticLogger?.LogDebug(
                 "Failed to fetch 'Installation ID' from the native SDK. Creating new 'Default User ID'.");
 
-            // We fall back to Unity's Analytics Session Info: https://docs.unity3d.com/ScriptReference/Analytics.AnalyticsSessionInfo-userId.html
-            // It's a randomly generated GUID that gets created immediately after installation helping
-            // to identify the same instance of the game
-            options.DefaultUserId = AnalyticsSessionInfo.userId;
+            options.DefaultUserId = SentryInstallationIdProvider.GetInstallationId(options);
             if (options.DefaultUserId is not null)
             {
                 options.ScopeObserver.SetUser(new SentryUser { Id = options.DefaultUserId });

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -58,8 +58,7 @@ public static class SentryNative
         options.EnableScopeSync = true;
         options.NativeContextWriter = new NativeContextWriter();
 
-        // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
-        options.DefaultUserId = AnalyticsSessionInfo.userId;
+        options.DefaultUserId = SentryInstallationIdProvider.GetInstallationId(options);
         if (options.DefaultUserId is not null)
         {
             options.ScopeObserver.SetUser(new SentryUser { Id = options.DefaultUserId });

--- a/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
+++ b/src/Sentry.Unity.iOS/SentryNativeCocoa.cs
@@ -75,10 +75,7 @@ public static class SentryNativeCocoa
                 // In case we can't get an installation ID we create one and sync that down to the native layer
                 options.DiagnosticLogger?.LogDebug("Failed to fetch 'Installation ID' from the native SDK. Creating new 'Default User ID'.");
 
-                // We fall back to Unity's Analytics Session Info: https://docs.unity3d.com/ScriptReference/Analytics.AnalyticsSessionInfo-userId.html
-                // It's a randomly generated GUID that gets created immediately after installation helping
-                // to identify the same instance of the game
-                options.DefaultUserId = AnalyticsSessionInfo.userId;
+                options.DefaultUserId = SentryInstallationIdProvider.GetInstallationId(options);
                 if (options.DefaultUserId is not null)
                 {
                     options.ScopeObserver.SetUser(new SentryUser { Id = options.DefaultUserId });

--- a/src/Sentry.Unity/SentryInstallationIdProvider.cs
+++ b/src/Sentry.Unity/SentryInstallationIdProvider.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using Sentry.Extensibility;
+using UnityEngine;
+
+namespace Sentry.Unity;
+
+/// <summary>
+/// Provides game-specific installation IDs with robust fallback strategies for different Unity platforms.
+/// Ensures no cross-app tracking while maintaining persistence across app restarts where possible.
+/// Automatically avoids disk writes on platforms with restricted file access (consoles, WebGL, tvOS).
+/// </summary>
+internal static class SentryInstallationIdProvider
+{
+    private static string? SessionInstallationId;
+
+    /// <summary>
+    /// Gets a game-specific installation ID using a multi-tier approach:
+    /// 1. Persistent file storage (most platforms)
+    /// 2. PlayerPrefs (restricted platforms like Nintendo Switch)
+    /// 3. Session-only GUID (final fallback)
+    /// </summary>
+    /// <param name="options">Sentry options for file system access and settings</param>
+    /// <returns>A game-specific installation ID, or null if all methods fail</returns>
+    public static string? GetInstallationId(SentryUnityOptions options)
+    {
+        if (!IsPlatformWithRestrictedFileAccess())
+        {
+            var fileId = TryGetPersistentFileId(options);
+            if (!string.IsNullOrEmpty(fileId))
+            {
+                return fileId;
+            }
+        }
+
+        // Fallback to PlayerPrefs for restricted platforms
+        var prefsId = TryGetPlayerPrefsId(options.DiagnosticLogger);
+        if (!string.IsNullOrEmpty(prefsId))
+        {
+            return prefsId;
+        }
+
+        // Final fallback: session-only GUID
+        return TryGetSessionId(options.DiagnosticLogger);
+    }
+
+    private static string? TryGetPersistentFileId(SentryUnityOptions options)
+    {
+        // Check if file writes are disabled via options
+        if (options.DisableFileWrite)
+        {
+            options.DiagnosticLogger?.LogDebug("File write has been disabled via options. Skipping persistent installation ID.");
+            return null;
+        }
+
+        try
+        {
+            var directoryPath = Application.persistentDataPath;
+            var fileSystem = options.FileSystem;
+
+            // Ensure directory exists
+            if (!fileSystem.CreateDirectory(directoryPath))
+            {
+                options.DiagnosticLogger?.LogDebug("Failed to create directory for installation ID file ({0}).", directoryPath);
+                return null;
+            }
+
+            var filePath = Path.Combine(directoryPath, ".sentry-installation-id");
+
+            // Read existing installation ID if it exists
+            if (fileSystem.FileExists(filePath))
+            {
+                var existingId = fileSystem.ReadAllTextFromFile(filePath)?.Trim();
+                if (!string.IsNullOrEmpty(existingId))
+                {
+                    options.DiagnosticLogger?.LogDebug("Using existing persistent installation ID.");
+                    return existingId;
+                }
+            }
+
+            // Generate new game-specific installation ID
+            var newId = Guid.NewGuid().ToString();
+            if (!fileSystem.WriteAllTextToFile(filePath, newId))
+            {
+                options.DiagnosticLogger?.LogDebug("Failed to write installation ID to file ({0}).", filePath);
+                return null;
+            }
+
+            options.DiagnosticLogger?.LogDebug("Generated and saved new persistent installation ID to '{0}'.", filePath);
+            return newId;
+        }
+        catch (Exception e)
+        {
+            options.DiagnosticLogger?.LogError(e, "Persistent file storage failed, trying PlayerPrefs fallback.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Determines if the current platform has restricted file access where disk writes should be avoided.
+    /// </summary>
+    /// <returns>True if the platform has restricted file access</returns>
+    private static bool IsPlatformWithRestrictedFileAccess()
+    {
+        switch (Application.platform)
+        {
+            // Gaming consoles with restricted file systems
+            case RuntimePlatform.Switch:
+            case RuntimePlatform.PS4:
+            case RuntimePlatform.PS5:
+            case RuntimePlatform.XboxOne:
+            case RuntimePlatform.GameCoreXboxSeries:
+            case RuntimePlatform.GameCoreXboxOne:
+                return true;
+
+            // WebGL runs in browser with limited file system access
+            case RuntimePlatform.WebGLPlayer:
+                return true;
+
+            // tvOS and other restricted Apple platforms
+            case RuntimePlatform.tvOS:
+                return true;
+
+            // Platforms where file operations are generally reliable
+            case RuntimePlatform.WindowsPlayer:
+            case RuntimePlatform.WindowsEditor:
+            case RuntimePlatform.OSXPlayer:
+            case RuntimePlatform.OSXEditor:
+            case RuntimePlatform.LinuxPlayer:
+            case RuntimePlatform.LinuxEditor:
+            case RuntimePlatform.Android:
+            case RuntimePlatform.IPhonePlayer:
+            default:
+                return false;
+        }
+    }
+
+    private static string? TryGetPlayerPrefsId(IDiagnosticLogger? logger)
+    {
+        try
+        {
+            // Use Application.identifier to ensure game-specific key
+            var prefsKey = $"sentry_installation_id_{Application.identifier}";
+
+            if (PlayerPrefs.HasKey(prefsKey))
+            {
+                var existingId = PlayerPrefs.GetString(prefsKey);
+                if (!string.IsNullOrEmpty(existingId))
+                {
+                    logger?.LogDebug("Using existing PlayerPrefs installation ID.");
+                    return existingId;
+                }
+            }
+
+            var newId = Guid.NewGuid().ToString();
+            PlayerPrefs.SetString(prefsKey, newId);
+            PlayerPrefs.Save();
+            logger?.LogDebug("Generated and saved new PlayerPrefs installation ID.");
+            return newId;
+        }
+        catch (Exception e)
+        {
+            logger?.LogError(e, "PlayerPrefs storage failed, using session-only fallback.");
+            return null;
+        }
+    }
+
+    private static string? TryGetSessionId(IDiagnosticLogger? logger)
+    {
+        try
+        {
+            // Cache in static field for session persistence
+            if (string.IsNullOrEmpty(SessionInstallationId))
+            {
+                SessionInstallationId = Guid.NewGuid().ToString();
+                logger?.LogDebug("Generated session-only installation ID (will not persist across restarts).");
+            }
+            return SessionInstallationId;
+        }
+        catch (Exception e)
+        {
+            logger?.LogError(e, "Failed to generate session installation ID.");
+            return null;
+        }
+    }
+}

--- a/src/Sentry.Unity/WebGL/SentryWebGL.cs
+++ b/src/Sentry.Unity/WebGL/SentryWebGL.cs
@@ -38,8 +38,7 @@ public static class SentryWebGL
                                                  "it currently produces blank screenshots mid-frame.");
         }
 
-        // Use AnalyticsSessionInfo.userId as the default UserID in native & dotnet
-        options.DefaultUserId = AnalyticsSessionInfo.userId;
+        options.DefaultUserId = SentryInstallationIdProvider.GetInstallationId(options);
 
         // Indicate that this platform doesn't support running background threads.
         options.MultiThreading = false;


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2268

### Problem

`AnalyticsSessionInfo.userId` cannot be used on all platforms - i.e. Switch. We need to find a proper replacement. Ideally one, that works on all platforms.

### Proposal

Create a `Installation ID Provider`
1. Fetch `installation ID` from disk. If it does not exist, create a new GUID and persist it. This is how the Godot SDK does it and it is similar to how the .NET SDK does it with sessions
2. If we're running on a platform with restrictions to disk access - fetch and write the ID to the [`PlayerPrefs`](https://docs.unity3d.com/ScriptReference/PlayerPrefs.html). I'll have to test this on device if it works on console but I did not find contradicting documentation so I assume so.
3. If this does not work, use a new GUID for this session only.