### PR TITLE
chore: Renamed package artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
   GITHUB_ACTOR: ${{ github.actor }}
-  GITHUB_SHA: ${{ github.sha }}
   UNITY_VERSION: ${{ inputs.unity-version }}
 
 defaults:
@@ -129,7 +128,7 @@ jobs:
       - name: Upload release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ env.GITHUB_SHA }}
+          name: package-release
           if-no-files-found: error
           path: |
             package-release.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
-          name: ${{ github.sha }}
+          name: package-release
           wait-timeout: 3600
 
       - name: Verify package content against snapshot
@@ -183,7 +183,7 @@ jobs:
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
-          name: ${{ github.sha }}
+          name: package-release
           wait-timeout: 3600
 
       - name: Extract UPM package
@@ -437,7 +437,7 @@ jobs:
       - name: Download UPM package
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: ${{ github.sha }}
+          name: package-release
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/smoke-test-build-android.yml
+++ b/.github/workflows/smoke-test-build-android.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     env:
       GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_SHA: ${{ github.sha }}
       UNITY_PATH: docker exec unity unity-editor
       UNITY_VERSION: ${{ inputs.unity-version }}
     
@@ -68,7 +67,7 @@ jobs:
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
-          name: ${{ env.GITHUB_SHA }}
+          name: package-release
           wait-timeout: 3600
 
       - name: Extract UPM package

--- a/.github/workflows/smoke-test-build-ios.yml
+++ b/.github/workflows/smoke-test-build-ios.yml
@@ -22,7 +22,6 @@ jobs:
             build_platform: iOS
     env:
       GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_SHA: ${{ github.sha }}
       UNITY_PATH: docker exec unity unity-editor
       UNITY_VERSION: ${{ inputs.unity-version }}
     
@@ -87,7 +86,7 @@ jobs:
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
-          name: ${{ env.GITHUB_SHA }}
+          name: package-release
           wait-timeout: 3600
 
       - name: Extract UPM package


### PR DESCRIPTION
We named the package to sha, which is a pain to deal with when downloading it in other repos, i.e. console for testing.

#skip-changelog