### PR TITLE
chore: Update Unity versions in CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
         type: string
 
 env:
-  LOWEST_SUPPORTED_UNITY_VERSION: 2021.3
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
   GITHUB_ACTOR: ${{ github.actor }}
@@ -107,14 +106,12 @@ jobs:
         run: docker exec unity /home/gh/.dotnet/tools/assemblyalias --target-directory "package-dev/Runtime" --internalize --prefix "Sentry." --assemblies-to-alias "Microsoft*;System*"
 
       - name: Package for release
-        if: ${{ env.UNITY_VERSION == env.LOWEST_SUPPORTED_UNITY_VERSION }}
         run: |
           docker exec unity dotnet msbuild /t:UnityConfigureSentryOptions /p:Configuration=Release /p:OutDir=other src/Sentry.Unity
           ./scripts/pack.ps1
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ env.UNITY_VERSION == env.LOWEST_SUPPORTED_UNITY_VERSION }}
         with:
           name: ${{ env.GITHUB_SHA }}
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     steps:
       - name: Set Unity version matrices based on event type
         id: set-matrix
+        shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             versions='${{ env.PR_UNITY_VERSIONS }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,6 @@ on:
   workflow_dispatch: # e.g. to manually trigger on foreign PRs
 
 env:
-  LOWEST_SUPPORTED_UNITY_VERSION: 2021.3
-  # Unity versions for PR testing (most adopted versions to reduce CI load)
-  PR_UNITY_VERSIONS: '["2022.3", "6000.0"]'
-  # Unity versions for main/push testing (complete coverage)
-  FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.1"]'
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
 
@@ -32,39 +27,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  matrix-prep:
-    runs-on: ubuntu-latest
-    outputs:
-      unity-matrix: ${{ steps.set-matrix.outputs.matrix }}
-      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
-      android-matrix: ${{ steps.set-matrix.outputs.android-matrix }}
-      ios-matrix: ${{ steps.set-matrix.outputs.ios-matrix }}
-      desktop-matrix: ${{ steps.set-matrix.outputs.desktop-matrix }}
-    steps:
-      - name: Set Unity version matrices based on event type
-        id: set-matrix
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            versions='${{ env.PR_UNITY_VERSIONS }}'
-          else
-            versions='${{ env.FULL_UNITY_VERSIONS }}'
-          fi
-          
-          # Simple unity-version only matrix
-          echo "matrix={\"unity-version\":$versions}" >> $GITHUB_OUTPUT
-          
-          # Build matrix with platforms
-          echo "build-matrix={\"unity-version\":$versions,\"platform\":[\"WebGL\",\"Linux\"],\"include\":[{\"platform\":\"WebGL\",\"check_symbols\":true,\"build_platform\":\"WebGL\"},{\"platform\":\"Linux\",\"image-suffix\":\"-il2cpp\",\"check_symbols\":true,\"build_platform\":\"Linux\"}]}" >> $GITHUB_OUTPUT
-          
-          # Android matrix with API levels and init types
-          echo "android-matrix={\"api-level\":[30,31,34],\"init-type\":[\"runtime\",\"buildtime\"],\"unity-version\":$versions}" >> $GITHUB_OUTPUT
-          
-          # iOS matrix with iOS versions and init types  
-          echo "ios-matrix={\"unity-version\":$versions,\"ios-version\":[\"17.0\",\"latest\"],\"init-type\":[\"runtime\",\"buildtime\"]}" >> $GITHUB_OUTPUT
-          
-          # Desktop matrix with OS
-          echo "desktop-matrix={\"unity-version\":$versions,\"os\":[\"windows\"],\"include\":[{\"os\":\"windows\",\"unity-modules\":\"windows-il2cpp\",\"unity-config-path\":\"C:/ProgramData/Unity/config/\"}]}" >> $GITHUB_OUTPUT
+  create-unity-matrix:
+    uses: ./.github/workflows/create-unity-matrix.yml
+    with:
+      event-name: ${{ github.event_name }}
 
   sdk:
     strategy:
