### PR TITLE
fix: make Sentry settings scrollable

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -50,6 +50,7 @@ public class SentryWindow : EditorWindow
     public event Action<ValidationError> OnValidationError = _ => { };
 
     private int _currentTab = 0;
+    private Vector2 _scrollPosition = Vector2.zero;
     private readonly string[] _tabs =
     {
         "Core",
@@ -134,6 +135,8 @@ public class SentryWindow : EditorWindow
         EditorGUI.DrawRect(EditorGUILayout.GetControlRect(false, 1), Color.gray);
         EditorGUILayout.Space();
 
+        _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
+
         switch (_currentTab)
         {
             case 0:
@@ -160,6 +163,8 @@ public class SentryWindow : EditorWindow
             default:
                 break;
         }
+
+        EditorGUILayout.EndScrollView();
 
         EditorGUI.EndDisabledGroup();
     }


### PR DESCRIPTION
Currently tabs that have too many items are cut off; one can resize the window, but scrolling would be nicer

<details>

<summary>Comparison</summary>

Before
<img width="801" height="657" alt="Screenshot 2026-04-10 at 13 52 37" src="https://github.com/user-attachments/assets/d4ac1119-93df-462a-b3ea-dd94098df585" />

After

https://github.com/user-attachments/assets/3e38152a-3c8a-4dcc-88c4-e19da307d14a

</details>


#skip-changelog
