### PR TITLE
chore: Add `SentrySdk.CrashedLastRunState` to SmokeTester

### DIFF
--- a/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/SmokeTester.cs
@@ -217,6 +217,10 @@ public class SmokeTester : MonoBehaviour
         t.Start("HASNT-CRASHED");
         var crashed = CrashedLastRun();
         t.Expect($"options.CrashedLastRun ({crashed}) == false (0)", crashed == 0);
+
+        var lastRunState = SentrySdk.GetLastRunState();
+        t.Expect($"SentrySdk.GetLastRunState() ({lastRunState}) is 'DidNotCrash'", lastRunState == CrashedLastRun.DidNotCrash);
+
         t.Pass();
     }
 
@@ -225,6 +229,10 @@ public class SmokeTester : MonoBehaviour
         t.Start("HAS-CRASHED");
         var crashed = CrashedLastRun();
         t.Expect($"options.CrashedLastRun ({crashed}) == true (1)", crashed == 1);
+        
+        var lastRunState = SentrySdk.GetLastRunState();
+        t.Expect($"SentrySdk.GetLastRunState() ({lastRunState}) is 'Crashed'", lastRunState == CrashedLastRun.Crashed);
+        
         t.Pass();
     }
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/1627, https://github.com/getsentry/sentry-unity/issues/2090

Thinking out loud: It seems like most people trying the SDK for the first time gravitate towards using `ForceCrash` to test out the SDK's capabilities. Maybe we should use the same in the SmokeTester? 