### PR TITLE
chore: bump actions in ci

### DIFF
--- a/.github/actions/wait-for-artifact/action.yml
+++ b/.github/actions/wait-for-artifact/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "Timed out after 60 minutes waiting for artifact: $NAME" >&2
         exit 1
 
-    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/actions/wait-for-artifact/action.yml
+++ b/.github/actions/wait-for-artifact/action.yml
@@ -15,16 +15,16 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         NAME: ${{ inputs.name }}
-      shell: bash
+      shell: pwsh
       run: |
-        for _ in $(seq 1 120); do
-          count=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?name=$NAME" --jq .total_count)
-          if [[ "$count" -gt 0 ]]; then
+        for ($i = 0; $i -lt 120; $i++) {
+          $count = gh api "/repos/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID/artifacts?name=$env:NAME" --jq .total_count
+          if ([int]$count -gt 0) {
             exit 0
-          fi
-          sleep 30
-        done
-        echo "Timed out after 60 minutes waiting for artifact: $NAME" >&2
+          }
+          Start-Sleep -Seconds 30
+        }
+        Write-Error "Timed out after 60 minutes waiting for artifact: $env:NAME"
         exit 1
 
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/actions/wait-for-artifact/action.yml
+++ b/.github/actions/wait-for-artifact/action.yml
@@ -1,0 +1,33 @@
+name: 'Wait for and download artifact'
+description: 'Polls the run''s artifacts API until the named artifact appears, then downloads it.'
+inputs:
+  name:
+    description: 'Artifact name'
+    required: true
+  path:
+    description: 'Destination path for the artifact contents'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for ${{ inputs.name }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        NAME: ${{ inputs.name }}
+      shell: bash
+      run: |
+        for _ in $(seq 1 120); do
+          count=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?name=$NAME" --jq .total_count)
+          if [[ "$count" -gt 0 ]]; then
+            exit 0
+          fi
+          sleep 30
+        done
+        echo "Timed out after 60 minutes waiting for artifact: $NAME" >&2
+        exit 1
+
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
     name: Build - ${{ inputs.unity-version }}
     runs-on: ubuntu-22.04
     permissions:
+      actions: read
       checks: write
-      statuses: write
       contents: read
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0
@@ -48,7 +48,7 @@ jobs:
           UNITY_SCRIPT_ARG: unity${{ env.UNITY_VERSION }}
 
       - name: Cache Unity Library
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/unity-of-bugs/Library
           key: Library-unity-of-bugs-${{ steps.env.outputs.unityVersion }}-v1
@@ -56,7 +56,7 @@ jobs:
             Library-unity-of-bugs-${{ steps.env.outputs.unityVersion }}-
 
       - name: Docker Login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ env.GITHUB_ACTOR }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install .NET SDK
         if: runner.os != 'Windows'
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
         
@@ -81,32 +81,28 @@ jobs:
         run: ./scripts/download-sentry-cli.ps1
 
       - name: Download Android SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Android-sdk
           path: package-dev/Plugins/Android
-          wait-timeout: 3600
 
       - name: Download Cocoa SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Cocoa-sdk
           path: package-dev/Plugins
-          wait-timeout: 3600
 
       - name: Download Linux SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Linux-sdk
           path: package-dev/Plugins/Linux
-          wait-timeout: 3600
 
       - name: Download Windows SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Windows-sdk
           path: package-dev/Plugins/Windows
-          wait-timeout: 3600
 
       - name: Build Sentry.Unity Solution
         run: docker exec unity dotnet build -c Release -v:d
@@ -126,7 +122,7 @@ jobs:
           ./scripts/pack.ps1
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: package-release
           if-no-files-found: error
@@ -140,7 +136,7 @@ jobs:
         run: docker exec unity dotnet msbuild /t:UnityEditModeTest /p:Configuration=Release /p:OutDir=other test/Sentry.Unity.Editor.Tests
 
       - name: Publish Test Results
-        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v2.1.1
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
         if: ${{ !cancelled() }}
         with:
           name: Unity Test Results - ${{ env.UNITY_VERSION }}
