### PR TITLE
chore: Pin `craft` to `2.12.1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,4 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
+          craft_version: '2.12.1'


### PR DESCRIPTION
#skip-changelog