### PR TITLE
fix: skip screenshot capture on dropped events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## Unreleased
 
+### Fixes
+
+- The SDK no longer sends screenshot attachments for events that were dropped during processing (e.g., by `BeforeSend` or sampling) ([#2661](https://github.com/getsentry/sentry-unity/pull/2661))
+
 ### Dependencies
 
+- Bump .NET SDK from v6.3.1 to v6.5.0 ([#2661](https://github.com/getsentry/sentry-unity/pull/2661))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#650)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/6.3.1...6.5.0)
 - Bump Native SDK from v0.13.5 to v0.14.0 ([#2660](https://github.com/getsentry/sentry-unity/pull/2660))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0140)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.13.5...0.14.0)

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.201",
-    "workloadVersion": "10.0.201",
+    "version": "10.0.203",
+    "workloadVersion": "10.0.203",
     "rollForward": "disable",
     "allowPrerelease": false
   }

--- a/src/Sentry.Unity/ScreenshotEventProcessor.cs
+++ b/src/Sentry.Unity/ScreenshotEventProcessor.cs
@@ -44,6 +44,12 @@ public class ScreenshotEventProcessor : ISentryEventProcessor
         Texture2D? screenshot = null;
         try
         {
+            if (!@event.IsCaptured)
+            {
+                _options.LogDebug("Skipping screenshot for event {0}. Event was not captured.", @event.EventId);
+                yield break;
+            }
+
             if (_options.BeforeCaptureScreenshotInternal?.Invoke(@event) is false)
             {
                 yield break;

--- a/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Sentry.Unity.Tests.Stubs;
 using UnityEngine;
@@ -397,40 +398,89 @@ public class ScreenshotEventProcessorTests
     }
 
     [UnityTest]
-    public IEnumerator Process_EventDroppedByBeforeSend_ScreenshotAttachmentIsNotSent()
+    public IEnumerator Process_EventCapturedSuccessfully_ScreenshotAttachmentIsSent()
     {
-        // When before_send drops an event (returns null), the screenshot should NOT be sent.
-        // The screenshot processor's async coroutine must not send orphaned attachment envelopes
-        // that count against quota but have no associated event in Sentry.
+        // Positive control: when the event IS captured, the screenshot coroutine should send
+        // the attachment. This validates the test infrastructure so the negative test below
+        // is meaningful — if this test passes but the next one doesn't, the WasCaptured flag
+        // is doing its job.
 
-        var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
-        var sdkOptions = new SentryUnityOptions(application: new TestApplication())
+        var httpHandler = new TestHttpClientHandler("ScreenshotSuccessTest");
+        var sentryMonoBehaviour = GetTestMonoBehaviour();
+
+        var options = new SentryUnityOptions(application: new TestApplication())
         {
             Dsn = SentryTests.TestDsn,
             CreateHttpMessageHandler = () => httpHandler
         };
-        sdkOptions.SetBeforeSend((_, _) => null); // Drop all events
-        SentrySdk.Init(sdkOptions);
+
+        // Register test screenshot processor as an event processor — it will be called
+        // during DoSendEvent → ProcessEvent, just like the real ScreenshotEventProcessor.
+        options.AddEventProcessor(new RealCaptureScreenshotEventProcessor(options, sentryMonoBehaviour));
+
+        SentrySdk.Init(options);
 
         try
         {
-            // Sanity check: verify before_send drops events
-            var capturedEventId = SentrySdk.CaptureMessage("test message");
-            Assert.AreEqual(SentryId.Empty, capturedEventId, "Sanity check: before_send should drop events");
+            // Event goes through the full DoSendEvent pipeline and is captured successfully.
+            // DoSendEvent sets @event.WasCaptured = true after CaptureEnvelope succeeds.
+            var capturedId = SentrySdk.CaptureMessage("test message");
+            Assert.AreNotEqual(SentryId.Empty, capturedId, "Sanity check: event should be captured");
 
-            // Create a processor that mocks screenshot capture but uses the real CaptureAttachment
-            // pathway (Hub.CaptureAttachment → Envelope.FromAttachment → HTTP transport)
-            var sentryMonoBehaviour = GetTestMonoBehaviour();
-            var processor = new RealCaptureScreenshotEventProcessor(new SentryUnityOptions(), sentryMonoBehaviour);
-
-            var sentryEvent = new SentryEvent();
-            processor.Process(sentryEvent);
-
-            // Wait for the coroutine to complete (fires at end of frame)
+            // Wait for the screenshot coroutine to complete
             yield return null;
             yield return null;
 
-            // The screenshot attachment must not be sent when the event was dropped by before_send
+            // Screenshot envelope should reach the transport
+            var screenshotRequest = httpHandler.GetEvent("screenshot.jpg", TimeSpan.FromSeconds(2));
+            Assert.IsNotEmpty(screenshotRequest,
+                "Screenshot attachment should be sent when the event is captured successfully");
+        }
+        finally
+        {
+            SentrySdk.Close();
+        }
+    }
+
+    [UnityTest]
+    public IEnumerator Process_EventDroppedByBeforeSend_ScreenshotAttachmentIsNotSent()
+    {
+        // Full pipeline test: the event goes through DoSendEvent where before_send drops it.
+        // The screenshot coroutine (queued during ProcessEvent, before the drop decision)
+        // must check WasCaptured and skip — no orphaned attachment envelope.
+
+        var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
+        var sentryMonoBehaviour = GetTestMonoBehaviour();
+
+        var options = new SentryUnityOptions(application: new TestApplication())
+        {
+            Dsn = SentryTests.TestDsn,
+            CreateHttpMessageHandler = () => httpHandler
+        };
+
+        // Register test screenshot processor — called during DoSendEvent → ProcessEvent
+        options.AddEventProcessor(new RealCaptureScreenshotEventProcessor(options, sentryMonoBehaviour));
+
+        // Drop all events via before_send
+        options.SetBeforeSend((_, _) => null);
+
+        SentrySdk.Init(options);
+
+        try
+        {
+            // CaptureMessage goes through the full DoSendEvent pipeline:
+            //   ProcessEvent → screenshot processor queues coroutine with @event in closure
+            //   DoBeforeSend → returns null → event dropped, WasCaptured stays false
+            var capturedId = SentrySdk.CaptureMessage("test message");
+            Assert.AreEqual(SentryId.Empty, capturedId, "Sanity check: before_send should drop events");
+
+            // Wait for the screenshot coroutine to complete
+            yield return null;
+            yield return null;
+
+            // No screenshot envelope should reach the transport.
+            // GetEvent logs Debug.LogError on timeout — tell the test runner this is expected.
+            LogAssert.Expect(LogType.Error, new Regex("timed out"));
             var screenshotRequest = httpHandler.GetEvent("screenshot.jpg", TimeSpan.FromSeconds(2));
             Assert.IsEmpty(screenshotRequest,
                 "Screenshot attachment should not be sent when before_send drops the event");

--- a/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
@@ -10,6 +10,26 @@ namespace Sentry.Unity.Tests;
 
 public class ScreenshotEventProcessorTests
 {
+    /// <summary>
+    /// Subclass that mocks screenshot capture and WaitForEndOfFrame but uses the REAL
+    /// CaptureAttachment implementation (via Hub.CaptureAttachment), allowing us to verify
+    /// that the attachment envelope actually reaches the HTTP transport.
+    /// </summary>
+    private class RealCaptureScreenshotEventProcessor : ScreenshotEventProcessor
+    {
+        public RealCaptureScreenshotEventProcessor(SentryUnityOptions options, ISentryMonoBehaviour sentryMonoBehaviour)
+            : base(options, sentryMonoBehaviour) { }
+
+        internal override Texture2D CreateNewScreenshotTexture2D(SentryUnityOptions options)
+            => new Texture2D(1, 1);
+
+        internal override YieldInstruction WaitForEndOfFrame()
+            => new YieldInstruction();
+
+        // CaptureAttachment is intentionally NOT overridden — the base implementation
+        // calls Hub.CaptureAttachment which sends a standalone attachment envelope.
+    }
+
     private class TestScreenshotEventProcessor : ScreenshotEventProcessor
     {
         public Func<SentryUnityOptions, Texture2D> CreateScreenshotFunc { get; set; }
@@ -374,6 +394,51 @@ public class ScreenshotEventProcessorTests
 
         Assert.AreEqual(0, screenshotCaptureCallCount);
         Assert.AreEqual(0, attachmentCaptureCallCount);
+    }
+
+    [UnityTest]
+    public IEnumerator Process_EventDroppedByBeforeSend_ScreenshotAttachmentIsNotSent()
+    {
+        // When before_send drops an event (returns null), the screenshot should NOT be sent.
+        // The screenshot processor's async coroutine must not send orphaned attachment envelopes
+        // that count against quota but have no associated event in Sentry.
+
+        var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
+        var sdkOptions = new SentryUnityOptions(application: new TestApplication())
+        {
+            Dsn = SentryTests.TestDsn,
+            CreateHttpMessageHandler = () => httpHandler
+        };
+        sdkOptions.SetBeforeSend((_, _) => null); // Drop all events
+        SentrySdk.Init(sdkOptions);
+
+        try
+        {
+            // Sanity check: verify before_send drops events
+            var capturedEventId = SentrySdk.CaptureMessage("test message");
+            Assert.AreEqual(SentryId.Empty, capturedEventId, "Sanity check: before_send should drop events");
+
+            // Create a processor that mocks screenshot capture but uses the real CaptureAttachment
+            // pathway (Hub.CaptureAttachment → Envelope.FromAttachment → HTTP transport)
+            var sentryMonoBehaviour = GetTestMonoBehaviour();
+            var processor = new RealCaptureScreenshotEventProcessor(new SentryUnityOptions(), sentryMonoBehaviour);
+
+            var sentryEvent = new SentryEvent();
+            processor.Process(sentryEvent);
+
+            // Wait for the coroutine to complete (fires at end of frame)
+            yield return null;
+            yield return null;
+
+            // The screenshot attachment must not be sent when the event was dropped by before_send
+            var screenshotRequest = httpHandler.GetEvent("screenshot.jpg", TimeSpan.FromSeconds(2));
+            Assert.IsEmpty(screenshotRequest,
+                "Screenshot attachment should not be sent when before_send drops the event");
+        }
+        finally
+        {
+            SentrySdk.Close();
+        }
     }
 
     private static TestSentryMonoBehaviour GetTestMonoBehaviour()

--- a/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
@@ -59,7 +59,7 @@ public class ScreenshotEventProcessorTests
         };
 
         var eventId = SentryId.Create();
-        var sentryEvent = new SentryEvent(eventId: eventId);
+        var sentryEvent = new SentryEvent(eventId: eventId) { IsCaptured = true };
 
         screenshotProcessor.Process(sentryEvent);
 
@@ -95,9 +95,9 @@ public class ScreenshotEventProcessorTests
         };
 
         // Process multiple events quickly (before any coroutine can complete)
-        screenshotProcessor.Process(new SentryEvent());
-        screenshotProcessor.Process(new SentryEvent());
-        screenshotProcessor.Process(new SentryEvent());
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
 
         // Wait for the coroutine to complete - need to wait for processing
         yield return null;
@@ -121,7 +121,7 @@ public class ScreenshotEventProcessorTests
             attachmentCaptureCallCount++;
         };
 
-        var sentryEvent = new SentryEvent();
+        var sentryEvent = new SentryEvent { IsCaptured = true };
         screenshotProcessor.Process(sentryEvent);
 
         // Wait for the coroutine to complete - need to wait for processing
@@ -151,7 +151,7 @@ public class ScreenshotEventProcessorTests
         var screenshotProcessor = new TestScreenshotEventProcessor(options, sentryMonoBehaviour);
 
         var eventId = SentryId.Create();
-        var sentryEvent = new SentryEvent(eventId: eventId);
+        var sentryEvent = new SentryEvent(eventId: eventId) { IsCaptured = true };
 
         screenshotProcessor.Process(sentryEvent);
 
@@ -179,7 +179,7 @@ public class ScreenshotEventProcessorTests
             attachmentCaptureCallCount++;
         };
 
-        var sentryEvent = new SentryEvent();
+        var sentryEvent = new SentryEvent { IsCaptured = true };
         screenshotProcessor.Process(sentryEvent);
 
         yield return null;
@@ -221,7 +221,7 @@ public class ScreenshotEventProcessorTests
             }
         };
 
-        screenshotProcessor.Process(new SentryEvent());
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
 
         yield return null;
         yield return null;
@@ -279,7 +279,7 @@ public class ScreenshotEventProcessorTests
             }
         };
 
-        screenshotProcessor.Process(new SentryEvent());
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
 
         yield return null;
         yield return null;
@@ -308,7 +308,7 @@ public class ScreenshotEventProcessorTests
             return new Texture2D(1, 1);
         };
 
