### PR TITLE
chore: Pin SDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
-          global-json-file: src/sentry-dotnet/global.json
+          global-json-file: global.json
         
       - name: Install Android dotnet workflow
         run: dotnet workload install android --temp-dir "$RUNNER_TEMP"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -21,6 +21,15 @@ jobs:
           -o -name "*.m"
           | xargs clang-format -i -style=file
 
+      - name: Install .NET SDK
+        if: runner.os != 'Windows'
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore .NET Workload
+        run: dotnet workload restore
+
       - name: Format C# Code Whitespace
         run: dotnet format whitespace Sentry.Unity.sln --exclude src/sentry-dotnet --verbosity diag
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -22,7 +22,6 @@ jobs:
           | xargs clang-format -i -style=file
 
       - name: Install .NET SDK
-        if: runner.os != 'Windows'
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           global-json-file: global.json

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
   "sdk": {
+    "version": "9.0.304",
+    "workloadVersion": "9.0.304",
+    "rollForward": "disable",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Pinning the the SDK version so `dotnet` doesn't just take whatever is there.

#skip-changelog