@@ -149,13 +145,13 @@ jobs:
           fail-on-error: false
 
       - name: Upload test artifacts (playmode)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Test results (playmode) - ${{ env.UNITY_VERSION }}
           path: artifacts/test/playmode
 
       - name: Upload test artifacts (editmode)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Test results (editmode) - ${{ env.UNITY_VERSION }}
           path: artifacts/test/editmode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,32 +81,28 @@ jobs:
         run: ./scripts/download-sentry-cli.ps1
 
       - name: Download Android SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: Android-sdk
           path: package-dev/Plugins/Android
-          wait-timeout: 3600
 
       - name: Download Cocoa SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: Cocoa-sdk
           path: package-dev/Plugins
-          wait-timeout: 3600
 
       - name: Download Linux SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: Linux-sdk
           path: package-dev/Plugins/Linux
-          wait-timeout: 3600
 
       - name: Download Windows SDK
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: Windows-sdk
           path: package-dev/Plugins/Windows
-          wait-timeout: 3600
 
       - name: Build Sentry.Unity Solution
         run: docker exec unity dotnet build -c Release -v:d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,28 +81,32 @@ jobs:
         run: ./scripts/download-sentry-cli.ps1
 
       - name: Download Android SDK
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: Android-sdk
           path: package-dev/Plugins/Android
+          wait-timeout: 3600
 
       - name: Download Cocoa SDK
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: Cocoa-sdk
           path: package-dev/Plugins
+          wait-timeout: 3600
 
       - name: Download Linux SDK
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: Linux-sdk
           path: package-dev/Plugins/Linux
+          wait-timeout: 3600
 
       - name: Download Windows SDK
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: Windows-sdk
           path: package-dev/Plugins/Windows
+          wait-timeout: 3600
 
       - name: Build Sentry.Unity Solution
         run: docker exec unity dotnet build -c Release -v:d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,9 @@ jobs:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Check snapshot
         id: snapshot-check
@@ -196,10 +195,9 @@ jobs:
           BUILD_PLATFORM: ${{ matrix.build_platform }}
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
         with:
           access_token: ${{ github.token }}
 
@@ -70,16 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref || github.ref }}
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Check snapshot
         id: snapshot-check
@@ -136,7 +135,7 @@ jobs:
       UNITY_PATH: docker exec unity unity-editor
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0
@@ -149,7 +148,7 @@ jobs:
           swap-storage: true
 
       - name: Docker Login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }} 