-        screenshotProcessor.Process(new SentryEvent());
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
 
         yield return null;
         yield return null;
@@ -339,13 +339,41 @@ public class ScreenshotEventProcessorTests
             return new Texture2D(1, 1);
         };
 
-        screenshotProcessor.Process(new SentryEvent());
+        screenshotProcessor.Process(new SentryEvent { IsCaptured = true });
 
         yield return null;
         yield return null;
 
         Assert.IsTrue(callbackInvoked);
         Assert.AreEqual(1, screenshotCaptureCallCount);
+    }
+
+    [UnityTest]
+    public IEnumerator Process_EventNotCaptured_SkipsAttachment()
+    {
+        var sentryMonoBehaviour = GetTestMonoBehaviour();
+        var screenshotProcessor = new TestScreenshotEventProcessor(new SentryUnityOptions(), sentryMonoBehaviour);
+
+        var screenshotCaptureCallCount = 0;
+        screenshotProcessor.CreateScreenshotFunc = _ =>
+        {
+            screenshotCaptureCallCount++;
+            return new Texture2D(1, 1);
+        };
+
+        var attachmentCaptureCallCount = 0;
+        screenshotProcessor.CaptureAttachmentAction = (_, _) =>
+        {
+            attachmentCaptureCallCount++;
+        };
+
+        screenshotProcessor.Process(new SentryEvent());
+
+        yield return null;
+        yield return null;
+
+        Assert.AreEqual(0, screenshotCaptureCallCount);
+        Assert.AreEqual(0, attachmentCaptureCallCount);
     }
 
     private static TestSentryMonoBehaviour GetTestMonoBehaviour()

