### PR TITLE
fix: drop screenshots for events filtered by `before_send`

### DIFF
--- a/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
@@ -369,40 +370,89 @@ public class ScreenshotEventProcessorTests
     }
 
     [UnityTest]
-    public IEnumerator Process_EventDroppedByBeforeSend_ScreenshotAttachmentIsNotSent()
+    public IEnumerator Process_EventCapturedSuccessfully_ScreenshotAttachmentIsSent()
     {
-        // When before_send drops an event (returns null), the screenshot should NOT be sent.
-        // The screenshot processor's async coroutine must not send orphaned attachment envelopes
-        // that count against quota but have no associated event in Sentry.
+        // Positive control: when the event IS captured, the screenshot coroutine should send
+        // the attachment. This validates the test infrastructure so the negative test below
+        // is meaningful — if this test passes but the next one doesn't, the WasCaptured flag
+        // is doing its job.
 
-        var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
-        var sdkOptions = new SentryUnityOptions(application: new TestApplication())
+        var httpHandler = new TestHttpClientHandler("ScreenshotSuccessTest");
+        var sentryMonoBehaviour = GetTestMonoBehaviour();
+
+        var options = new SentryUnityOptions(application: new TestApplication())
         {
             Dsn = SentryTests.TestDsn,
             CreateHttpMessageHandler = () => httpHandler
         };
-        sdkOptions.SetBeforeSend((_, _) => null); // Drop all events
-        SentrySdk.Init(sdkOptions);
+
+        // Register test screenshot processor as an event processor — it will be called
+        // during DoSendEvent → ProcessEvent, just like the real ScreenshotEventProcessor.
+        options.AddEventProcessor(new RealCaptureScreenshotEventProcessor(options, sentryMonoBehaviour));
+
+        SentrySdk.Init(options);
 
         try
         {
-            // Sanity check: verify before_send drops events
-            var capturedEventId = SentrySdk.CaptureMessage("test message");
-            Assert.AreEqual(SentryId.Empty, capturedEventId, "Sanity check: before_send should drop events");
+            // Event goes through the full DoSendEvent pipeline and is captured successfully.
+            // DoSendEvent sets @event.WasCaptured = true after CaptureEnvelope succeeds.
+            var capturedId = SentrySdk.CaptureMessage("test message");
+            Assert.AreNotEqual(SentryId.Empty, capturedId, "Sanity check: event should be captured");
 
-            // Create a processor that mocks screenshot capture but uses the real CaptureAttachment
-            // pathway (Hub.CaptureAttachment → Envelope.FromAttachment → HTTP transport)
-            var sentryMonoBehaviour = GetTestMonoBehaviour();
-            var processor = new RealCaptureScreenshotEventProcessor(new SentryUnityOptions(), sentryMonoBehaviour);
-
-            var sentryEvent = new SentryEvent();
-            processor.Process(sentryEvent);
-
-            // Wait for the coroutine to complete (fires at end of frame)
+            // Wait for the screenshot coroutine to complete
             yield return null;
             yield return null;
 
-            // The screenshot attachment must not be sent when the event was dropped by before_send
+            // Screenshot envelope should reach the transport
+            var screenshotRequest = httpHandler.GetEvent("screenshot.jpg", TimeSpan.FromSeconds(2));
+            Assert.IsNotEmpty(screenshotRequest,
+                "Screenshot attachment should be sent when the event is captured successfully");
+        }
+        finally
+        {
+            SentrySdk.Close();
+        }
+    }
+
+    [UnityTest]
+    public IEnumerator Process_EventDroppedByBeforeSend_ScreenshotAttachmentIsNotSent()
+    {
+        // Full pipeline test: the event goes through DoSendEvent where before_send drops it.
+        // The screenshot coroutine (queued during ProcessEvent, before the drop decision)
+        // must check WasCaptured and skip — no orphaned attachment envelope.
+
+        var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
+        var sentryMonoBehaviour = GetTestMonoBehaviour();
+
+        var options = new SentryUnityOptions(application: new TestApplication())
+        {
+            Dsn = SentryTests.TestDsn,
+            CreateHttpMessageHandler = () => httpHandler
+        };
+
+        // Register test screenshot processor — called during DoSendEvent → ProcessEvent
+        options.AddEventProcessor(new RealCaptureScreenshotEventProcessor(options, sentryMonoBehaviour));
+
+        // Drop all events via before_send
+        options.SetBeforeSend((_, _) => null);
+
+        SentrySdk.Init(options);
+
+        try
+        {
+            // CaptureMessage goes through the full DoSendEvent pipeline:
+            //   ProcessEvent → screenshot processor queues coroutine with @event in closure
+            //   DoBeforeSend → returns null → event dropped, WasCaptured stays false
+            var capturedId = SentrySdk.CaptureMessage("test message");
+            Assert.AreEqual(SentryId.Empty, capturedId, "Sanity check: before_send should drop events");
+
+            // Wait for the screenshot coroutine to complete
+            yield return null;
+            yield return null;
+
+            // No screenshot envelope should reach the transport.
+            // GetEvent logs Debug.LogError on timeout — tell the test runner this is expected.
+            LogAssert.Expect(LogType.Error, new Regex("timed out"));
             var screenshotRequest = httpHandler.GetEvent("screenshot.jpg", TimeSpan.FromSeconds(2));
             Assert.IsEmpty(screenshotRequest,
                 "Screenshot attachment should not be sent when before_send drops the event");

--- a/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
@@ -10,6 +10,26 @@ namespace Sentry.Unity.Tests;
 
 public class ScreenshotEventProcessorTests
 {
+    /// <summary>
+    /// Subclass that mocks screenshot capture and WaitForEndOfFrame but uses the REAL
+    /// CaptureAttachment implementation (via Hub.CaptureAttachment), allowing us to verify
+    /// that the attachment envelope actually reaches the HTTP transport.
+    /// </summary>
+    private class RealCaptureScreenshotEventProcessor : ScreenshotEventProcessor
+    {
+        public RealCaptureScreenshotEventProcessor(SentryUnityOptions options, ISentryMonoBehaviour sentryMonoBehaviour)
+            : base(options, sentryMonoBehaviour) { }
+
+        internal override Texture2D CreateNewScreenshotTexture2D(SentryUnityOptions options)
+            => new Texture2D(1, 1);
+
+        internal override YieldInstruction WaitForEndOfFrame()
+            => new YieldInstruction();
+
+        // CaptureAttachment is intentionally NOT overridden — the base implementation
+        // calls Hub.CaptureAttachment which sends a standalone attachment envelope.
+    }
+
     private class TestScreenshotEventProcessor : ScreenshotEventProcessor
     {
         public Func<SentryUnityOptions, Texture2D> CreateScreenshotFunc { get; set; }
@@ -346,6 +366,51 @@ public class ScreenshotEventProcessorTests
 
         Assert.IsTrue(callbackInvoked);
         Assert.AreEqual(1, screenshotCaptureCallCount);
+    }
+
+    [UnityTest]
+    public IEnumerator Process_EventDroppedByBeforeSend_ScreenshotAttachmentIsNotSent()
+    {
+        // When before_send drops an event (returns null), the screenshot should NOT be sent.
+        // The screenshot processor's async coroutine must not send orphaned attachment envelopes
+        // that count against quota but have no associated event in Sentry.
+
+        var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
+        var sdkOptions = new SentryUnityOptions(application: new TestApplication())
+        {
+            Dsn = SentryTests.TestDsn,
+            CreateHttpMessageHandler = () => httpHandler
+        };
+        sdkOptions.SetBeforeSend((_, _) => null); // Drop all events
+        SentrySdk.Init(sdkOptions);
+
+        try
+        {
+            // Sanity check: verify before_send drops events
+            var capturedEventId = SentrySdk.CaptureMessage("test message");
+            Assert.AreEqual(SentryId.Empty, capturedEventId, "Sanity check: before_send should drop events");
+
+            // Create a processor that mocks screenshot capture but uses the real CaptureAttachment
+            // pathway (Hub.CaptureAttachment → Envelope.FromAttachment → HTTP transport)
+            var sentryMonoBehaviour = GetTestMonoBehaviour();
+            var processor = new RealCaptureScreenshotEventProcessor(new SentryUnityOptions(), sentryMonoBehaviour);
+
+            var sentryEvent = new SentryEvent();
+            processor.Process(sentryEvent);
+
+            // Wait for the coroutine to complete (fires at end of frame)
+            yield return null;
+            yield return null;
+
+            // The screenshot attachment must not be sent when the event was dropped by before_send
+            var screenshotRequest = httpHandler.GetEvent("screenshot.jpg", TimeSpan.FromSeconds(2));
+            Assert.IsEmpty(screenshotRequest,
+                "Screenshot attachment should not be sent when before_send drops the event");
+        }
+        finally
+        {
+            SentrySdk.Close();
+        }
     }
 
     private static TestSentryMonoBehaviour GetTestMonoBehaviour()


### PR DESCRIPTION
Fixes #2641 

Since screenshots await `EndOfFrame()` , we start a coroutine that ends up sending an envelope with just the screenshot item. However, in the meantime, the related event might have been discarded by the `before_send` filter. In this case, we don't want to send unnecessary data over to Relay.

As a temporary workaround, setting `SetBeforeCaptureScreenshot` to the same filter used in `SetBeforeSend` prevents these screenshots from being sent.


## Proposed Fix

- Add internal `bool WasCaptured` to `SentryEvent` ([sentry-dotnet/SentryEvent.cs:249](https://github.com/getsentry/sentry-dotnet/blob/6.3.1/src/Sentry/SentryEvent.cs#L13)) — a flag that tracks whether an event actually made it through the entire send pipeline. We gate it behind a `#if SENTRY_UNITY` to avoid unnecessary fields for all of the other .NET SDKs. Defaults to `false`, which is the safe default: if the flag is never set, the screenshot is skipped rather than sent as an orphan.

- Set it to `true` on the success path in `DoSendEvent` ([sentry-dotnet/SentryClient.cs:416](https://github.com/getsentry/sentry-dotnet/blob/6.3.1/src/Sentry/SentryClient.cs#L414)) — placed immediately after `CaptureEnvelope` returns true, which is the only point where we know the event was actually sent. The flag is set on the original @event parameter (not processedEvent) because event processors and `before_send` can swap the event object, but the screenshot coroutine's closure holds a reference to the original. All five drop paths (exception filters, event processors, before_send, sampling, transport failure) return early and never reach this line, leaving the flag false.

- Check the flag in the screenshot coroutine before capturing ([ScreenshotEventProcessor.cs:48](https://github.com/getsentry/sentry-unity/blob/4.2.0/src/Sentry.Unity/ScreenshotEventProcessor.cs#L45)) — after `WaitForEndOfFrame` resumes the coroutine (at which point `DoSendEvent` has already completed synchronously), we read `WasCaptured`. If false, we yield break and skip the screenshot entirely. This check runs before any screenshot capture or CaptureAttachment call, preventing orphaned attachment envelopes from ever being created.


### Future Ideas
- Would it make sense to have our own `ISentryClient` in Unity which overwrites some methods (either deriving or implement custom one that wraps)
  - If user binds their own client, wrapping makes more sense than doing inheritance
  - The wrapper could then "attach" additional data to `SentryEvent`s via a Unity-SDK-owned [ConditionalWeakTable<,>](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2), that the Unity-ScreenshotEventProcessor reads, to have a fully Unity-owned implementation without requiring changes+release on `sentry-dotnet`

---

Related PRs:
- https://github.com/getsentry/sentry-unity/pull/2240
- https://github.com/getsentry/sentry-dotnet/pull/4357