### PR TITLE
chore: Provide craft with an artifact provider

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,9 @@
-minVersion: 0.24.0
+minVersion: 2.21.4
 changelogPolicy: auto
+artifactProvider:
+  name: github
+  config:
+    artifacts: package-release
 targets:
   - name: upm
     releaseRepoOwner: getsentry


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-unity/pull/2542

[Craft](https://github.com/getsentry/craft) has a legacy fallback picking the `SHA` as the release artifact's name. Since I renamed the artifact, we need to provide craft with the actual name.

#skip-changelog