@@ -166,7 +165,7 @@ jobs:
           UNITY_LICENSE_SERVER_CONFIG: ${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-${{ matrix.unity-version }}
 
@@ -174,7 +173,7 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Cache Unity Library
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
           key: Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-v1
@@ -184,7 +183,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-${{ matrix.build_platform }}-${{ matrix.unity-version }}
@@ -196,10 +195,9 @@ jobs:
           BUILD_PLATFORM: ${{ matrix.build_platform }}
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
@@ -226,7 +224,7 @@ jobs:
           UNITY_VERSION: ${{ matrix.unity-version }}
 
       - name: Upload build size measurement
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-size-${{ matrix.platform }}-${{ matrix.unity-version }}
           path: build-size-measurements/*.json
@@ -241,7 +239,7 @@ jobs:
           tar -cvzf test-app-webgl.tar.gz samples/IntegrationTest/Build
 
       - name: Upload test app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-webgl-compiled-${{ matrix.unity-version }}
           if-no-files-found: error
@@ -250,7 +248,7 @@ jobs:
           
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-project-${{ matrix.platform }}-${{ matrix.unity-version }}
           path: |
@@ -416,10 +414,10 @@ jobs:
     needs: [test-build-webgl, test-build-android, test-compile-ios, test-build-linux, test-build-windows]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download all build size measurements
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: build-size-*
           path: build-size-measurements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
     name: Build Unity SDK
     secrets: inherit
     permissions:
+      actions: read
       checks: write
-      statuses: write
       contents: read
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,10 @@ jobs:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
       - name: Download UPM package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: package-release
+          wait-timeout: 3600
 
       - name: Check snapshot
         id: snapshot-check
@@ -195,9 +196,10 @@ jobs:
           BUILD_PLATFORM: ${{ matrix.build_platform }}
 
       - name: Download UPM package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: package-release
+          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # pin@0.11.0
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.head_ref || github.ref }}
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
@@ -136,7 +136,7 @@ jobs:
       UNITY_PATH: docker exec unity unity-editor
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0
@@ -416,7 +416,7 @@ jobs:
     needs: [test-build-webgl, test-build-android, test-compile-ios, test-build-linux, test-build-windows]
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Download all build size measurements
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           submodules: recursive
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
@@ -22,7 +22,7 @@ jobs:
           | xargs clang-format -i -style=file
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select submodules
         id: env
@@ -54,7 +54,7 @@ jobs:
         shell: bash
 
       - name: Restore from cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache
         with:
           # Note: native SDKs are cached and only built if the respective 'package-dev/Plugins/' directories are empty.
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install .NET SDK
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
           
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload build logs on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: |
             ${{ steps.env.outputs.submodulesPath }}/build.log
@@ -100,7 +100,7 @@ jobs:
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ env.TARGET == 'Cocoa' }}
         with:
           name: ${{ env.TARGET }}-sdk
@@ -110,7 +110,7 @@ jobs:
           # Lower retention period - we only need this to retry CI.
           retention-days: 14
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ env.TARGET != 'Cocoa' }}
         with:
           name: ${{ env.TARGET }}-sdk

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Select submodules
         id: env

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -66,9 +66,10 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: package-release
+          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -66,10 +66,9 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Docker Login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Docker Login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ env.GITHUB_ACTOR }}
@@ -38,7 +38,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-${{ env.UNITY_VERSION }}
 
@@ -46,7 +46,7 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Cache Unity Library
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
           key: Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-v1
@@ -56,7 +56,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Android-${{ inputs.unity-version }}
@@ -66,10 +66,9 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
@@ -89,14 +88,14 @@ jobs:
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform "Android" -UnityVersion "$env:UNITY_VERSION"
 
       - name: Upload build size measurement
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-size-Android-${{ env.UNITY_VERSION }}
           path: build-size-measurements/*.json
           retention-days: 1
 
       - name: Upload .apk
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-android-compiled-${{ env.UNITY_VERSION }}-runtime
           path: samples/IntegrationTest/Build/*.apk # Collect app but ignore the files that are not required for the test.
@@ -113,7 +112,7 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -UnityVersion "$env:UNITY_VERSION"
 
       - name: Upload .apk
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-android-compiled-${{ env.UNITY_VERSION }}-buildtime
           path: samples/IntegrationTest/Build/*.apk
@@ -121,7 +120,7 @@ jobs:
 
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-project-android-${{ env.UNITY_VERSION }}
           path: |

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -85,10 +85,9 @@ jobs:
           retention-days: 1
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -5,7 +5,7 @@ on:
       unity-version:
         required: true
         type: string
-  
+
 defaults:
   run:
     shell: pwsh
@@ -85,9 +85,10 @@ jobs:
           retention-days: 1
 
       - name: Download UPM package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: package-release
+          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Docker Login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -27,10 +27,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Docker Login
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ env.GITHUB_ACTOR }}
@@ -44,7 +44,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-${{ env.UNITY_VERSION }}
 
@@ -52,7 +52,7 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Cache Unity Library
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
           key: Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-v1
@@ -62,7 +62,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-iOS-${{ inputs.unity-version }}
@@ -78,17 +78,16 @@ jobs:
           tar -cvzf test-app-no-sentry.tar.gz samples/IntegrationTest/Build-NoSentry
 
       - name: Upload build without Sentry
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-ios-no-sentry-${{ env.UNITY_VERSION }}
           path: test-app-no-sentry.tar.gz
           retention-days: 1
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
@@ -117,7 +116,7 @@ jobs:
 
       # Upload runtime initialization build
       - name: Upload test app (runtime initialization)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-ios-${{ env.UNITY_VERSION }}-runtime
           if-no-files-found: error
@@ -144,7 +143,7 @@ jobs:
 
       # Upload build-time initialization build
       - name: Upload test app (build-time initialization)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-ios-${{ env.UNITY_VERSION }}-buildtime
           if-no-files-found: error
@@ -153,7 +152,7 @@ jobs:
           
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-project-ios-${{ env.UNITY_VERSION }}
           path: |

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -77,9 +77,10 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Linux -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: package-release
+          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0
@@ -35,7 +35,7 @@ jobs:
           swap-storage: true
 
       - name: Log into Docker
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ env.GITHUB_ACTOR }}
@@ -49,7 +49,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-${{ env.UNITY_VERSION }}
 
@@ -57,7 +57,7 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Cache Unity Library
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
           key: Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-v1
@@ -67,7 +67,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Linux-${{ inputs.unity-version }}
@@ -77,10 +77,9 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Linux -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
@@ -100,7 +99,7 @@ jobs:
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform Linux -UnityVersion "$env:UNITY_VERSION"
 
       - name: Upload build size measurement
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-size-Linux-${{ env.UNITY_VERSION }}
           path: build-size-measurements/*.json
@@ -113,7 +112,7 @@ jobs:
           tar -cvzf test-app-desktop.tar.gz samples/IntegrationTest/Build
 
       - name: Upload test app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-desktop-compiled-${{ env.UNITY_VERSION }}-linux
           if-no-files-found: error
@@ -135,7 +134,7 @@ jobs:
 
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-project-desktop-linux-${{ env.UNITY_VERSION }}
           path: |

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -77,10 +77,9 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Linux -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8 # v1.3.0

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -68,10 +68,9 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Windows -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: ./.github/actions/wait-for-artifact
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Load env
         id: env

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -68,9 +68,10 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Windows -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
         with:
           name: package-release
+          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Load env
         id: env
@@ -40,7 +40,7 @@ jobs:
           UNITY_LICENSE_SERVER_CONFIG: ${{ secrets.UNITY_LICENSE_SERVER_CONFIG }}
 
       - name: Download IntegrationTest project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-${{ env.UNITY_VERSION }}
 
@@ -48,7 +48,7 @@ jobs:
         run: tar -xvzf test-project.tar.gz
 
       - name: Cache Unity Library
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
           key: Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-v1
@@ -58,7 +58,7 @@ jobs:
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Windows-${{ inputs.unity-version }}
@@ -68,10 +68,9 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Windows -BuildDirName "Build-NoSentry"
 
       - name: Download UPM package
-        uses: vaind/download-artifact@e7141b6a94ef28aa3d828b52830cfa1f406a1848 # v4-with-wait-timeout
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package-release
-          wait-timeout: 3600
 
       - name: Extract UPM package
         run: ./test/Scripts.Integration.Test/extract-package.ps1
@@ -91,7 +90,7 @@ jobs:
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform Windows -UnityVersion "$env:UNITY_VERSION"
 
       - name: Upload build size measurement
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-size-Windows-${{ env.UNITY_VERSION }}
           path: build-size-measurements/*.json
@@ -104,7 +103,7 @@ jobs:
           tar -cvzf test-app-desktop.tar.gz samples/IntegrationTest/Build
 
       - name: Upload test app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-desktop-compiled-${{ env.UNITY_VERSION }}-windows
           if-no-files-found: error
@@ -113,7 +112,7 @@ jobs:
 
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-project-desktop-windows-${{ env.UNITY_VERSION }}
           path: |

--- a/.github/workflows/test-compile-ios.yml
+++ b/.github/workflows/test-compile-ios.yml
@@ -23,19 +23,19 @@ jobs:
             
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore cached compiled iOS build without Sentry
         if: ${{ inputs.init-type == 'runtime' }}
         id: cache-compiled-nosentry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: IntegrationTest-NoSentry.app
           key: build-nosentry-iOS-compiled-${{ inputs.unity-version }}
 
       - name: Download build without Sentry (for size comparison)
         if: ${{ inputs.init-type == 'runtime' && steps.cache-compiled-nosentry.outputs.cache-hit != 'true' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: testapp-ios-no-sentry-${{ env.UNITY_VERSION }}
 
@@ -58,7 +58,7 @@ jobs:
           Remove-Item -Path "samples/IntegrationTest/Build" -Recurse -Force
 
       - name: Download app project
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: testapp-ios-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload integration-test project on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-project-ios-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}-compiled
           path: |
@@ -85,7 +85,7 @@ jobs:
           Get-ChildItem -Path "samples/IntegrationTest/Build" -Recurse
           
       - name: Upload app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-ios-compiled-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
           # Collect app but ignore the files that are not required for the test.
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload build size measurement
         if: ${{ inputs.init-type == 'runtime' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-size-iOS-${{ env.UNITY_VERSION }}
           path: build-size-measurements/*.json

--- a/.github/workflows/test-compile-ios.yml
+++ b/.github/workflows/test-compile-ios.yml
@@ -23,7 +23,7 @@ jobs:
             
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Restore cached compiled iOS build without Sentry
         if: ${{ inputs.init-type == 'runtime' }}

--- a/.github/workflows/test-create.yml
+++ b/.github/workflows/test-create.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Docker Login
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3

--- a/.github/workflows/test-create.yml
+++ b/.github/workflows/test-create.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Docker Login
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned v3
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ghcr.io
         username: ${{ env.GITHUB_ACTOR }}
@@ -32,7 +32,7 @@ jobs:
 
     - name: Cache IntegrationTest Project
       id: cache-project
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: samples/IntegrationTest
         key: IntegrationTest-Project-${{ env.UNITY_VERSION }}-${{ hashFiles('test/Scripts.Integration.Test/**') }}-v1
@@ -55,7 +55,7 @@ jobs:
       run: tar -cvzf test-project.tar.gz samples/IntegrationTest
 
     - name: Upload project
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-${{ env.UNITY_VERSION }}
         if-no-files-found: error

--- a/.github/workflows/test-run-android.yml
+++ b/.github/workflows/test-run-android.yml
@@ -36,14 +36,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize app-runner submodule
         run: git submodule update --init modules/app-runner
         shell: bash
 
       - name: Download test app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: testapp-android-compiled-${{ inputs.unity-version }}-${{ inputs.init-type }}
           path: samples/IntegrationTest/Build
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Run Android Integration Tests
-        uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b # pin@v2.33.0
+        uses: reactivecircus/android-emulator-runner@0a638108440efd5c7f980e6ba145dbcdd8f32009 # v2.37.0
         id: integration-test
         timeout-minutes: 30
         with:
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload test results on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-android-logs-${{ inputs.api-level }}-${{ inputs.unity-version }}
           path: |

--- a/.github/workflows/test-run-desktop.yml
+++ b/.github/workflows/test-run-desktop.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize app-runner submodule
         run: git submodule update --init modules/app-runner
         shell: bash
 
       - name: Download test app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: testapp-desktop-compiled-${{ inputs.unity-version }}-${{ inputs.platform }}
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload test results on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-desktop-logs-${{ inputs.platform }}-${{ inputs.unity-version }}
           path: |

--- a/.github/workflows/test-run-ios.yml
+++ b/.github/workflows/test-run-ios.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Initialize app-runner submodule
         run: git submodule update --init modules/app-runner

--- a/.github/workflows/test-run-ios.yml
+++ b/.github/workflows/test-run-ios.yml
@@ -38,14 +38,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize app-runner submodule
         run: git submodule update --init modules/app-runner
         shell: bash
 
       - name: Download app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: testapp-ios-compiled-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
           path: samples/IntegrationTest/Build
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set Xcode for iOS version ${{ env.IOS_VERSION }}
         if: ${{ env.IOS_VERSION != 'latest'}}
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # pin@v1.6
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '15.0' # to run iOS 17.0 we need Xcode 15.0
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload test results on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-ios-logs-${{ env.IOS_VERSION }}-${{ env.UNITY_VERSION }}-${{ env.INIT_TYPE }}
           path: |

--- a/.github/workflows/test-run-webgl.yml
+++ b/.github/workflows/test-run-webgl.yml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize app-runner submodule
         run: git submodule update --init modules/app-runner
         shell: bash
 
       - name: Download test app artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: testapp-webgl-compiled-${{ inputs.unity-version }}
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload test results on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testapp-webgl-logs-${{ inputs.unity-version }}
           path: |

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -56,7 +56,7 @@ jobs:
           "version=$($latest.version)" >> $env:GITHUB_OUTPUT
           "changeset=$($latest.shortRevision)" >> $env:GITHUB_OUTPUT
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -56,7 +56,7 @@ jobs:
           "version=$($latest.version)" >> $env:GITHUB_OUTPUT
           "changeset=$($latest.shortRevision)" >> $env:GITHUB_OUTPUT
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
@@ -70,7 +70,7 @@ jobs:
       - run: git --no-pager diff
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pin#v7.0.5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/unity-${{ steps.version-select.outputs.version }}
           commit-message: 'chore: update to Unity ${{ steps.version-select.outputs.version }}'


### PR DESCRIPTION
This addresses the 79 warnings that 
```
Node.js 20 actions are deprecated.
```
which will hit us in June. 

#skip-changelog