### PR TITLE
chore: Tweaked build logs for Apple platforms

### DIFF
--- a/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor.iOS/BuildPostProcess.cs
@@ -160,7 +160,7 @@ public static class BuildPostProcess
 
         logger.LogInfo("Setting up Sentry CLI.");
 
-        if (options.Il2CppLineNumberSupportEnabled && cliOptions.IsValid(logger, EditorUserBuildSettings.development))
+        if (options.Il2CppLineNumberSupportEnabled && !cliOptions.IsValid(logger, EditorUserBuildSettings.development))
         {
             logger.LogWarning("The IL2CPP line number support requires the debug symbol upload to be enabled.");
         }


### PR DESCRIPTION
The check was inverted, warning when the options were set up correctly.

#skip-changelog