@@ -123,11 +89,11 @@ jobs:
   smoke-test-create:
     name: Create ${{ matrix.unity-version }} Smoke Test Project
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [matrix-prep]
+    needs: [create-unity-matrix]
     secrets: inherit
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix) }}
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix) }}
     uses: ./.github/workflows/smoke-test-create.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -136,11 +102,11 @@ jobs:
   smoke-test-build:
     name: Build ${{ matrix.platform }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create, matrix-prep]
+    needs: [smoke-test-create, create-unity-matrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.build-matrix) }}            
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.build-matrix) }}            
     env:
       UNITY_PATH: docker exec unity unity-editor
     steps:
@@ -230,11 +196,11 @@ jobs:
   smoke-test-build-android:
     name: Build Android ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create, matrix-prep]
+    needs: [smoke-test-create, create-unity-matrix]
     secrets: inherit
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix) }}
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix) }}
     uses: ./.github/workflows/smoke-test-build-android.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -242,7 +208,7 @@ jobs:
   smoke-test-run-android:
     name: Run Android ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build-android, matrix-prep]
+    needs: [smoke-test-build-android, create-unity-matrix]
     uses: ./.github/workflows/smoke-test-run-android.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -250,16 +216,16 @@ jobs:
       init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.android-matrix) }}
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.android-matrix) }}
 
   smoke-test-build-ios:
     name: Build iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create, matrix-prep]
+    needs: [smoke-test-create, create-unity-matrix]
     secrets: inherit
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix) }}
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix) }}
     uses: ./.github/workflows/smoke-test-build-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -267,12 +233,12 @@ jobs:
   smoke-test-compile-ios:
     name: Compile iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build-ios, matrix-prep]
+    needs: [smoke-test-build-ios, create-unity-matrix]
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        unity-version: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix).unity-version }}
+        unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
         init-type: ["runtime", "buildtime"]
     uses: ./.github/workflows/smoke-test-compile-ios.yml
     with:
@@ -282,7 +248,7 @@ jobs:
   smoke-test-run-ios:
     name: Run iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-compile-ios, matrix-prep]
+    needs: [smoke-test-compile-ios, create-unity-matrix]
     uses: ./.github/workflows/smoke-test-run-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -290,7 +256,7 @@ jobs:
       init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.ios-matrix) }}
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.ios-matrix) }}
         # Check https://support.apple.com/en-us/HT201222 for the latest minor version for a given major one.
         # https://developer.apple.com/support/app-store/ shows that of all iOS devices
         # - `iOS 18`: 88 %
@@ -304,12 +270,12 @@ jobs:
   smoke-test-run:
     name: Run ${{ matrix.platform }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build, matrix-prep]
+    needs: [smoke-test-build, create-unity-matrix]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        unity-version: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix).unity-version }}
+        unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
         platform: ["WebGL", "Linux"]
     steps:
       - name: Checkout
@@ -342,11 +308,11 @@ jobs:
   desktop-smoke-test:
     name: Run ${{ matrix.os }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create, matrix-prep]
+    needs: [smoke-test-create, create-unity-matrix]
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix-prep.outputs.desktop-matrix) }}
+      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.desktop-matrix) }}
         # os: ["windows", "macos"]
         # include:
           # - os: macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 
 env:
   LOWEST_SUPPORTED_UNITY_VERSION: 2021.3
+  # Unity versions for PR testing (most adopted versions to reduce CI load)
+  PR_UNITY_VERSIONS: '["2022.3", "6000.0"]'
+  # Unity versions for main/push testing (complete coverage)
+  FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.1"]'
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
 
@@ -27,6 +31,39 @@ jobs:
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # pin@0.11.0
         with:
           access_token: ${{ github.token }}
