### PR TITLE
chore: Cleanup PlayStation build target

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -313,17 +313,6 @@ Expected to exist:
     <Exec WorkingDirectory="$(SentryLinuxArtifactsDestination)" Command="objcopy --add-gnu-debuglink=libsentry.dbg.so libsentry.so" />
   </Target>
 
-  <!-- Build PlayStation version of Sentry.Unity.Native: dotnet msbuild /t:BuildPlayStationAssembly src/Sentry.Unity.Native -->
-  <Target Name="BuildPlayStationAssembly"
-          AfterTargets="AfterBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity.Native' AND '$(IsPlayStationBuild)' != 'true'">
-    <Message Importance="High" Text="Building PlayStation-specific native assembly." />
-
-    <MSBuild Projects="$(MSBuildProjectFile)"
-             Targets="Build"
-             Properties="IsPlayStationBuild=true;Configuration=$(Configuration)" />
-  </Target>
-
   <!-- Even with a successful build, Unity will error on 'usbmuxd' or log out to std-error which breaks msbuild.
 We need to run a unity build to restore the test packages and for that reason we'll ignore errors here and assume a later step will validate the build is actually working:
   The offending error:

--- a/src/Sentry.Unity.Native/Sentry.Unity.Native.csproj
+++ b/src/Sentry.Unity.Native/Sentry.Unity.Native.csproj
@@ -3,15 +3,27 @@
     <OutDir>$(PackageRuntimePath)</OutDir>
   </PropertyGroup>
 
-  <!-- Configure PlayStation-specific build -->
-  <PropertyGroup Condition="'$(IsPlayStationBuild)' == 'true'">
-    <DefineConstants>$(DefineConstants);SENTRY_NATIVE_PLAYSTATION</DefineConstants>
-    <AssemblyName>Sentry.Unity.Native.PlayStation</AssemblyName>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="../sentry-dotnet/src/Sentry/Sentry.csproj" Private="false" />
     <ProjectReference Include="../Sentry.Unity/Sentry.Unity.csproj" Private="false" />
   </ItemGroup>
+
+  <!-- Build PlayStation version after the main build -->
+  <Target Name="BuildPlayStationAssembly" AfterTargets="AfterBuild">
+    <Message Importance="High" Text="Building PlayStation-specific native assembly." />
+
+    <Csc
+      Sources="@(Compile)"
+      References="@(ReferencePath)"
+      OutputAssembly="$(OutDir)Sentry.Unity.Native.PlayStation.dll"
+      DefineConstants="$(DefineConstants);SENTRY_NATIVE_PLAYSTATION"
+      TargetType="library"
+      EmitDebugInformation="true"
+      Nullable="$(Nullable)"
+      LangVersion="$(LangVersion)"
+      TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
+      WarningLevel="$(WarningLevel)"
+    />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-unity/pull/2433

Passing down the global attributes into the Csc, i.e. `Nullable` and `TreatWarningsAsErrors`.

#skip-changelog