### PR TITLE
chore: Add error monitoring solution question to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
       required: true
 
   - type: dropdown
-    id: other_error_monitoring
+    id: other-error-monitoring
     attributes:
       description: Are you using any other error monitoring solution alongside Sentry?
       label: Other Error Monitoring Solution


### PR DESCRIPTION
## Description

Adds a new dropdown and optional input field to the Unity bug report issue template asking users if they are using any other error monitoring solution alongside Sentry, and if so, which one.

## Motivation and Context

Other error monitoring SDKs can interfere with Sentry's error reporting in Unity projects. Knowing upfront whether a user has another solution installed helps triage bugs faster.

## How did you test it?

Reviewed the YAML template manually.

#skip-changelog