+
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      unity-matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+      android-matrix: ${{ steps.set-matrix.outputs.android-matrix }}
+      ios-matrix: ${{ steps.set-matrix.outputs.ios-matrix }}
+      desktop-matrix: ${{ steps.set-matrix.outputs.desktop-matrix }}
+    steps:
+      - name: Set Unity version matrices based on event type
+        id: set-matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            versions='${{ env.PR_UNITY_VERSIONS }}'
+          else
+            versions='${{ env.FULL_UNITY_VERSIONS }}'
+          fi
+          
+          # Simple unity-version only matrix
+          echo "matrix={\"unity-version\":$versions}" >> $GITHUB_OUTPUT
+          
+          # Build matrix with platforms
+          echo "build-matrix={\"unity-version\":$versions,\"platform\":[\"WebGL\",\"Linux\"],\"include\":[{\"platform\":\"WebGL\",\"check_symbols\":true,\"build_platform\":\"WebGL\"},{\"platform\":\"Linux\",\"image-suffix\":\"-il2cpp\",\"check_symbols\":true,\"build_platform\":\"Linux\"}]}" >> $GITHUB_OUTPUT
+          
+          # Android matrix with API levels and init types
+          echo "android-matrix={\"api-level\":[30,31,34],\"init-type\":[\"runtime\",\"buildtime\"],\"unity-version\":$versions}" >> $GITHUB_OUTPUT
+          
+          # iOS matrix with iOS versions and init types  
+          echo "ios-matrix={\"unity-version\":$versions,\"ios-version\":[\"17.0\",\"latest\"],\"init-type\":[\"runtime\",\"buildtime\"]}" >> $GITHUB_OUTPUT
+          
+          # Desktop matrix with OS
+          echo "desktop-matrix={\"unity-version\":$versions,\"os\":[\"windows\"],\"include\":[{\"os\":\"windows\",\"unity-modules\":\"windows-il2cpp\",\"unity-config-path\":\"C:/ProgramData/Unity/config/\"}]}" >> $GITHUB_OUTPUT
 
   sdk:
     strategy:
@@ -85,11 +122,11 @@ jobs:
   smoke-test-create:
     name: Create ${{ matrix.unity-version }} Smoke Test Project
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
+    needs: [matrix-prep]
     secrets: inherit
     strategy:
       fail-fast: false
-      matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix) }}
     uses: ./.github/workflows/smoke-test-create.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -98,21 +135,11 @@ jobs:
   smoke-test-build:
     name: Build ${{ matrix.platform }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create]
+    needs: [smoke-test-create, matrix-prep]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
-        platform: ["WebGL", "Linux"]
-        include:
-          - platform: WebGL
-            check_symbols: true
-            build_platform: WebGL
-          - platform: Linux
-            image-suffix: "-il2cpp"
-            check_symbols: true
-            build_platform: Linux            
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.build-matrix) }}            
     env:
       UNITY_PATH: docker exec unity unity-editor
     steps:
@@ -202,12 +229,11 @@ jobs:
   smoke-test-build-android:
     name: Build Android ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create]
+    needs: [smoke-test-create, matrix-prep]
     secrets: inherit
     strategy:
       fail-fast: false
-      matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix) }}
     uses: ./.github/workflows/smoke-test-build-android.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -215,7 +241,7 @@ jobs:
   smoke-test-run-android:
     name: Run Android ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build-android]
+    needs: [smoke-test-build-android, matrix-prep]
     uses: ./.github/workflows/smoke-test-run-android.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -223,20 +249,16 @@ jobs:
       init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
-      matrix:
-        api-level: [30, 31, 34] # last updated January 2025
-        init-type: ["runtime", "buildtime"]
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.android-matrix) }}
 
   smoke-test-build-ios:
     name: Build iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create]
+    needs: [smoke-test-create, matrix-prep]
     secrets: inherit
     strategy:
       fail-fast: false
