### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   changelog-preview:
-    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # v2
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Download UPM package
         uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
@@ -116,7 +116,7 @@ jobs:
       UNITY_PATH: docker exec unity unity-editor
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0
@@ -164,7 +164,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-${{ matrix.build_platform }}-${{ matrix.unity-version }}
@@ -396,7 +396,7 @@ jobs:
     needs: [test-build-webgl, test-build-android, test-compile-ios, test-build-linux, test-build-windows]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Download all build size measurements
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -7,4 +7,4 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/danger@v3
+      - uses: getsentry/github-workflows/danger@26f565c05d0dd49f703d238706b775883037d76b # v3

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Android-${{ inputs.unity-version }}

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-iOS-${{ inputs.unity-version }}

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Linux-${{ inputs.unity-version }}

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Windows-${{ inputs.unity-version }}

--- a/.github/workflows/test-compile-ios.yml
+++ b/.github/workflows/test-compile-ios.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Restore cached compiled iOS build without Sentry
         if: ${{ inputs.init-type == 'runtime' }}
         id: cache-compiled-nosentry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: IntegrationTest-NoSentry.app
           key: build-nosentry-iOS-compiled-${{ inputs.unity-version }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,7 +26,7 @@ jobs:
             path: src/sentry-dotnet
           - name: CLI
             path: modules/sentry-cli.properties
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
     with:
       name: ${{ matrix.name }}
       path: ${{ matrix.path }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)