### PR TITLE
fix: Cocoa provides an objc `Sentry ID`

### DIFF
--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -213,7 +213,7 @@ void SentryNativeBridgeSetTrace(const char *traceId, const char *spanId)
     NSString *spanIdStr = [NSString stringWithUTF8String:spanId];
 
     // This is a workaround to deal with SentryId living inside the Swift header
-    Class sentryIdClass = NSClassFromString(@"_TtC6Sentry8SentryId");
+    Class sentryIdClass = NSClassFromString(@"SentryId");
     Class sentrySpanIdClass = NSClassFromString(@"SentrySpanId");
 
     if (sentryIdClass && sentrySpanIdClass) {

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -84,7 +84,7 @@ int SentryNativeBridgeLoadLibrary()
             LOAD_CLASS_OR_BREAK(SentryUser)
             LOAD_CLASS_OR_BREAK(SentryOptions)
             LOAD_CLASS_OR_BREAK(SentryOptionsInternal)
-            LOAD_SWIFT_CLASS_OR_BREAK(SentryId, _TtC6Sentry8SentryId)
+            LOAD_CLASS_OR_BREAK(SentryId)
             LOAD_CLASS_OR_BREAK(SentrySpanId)
             LOAD_CLASS_OR_BREAK(PrivateSentrySDKOnly)
 


### PR DESCRIPTION
`sentry-cocoa` `v9.4.0` added `@objc(SentryId)`. This means it's now exported as `_OBJC_CLASS_$_SentryId` instead of the Swift-mangled `_OBJC_CLASS_$__TtC6Sentry8SentryId`. 

The break happened in between releases. No changelog required.

#skip-changelog