-      matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix) }}
     uses: ./.github/workflows/smoke-test-build-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -244,12 +266,12 @@ jobs:
   smoke-test-compile-ios:
     name: Compile iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build-ios]
+    needs: [smoke-test-build-ios, matrix-prep]
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+        unity-version: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix).unity-version }}
         init-type: ["runtime", "buildtime"]
     uses: ./.github/workflows/smoke-test-compile-ios.yml
     with:
@@ -259,7 +281,7 @@ jobs:
   smoke-test-run-ios:
     name: Run iOS ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-compile-ios]
+    needs: [smoke-test-compile-ios, matrix-prep]
     uses: ./.github/workflows/smoke-test-run-ios.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -267,8 +289,7 @@ jobs:
       init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
-      matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.ios-matrix) }}
         # Check https://support.apple.com/en-us/HT201222 for the latest minor version for a given major one.
         # https://developer.apple.com/support/app-store/ shows that of all iOS devices
         # - `iOS 18`: 88 %
@@ -278,18 +299,16 @@ jobs:
         # Numbers as string otherwise GH will reformat the runtime numbers removing the fractions.
         # Also make sure to match the versions available here:
         #  - https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
-        ios-version: ["17.0", latest] # updated August 2025 to match available simulators
-        init-type: ["runtime", "buildtime"]
 
   smoke-test-run:
     name: Run ${{ matrix.platform }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-build]
+    needs: [smoke-test-build, matrix-prep]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+        unity-version: ${{ fromJSON(needs.matrix-prep.outputs.unity-matrix).unity-version }}
         platform: ["WebGL", "Linux"]
     steps:
       - name: Checkout
@@ -322,18 +341,13 @@ jobs:
   desktop-smoke-test:
     name: Run ${{ matrix.os }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create]
+    needs: [smoke-test-create, matrix-prep]
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
-      matrix:
-        unity-version: ["2021.3", "2022.3", "6000.0", "6000.1"]
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.desktop-matrix) }}
         # os: ["windows", "macos"]
-        os: ["windows"]
-        include:
-          - os: windows
-            unity-modules: windows-il2cpp
-            unity-config-path: C:/ProgramData/Unity/config/
+        # include:
           # - os: macos
           #   unity-modules: mac-il2cpp
           #   unity-config-path: /Library/Application Support/Unity/config/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.build-matrix) }}            
+      matrix:
+        unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
+        platform: ["WebGL", "Linux"]
+        include:
+          - platform: WebGL
+            check_symbols: true
+            build_platform: WebGL
+          - platform: Linux
+            image-suffix: "-il2cpp"
+            check_symbols: true
+            build_platform: Linux            
     env:
       UNITY_PATH: docker exec unity unity-editor
     steps:
@@ -216,7 +226,10 @@ jobs:
       init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.android-matrix) }}
+      matrix:
+        unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
+        api-level: [30, 31, 34]
+        init-type: ["runtime", "buildtime"]
 
   smoke-test-build-ios:
     name: Build iOS ${{ matrix.unity-version }} Smoke Test
@@ -256,7 +269,10 @@ jobs:
       init-type: ${{ matrix.init-type }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.ios-matrix) }}
+      matrix:
+        unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
+        ios-version: ["17.0", "latest"]
+        init-type: ["runtime", "buildtime"]
         # Check https://support.apple.com/en-us/HT201222 for the latest minor version for a given major one.
         # https://developer.apple.com/support/app-store/ shows that of all iOS devices
         # - `iOS 18`: 88 %
@@ -312,7 +328,13 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.create-unity-matrix.outputs.desktop-matrix) }}
+      matrix:
+        unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
+        os: ["windows"]
+        include:
+          - os: windows
+            unity-modules: "windows-il2cpp"
+            unity-config-path: "C:/ProgramData/Unity/config/"
         # os: ["windows", "macos"]
         # include:
           # - os: macos

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -9,7 +9,7 @@ on:
         type: string
     outputs:
       unity-matrix:
