### PR TITLE
chore: Removed redundant clang invoking test

### DIFF
--- a/test/Sentry.Unity.Editor.iOS.Tests/NativeOptionsTests.cs
+++ b/test/Sentry.Unity.Editor.iOS.Tests/NativeOptionsTests.cs
@@ -1,32 +1,10 @@
-using System.Diagnostics;
 using System.IO;
 using NUnit.Framework;
-using UnityEngine;
 
 namespace Sentry.Unity.Editor.iOS.Tests;
 
 public class NativeOptionsTests
 {
-    [Test]
-    public void GenerateOptions_NewSentryOptions_Compiles()
-    {
-        if (Application.platform != RuntimePlatform.OSXEditor)
-        {
-            Assert.Inconclusive("Skipping: Not on macOS");
-        }
-
-        const string testOptionsFileName = "testOptions.m";
-        var nativeOptionsString = NativeOptions.Generate(new SentryUnityOptions());
-        File.WriteAllText(testOptionsFileName, nativeOptionsString);
-
-        var process = Process.Start("clang", $"-fsyntax-only {testOptionsFileName}");
-        process.WaitForExit();
-
-        Assert.AreEqual(0, process.ExitCode);
-
-        File.Delete(testOptionsFileName);
-    }
-
     [Test]
     public void CreateOptionsFile_NewSentryOptions_FileCreated()
     {


### PR DESCRIPTION
Removed a test invoking clang to compile some generated code. It's redundant and will break integration test anyway.

#skip-changelog