### PR TITLE
fix: forward enable logs/metrics options to native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- The SDK no longer sends screenshot attachments for events that were dropped during processing (e.g., by `BeforeSend` or sampling) ([#2661](https://github.com/getsentry/sentry-unity/pull/2661))
+- The SDK no longer sends screenshot attachments for events that were dropped during processing (e.g., by `BeforeSend` or sampling). ([#2661](https://github.com/getsentry/sentry-unity/pull/2661))
+- The SDK now forwards `EnableLogs` and `EnableMetrics` to the native layer. ([#2662](https://github.com/getsentry/sentry-unity/pull/2662))
 
 ### Dependencies
 

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -140,6 +140,16 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setEnableScopeSync", options.NdkScopeSyncEnabled);
                 androidOptions.Call("setNativeSdkName", "sentry.native.android.unity");
 
+                using (var logsOptions = androidOptions.Call<AndroidJavaObject>("getLogs"))
+                {
+                    logsOptions.Call("setEnabled", options.EnableLogs);
+                }
+
+                using (var metricsOptions = androidOptions.Call<AndroidJavaObject>("getMetrics"))
+                {
+                    metricsOptions.Call("setEnabled", options.EnableMetrics);
+                }
+
                 // Options that are not to be set by the user
                 // We're disabling some integrations as to not duplicate event or because the SDK relies on the .NET SDK
                 // implementation of certain feature - i.e. Session Tracking

--- a/src/Sentry.Unity.Native/SentryNativeBridge.cs
+++ b/src/Sentry.Unity.Native/SentryNativeBridge.cs
@@ -93,6 +93,9 @@ internal static class SentryNativeBridge
         }
 #endif
 
+        Logger?.LogDebug("Setting EnableLogs: {0}", options.EnableLogs);
+        sentry_options_set_enable_logs(cOptions, options.EnableLogs ? 1 : 0);
+
         Logger?.LogDebug("Setting EnableMetrics: {0}", options.EnableMetrics);
         sentry_options_set_enable_metrics(cOptions, options.EnableMetrics ? 1 : 0);
 
@@ -168,6 +171,9 @@ internal static class SentryNativeBridge
 
     [DllImport(SentryLib)]
     private static extern void sentry_options_set_attach_screenshot(IntPtr options, int attachScreenshot);
+
+    [DllImport(SentryLib)]
+    private static extern void sentry_options_set_enable_logs(IntPtr options, int enable_logs);
 
     [DllImport(SentryLib)]
     private static extern void sentry_options_set_enable_metrics(IntPtr options, int enable_metrics);

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -72,6 +72,12 @@ internal static class SentryCocoaBridgeProxy
         Logger?.LogDebug("Setting CaptureFailedRequests: {0}", options.CaptureFailedRequests);
         OptionsSetInt(cOptions, "enableCaptureFailedRequests", options.CaptureFailedRequests ? 1 : 0);
 
+        Logger?.LogDebug("Setting EnableLogs: {0}", options.EnableLogs);
+        OptionsSetInt(cOptions, "enableLogs", options.EnableLogs ? 1 : 0);
+
+        Logger?.LogDebug("Setting EnableMetrics: {0}", options.EnableMetrics);
+        OptionsSetInt(cOptions, "enableMetrics", options.EnableMetrics ? 1 : 0);
+
         foreach (var range in options.FailedRequestStatusCodes)
         {
             Logger?.LogDebug("Adding FailedRequestStatusCodeRange: {0}-{1}", range.Start, range.End);


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-unity/pull/2660 (and probably other native bumps)

The enable logs and metrics options need to be properly propagated to the native layers.