-        description: 'Simple Unity version matrix'
+        description: 'Base Unity version matrix'
         value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
       build-matrix:
         description: 'Build matrix with platforms'
@@ -50,7 +50,7 @@ jobs:
             versions='${{ env.FULL_UNITY_VERSIONS }}'
           fi
           
-          # Simple unity-version only matrix
+          # Base unity-version only matrix
           echo "matrix={\"unity-version\":$versions}" >> $GITHUB_OUTPUT
           
           # Build matrix with platforms
@@ -79,9 +79,9 @@ jobs:
           # Android matrix with API levels and init types
           android_matrix=$(cat <<-JSON
           {
+            "unity-version": $versions,
             "api-level": [30, 31, 34],
-            "init-type": ["runtime", "buildtime"],
-            "unity-version": $versions
+            "init-type": ["runtime", "buildtime"]
           }
           JSON
           )

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -54,8 +54,8 @@ jobs:
           echo "matrix={\"unity-version\":$versions}" >> $GITHUB_OUTPUT
           
           # Build matrix with platforms
-          cat << EOF >> $GITHUB_OUTPUT
-          build-matrix={
+          build_matrix=$(cat <<-JSON
+          {
             "unity-version": $versions,
             "platform": ["WebGL", "Linux"],
             "include": [
@@ -72,29 +72,35 @@ jobs:
               }
             ]
           }
-          EOF
+          JSON
+          )
+          echo "build-matrix=$(echo "$build_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT
           
           # Android matrix with API levels and init types
