### PR TITLE
chore: Fix Windows smoke-test dependency in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
   desktop-smoke-test:
     name: Run ${{ matrix.os }} ${{ matrix.unity-version }} Smoke Test
     if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
-    needs: [smoke-test-create, create-unity-matrix]
+    needs: [smoke-test-create, create-unity-matrix, build-unity-sdk]
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The job needs to wait for the SDK to be built. If the SDK does not get built fast enough the job attempts to download the UPM package too soon and fails.

#skip-changelog