### PR TITLE
fix: Retry Linux flake

### DIFF
--- a/test/Scripts.Integration.Test/run-smoke-test.ps1
+++ b/test/Scripts.Integration.Test/run-smoke-test.ps1
@@ -130,6 +130,11 @@ function RunTest([string] $type)
     }
     finally
     {
+        if ($null -ne $process -and !$process.HasExited)
+        {
+            Write-Warning "Process still running - forcing termination."
+            $process | Stop-Process -Force
+        }
         Write-Host "::endgroup::"
     }
 }


### PR DESCRIPTION
This is similar to https://github.com/getsentry/sentry-unity/pull/2527
If running the game hangs (i.e. on Linux during startup) the state has to be reset and the tests rerun.

This wraps the existing logic in a `max-try = 3` and resets the `AppDataDir.`

#skip-changelog