-          cat << EOF >> $GITHUB_OUTPUT
-          android-matrix={
+          android_matrix=$(cat <<-JSON
+          {
             "api-level": [30, 31, 34],
             "init-type": ["runtime", "buildtime"],
             "unity-version": $versions
           }
-          EOF
+          JSON
+          )
+          echo "android-matrix=$(echo "$android_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT
           
           # iOS matrix with iOS versions and init types
-          cat << EOF >> $GITHUB_OUTPUT
-          ios-matrix={
+          ios_matrix=$(cat <<-JSON
+          {
             "unity-version": $versions,
             "ios-version": ["17.0", "latest"],
             "init-type": ["runtime", "buildtime"]
           }
-          EOF
+          JSON
+          )
+          echo "ios-matrix=$(echo "$ios_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT
           
           # Desktop matrix with OS
-          cat << EOF >> $GITHUB_OUTPUT
-          desktop-matrix={
+          desktop_matrix=$(cat <<-JSON
+          {
             "unity-version": $versions,
             "os": ["windows"],
             "include": [
@@ -105,4 +111,6 @@ jobs:
               }
             ]
           }
-          EOF
+          JSON
+          )
+          echo "desktop-matrix=$(echo "$desktop_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -1,0 +1,108 @@
+name: Create Unity Version Matrix
+
+on:
+  workflow_call:
+    inputs:
+      event-name:
+        description: 'Event name (pull_request, push, etc.)'
+        required: true
+        type: string
+    outputs:
+      unity-matrix:
+        description: 'Simple Unity version matrix'
+        value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
+      build-matrix:
+        description: 'Build matrix with platforms'
+        value: ${{ jobs.create-unity-matrix.outputs.build-matrix }}
+      android-matrix:
+        description: 'Android matrix with API levels and init types'
+        value: ${{ jobs.create-unity-matrix.outputs.android-matrix }}
+      ios-matrix:
+        description: 'iOS matrix with iOS versions and init types'
+        value: ${{ jobs.create-unity-matrix.outputs.ios-matrix }}
+      desktop-matrix:
+        description: 'Desktop matrix with OS configurations'
+        value: ${{ jobs.create-unity-matrix.outputs.desktop-matrix }}
+
+env:
+  # Unity versions used in PRs
+  PR_UNITY_VERSIONS: '["2022.3", "6000.0"]'
+  # Unity versions used on main branch
+  FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.1"]'
+
+jobs:
+  create-unity-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      unity-matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+      android-matrix: ${{ steps.set-matrix.outputs.android-matrix }}
+      ios-matrix: ${{ steps.set-matrix.outputs.ios-matrix }}
+      desktop-matrix: ${{ steps.set-matrix.outputs.desktop-matrix }}
+    steps:
+      - name: Set Unity version matrices based on event type
+        id: set-matrix
+        shell: bash
+        run: |
+          if [[ "${{ inputs.event-name }}" == "pull_request" ]]; then
+            versions='${{ env.PR_UNITY_VERSIONS }}'
+          else
+            versions='${{ env.FULL_UNITY_VERSIONS }}'
+          fi
+          
+          # Simple unity-version only matrix
+          echo "matrix={\"unity-version\":$versions}" >> $GITHUB_OUTPUT
+          
+          # Build matrix with platforms
+          cat << EOF >> $GITHUB_OUTPUT
+          build-matrix={
+            "unity-version": $versions,
+            "platform": ["WebGL", "Linux"],
+            "include": [
+              {
+                "platform": "WebGL",
+                "check_symbols": true,
+                "build_platform": "WebGL"
+              },
+              {
+                "platform": "Linux", 
+                "image-suffix": "-il2cpp",
+                "check_symbols": true,
+                "build_platform": "Linux"
+              }
+            ]
+          }
+          EOF
+          
+          # Android matrix with API levels and init types
+          cat << EOF >> $GITHUB_OUTPUT
+          android-matrix={
+            "api-level": [30, 31, 34],
+            "init-type": ["runtime", "buildtime"],
+            "unity-version": $versions
+          }
+          EOF
+          
+          # iOS matrix with iOS versions and init types
+          cat << EOF >> $GITHUB_OUTPUT
+          ios-matrix={
+            "unity-version": $versions,
+            "ios-version": ["17.0", "latest"],
+            "init-type": ["runtime", "buildtime"]
+          }
+          EOF
+          
+          # Desktop matrix with OS
+          cat << EOF >> $GITHUB_OUTPUT
+          desktop-matrix={
+            "unity-version": $versions,
+            "os": ["windows"],
+            "include": [
+              {
+                "os": "windows",
+                "unity-modules": "windows-il2cpp", 
+                "unity-config-path": "C:/ProgramData/Unity/config/"
+              }
+            ]
+          }
+          EOF

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -9,20 +9,8 @@ on:
         type: string
     outputs:
       unity-matrix:
-        description: 'Base Unity version matrix'
+        description: 'Unity version matrix'
         value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
-      build-matrix:
-        description: 'Build matrix with platforms'
-        value: ${{ jobs.create-unity-matrix.outputs.build-matrix }}
-      android-matrix:
-        description: 'Android matrix with API levels and init types'
-        value: ${{ jobs.create-unity-matrix.outputs.android-matrix }}
-      ios-matrix:
-        description: 'iOS matrix with iOS versions and init types'
-        value: ${{ jobs.create-unity-matrix.outputs.ios-matrix }}
-      desktop-matrix:
-        description: 'Desktop matrix with OS configurations'
-        value: ${{ jobs.create-unity-matrix.outputs.desktop-matrix }}
 
 env:
   # Unity versions used in PRs
@@ -35,10 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       unity-matrix: ${{ steps.set-matrix.outputs.matrix }}
-      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
-      android-matrix: ${{ steps.set-matrix.outputs.android-matrix }}
-      ios-matrix: ${{ steps.set-matrix.outputs.ios-matrix }}
-      desktop-matrix: ${{ steps.set-matrix.outputs.desktop-matrix }}
     steps:
       - name: Set Unity version matrices based on event type
         id: set-matrix
@@ -50,67 +34,5 @@ jobs:
             versions='${{ env.FULL_UNITY_VERSIONS }}'
           fi
           
-          # Base unity-version only matrix
+          # Unity version matrix
           echo "matrix={\"unity-version\":$versions}" >> $GITHUB_OUTPUT
-          
-          # Build matrix with platforms
-          build_matrix=$(cat <<-JSON
-          {
-            "unity-version": $versions,
-            "platform": ["WebGL", "Linux"],
-            "include": [
-              {
-                "platform": "WebGL",
-                "check_symbols": true,
-                "build_platform": "WebGL"
-              },
-              {
-                "platform": "Linux", 
-                "image-suffix": "-il2cpp",
-                "check_symbols": true,
-                "build_platform": "Linux"
-              }
-            ]
-          }
-          JSON
-          )
-          echo "build-matrix=$(echo "$build_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT
-          
-          # Android matrix with API levels and init types
-          android_matrix=$(cat <<-JSON
-          {
-            "unity-version": $versions,
-            "api-level": [30, 31, 34],
-            "init-type": ["runtime", "buildtime"]
-          }
-          JSON
-          )
-          echo "android-matrix=$(echo "$android_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT
-          
-          # iOS matrix with iOS versions and init types
-          ios_matrix=$(cat <<-JSON
-          {
-            "unity-version": $versions,
-            "ios-version": ["17.0", "latest"],
-            "init-type": ["runtime", "buildtime"]
-          }
-          JSON
-          )
-          echo "ios-matrix=$(echo "$ios_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT
-          
-          # Desktop matrix with OS
-          desktop_matrix=$(cat <<-JSON
-          {
-            "unity-version": $versions,
-            "os": ["windows"],
-            "include": [
-              {
-                "os": "windows",
-                "unity-modules": "windows-il2cpp", 
-                "unity-config-path": "C:/ProgramData/Unity/config/"
-              }
-            ]
-          }
-          JSON
-          )
-          echo "desktop-matrix=$(echo "$desktop_matrix" | tr -d '\n' | tr -s ' ')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Optimize CI Unity Version Testing Strategy

### Problem

The current CI workflow tests all Unity versions (2021.3, 2022.3, 6000.0, 6000.1) across all platforms for every pull request. With only so many build server licenses, if there are multiple PRs they start blocking each other.

Minor annoyance that I ran into again when dropping support for Unity 2020: We've got the versions to test in a whole lot of different place. Ideally, this would be unified somewhere.

## Proposal

Split versions to be tested in 3 groups:
- `main` branch: Test everything: `2021`, `2022`, `6.0`, `6.1`. We'll need to look into `6.2` in the near future.
- `PR` branch: Test against the highest impacted versions: `2022`, `6.0`. We don't have any `#ifdef` as part of the initialization anymore, making this much saver.
- `Release` branches: Keep as is, a sanity check

Come up with a unified mechanism that creates the Unity-version-platform-matrix.

## Implementation

For this we have to:

1. Create matrix creation workflow `.github/workflows/create-unity-matrix.yml`:
    - Holds and defines which Unity versions to use based on where the action was triggered from
2. Updated CI workflow `.github/workflows/ci.yml`:
    - Replaced hardcoded Unity version arrays with dynamic matrices
    - All smoke test jobs now depend on the matrix creation job
3. Updated Build Workflow (.github/workflows/build.yml):
    - Removed Unity version restrictions on packaging steps. We're only building with one now.

## Impact

Pull Requests (50% reduction):
- Before: 4 Unity versions × multiple platforms = ~16-24 test combinations **per** platform
- After: 2 Unity versions × multiple platforms = ~8-12 test combinations **per** platform

Main Branch (no change):
- Continues testing all supported Unity versions for full compatibility validation

## Notes

- Reduced License Pressure: 50% fewer Unity license checkouts during PR validation
- Faster PR Feedback: Reduced CI runtime for pull request validation
- Less chance for flake
- Maintained Quality: Full version coverage still runs on main branch

#skip-changelog