--- a/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
+++ b/test/Sentry.Unity.Tests/ScreenshotEventProcessorTests.cs
@@ -402,7 +402,7 @@ public class ScreenshotEventProcessorTests
     {
         // Positive control: when the event IS captured, the screenshot coroutine should send
         // the attachment. This validates the test infrastructure so the negative test below
-        // is meaningful — if this test passes but the next one doesn't, the WasCaptured flag
+        // is meaningful — if this test passes but the next one doesn't, the IsCaptured flag
         // is doing its job.
 
         var httpHandler = new TestHttpClientHandler("ScreenshotSuccessTest");
@@ -423,7 +423,7 @@ public class ScreenshotEventProcessorTests
         try
         {
             // Event goes through the full DoSendEvent pipeline and is captured successfully.
-            // DoSendEvent sets @event.WasCaptured = true after CaptureEnvelope succeeds.
+            // DoSendEvent sets @event.IsCaptured = true after CaptureEnvelope succeeds.
             var capturedId = SentrySdk.CaptureMessage("test message");
             Assert.AreNotEqual(SentryId.Empty, capturedId, "Sanity check: event should be captured");
 
@@ -447,7 +447,7 @@ public class ScreenshotEventProcessorTests
     {
         // Full pipeline test: the event goes through DoSendEvent where before_send drops it.
         // The screenshot coroutine (queued during ProcessEvent, before the drop decision)
-        // must check WasCaptured and skip — no orphaned attachment envelope.
+        // must check IsCaptured and skip — no orphaned attachment envelope.
 
         var httpHandler = new TestHttpClientHandler("ScreenshotBeforeSendTest");
         var sentryMonoBehaviour = GetTestMonoBehaviour();
@@ -470,7 +470,7 @@ public class ScreenshotEventProcessorTests
         {
             // CaptureMessage goes through the full DoSendEvent pipeline:
             //   ProcessEvent → screenshot processor queues coroutine with @event in closure
-            //   DoBeforeSend → returns null → event dropped, WasCaptured stays false
+            //   DoBeforeSend → returns null → event dropped, IsCaptured stays false
             var capturedId = SentrySdk.CaptureMessage("test message");
             Assert.AreEqual(SentryId.Empty, capturedId, "Sanity check: before_send should drop events");
 


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry-unity/pull/2642 and follows the release of https://github.com/getsentry/sentry-dotnet/pull/5162

Fixes https://github.com/getsentry/sentry-unity/issues/2641

Screenshot capture will be skipped if the triggering event was not captured as this would lead to an "orphaned" screenshot.

## Changelog
### 6.5.0

#### Features ✨

- feat: Add support to send OTEL traces via OTLP by jamescrosswell in [#4899](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/4899)

#### Fixes 🐛

- fix(unity): update `SentryEvent` to have `IsCaptured` to allow dropping screenshots of filtered events by JoshuaMoelans in [#5162](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5162)
- fix: Memory leak when filtered Activities get garbage collected before `PruneFilteredSpans` runs by jamescrosswell in [#5186](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5186)

#### Dependencies ⬆️

##### Deps

- chore(deps): update Cocoa SDK to v9.12.0 by github-actions in [#5179](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5179)
- chore(deps): update CLI to v3.4.1 by github-actions in [#5171](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5171)
- chore(deps): update Native SDK to v0.13.8 by github-actions in [#5165](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5165)
- chore(deps): update Java SDK to v8.40.0 by github-actions in [#5161](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5161)
- chore(deps): update Cocoa SDK to v9.11.0 by github-actions in [#5160](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5160)
- chore(deps): update CLI to v3.4.0 by github-actions in [#5145](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5145)
- chore(deps): update Java SDK to v8.39.1 by github-actions in [#5144](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5144)

#### Other

- perf(logs): avoid string allocation when no parameters are passed by Flash0ver in [#4697](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/4697)
- chore: fix missing skill by jamescrosswell in [#5134](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5134)

### 6.4.1

#### Fixes 🐛

- fix: prevent redundant native exceptions on Android/CoreCLR by jpnurmi in [#5127](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5127)

#### Dependencies ⬆️

##### Deps

- chore(deps): update Java SDK to v8.39.0 by github-actions in [#5137](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5137)
- chore(deps): update Native SDK to v0.13.7 by github-actions in [#5136](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5136)

### 6.4.0

#### Features ✨

- feat: Add network details for session replay on iOS by jamescrosswell in [#4891](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/4891)
- feat: Add option to exclude certain HTTP statuses from tracing by jamescrosswell in [#5034](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5034)

#### Fixes 🐛

- fix: memory leak when profiling is enabled by jamescrosswell in [#5133](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5133)
- fix: prevent redundant native exceptions on iOS by jpnurmi in [#5126](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5126)
- fix: prevent redundant native exceptions on Android/Mono by jpnurmi in [#4676](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/4676)
  - Note: opt in by setting `options.Native.ExperimentalOptions.SignalHandlerStrategy` to `Sentry.Android.SignalHandlerStrategy.ChainAtStart`

#### Dependencies ⬆️

##### Deps

- chore(deps): update Cocoa SDK to v9.10.0 by github-actions in [#5132](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5132)
- chore(deps): update Cocoa SDK to v9.9.0 by github-actions in [#5115](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5115)
- chore(deps): update Java SDK to v8.38.0 by github-actions in [#5124](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5124)

### 6.3.2

#### Dependencies ⬆️

- chore(deps): update Native SDK to v0.13.6 by github-actions in [#5128](https://github-redirect.dependabot.com/getsentry/sentry-dotnet/pull/5128)