### PR TITLE
feat: added `AndroidNativeAnrEnabled` and related options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added `AndroidNativeAnrEnabled` (default `false`) to enable ANR detection through the native (sentry-java) SDK, monitoring the Android UI (Looper) main thread. On API ≥ 30 this uses [ANR v2](https://docs.sentry.io/platforms/android/configuration/app-not-respond/) via `ApplicationExitInfo` to report OS-detected ANRs from prior runs; on API < 30 it falls back to an in-process watchdog. Complementary to the Unity SDK's C# watchdog, which monitors the Unity player loop. ([#2671](https://github.com/getsentry/sentry-unity/pull/2671))
+- Added `AndroidNativeAnrEnabled` (default `true`) to enable ANR detection through `sentry-java` SDK. The native ANR integration monitors the Android UI thread. On API ≥ 30 this uses [ANR v2](https://docs.sentry.io/platforms/android/configuration/app-not-respond/) via `ApplicationExitInfo` to report OS-detected ANRs from prior runs; on API < 30 it falls back to an in-process watchdog. This is complementary to the Unity SDK's C# watchdog, which monitors the Unity player loop. ([#2671](https://github.com/getsentry/sentry-unity/pull/2671))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added `AndroidNativeAnrEnabled` (default `false`) to enable ANR detection through the native (sentry-java) SDK, monitoring the Android UI (Looper) main thread. On API ≥ 30 this uses [ANR v2](https://docs.sentry.io/platforms/android/configuration/app-not-respond/) via `ApplicationExitInfo` to report OS-detected ANRs from prior runs; on API < 30 it falls back to an in-process watchdog. Complementary to the Unity SDK's C# watchdog, which monitors the Unity player loop. ([#TBD](https://github.com/getsentry/sentry-unity/pull/TBD))
+- Added `AndroidNativeAnrEnabled` (default `false`) to enable ANR detection through the native (sentry-java) SDK, monitoring the Android UI (Looper) main thread. On API ≥ 30 this uses [ANR v2](https://docs.sentry.io/platforms/android/configuration/app-not-respond/) via `ApplicationExitInfo` to report OS-detected ANRs from prior runs; on API < 30 it falls back to an in-process watchdog. Complementary to the Unity SDK's C# watchdog, which monitors the Unity player loop. ([#2671](https://github.com/getsentry/sentry-unity/pull/2671))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Added experimental `AndroidAnrV2Enabled` option to enable ANR detection on Android through the native SDK. On Android API ≥ 30 this uses `ApplicationExitInfo` to report OS-detected ANRs from prior runs ([sentry-java ANR v2](https://docs.sentry.io/platforms/android/configuration/app-not-respond/)). Defaults to `false`; opt in via the `OptionsConfiguration.Configure(options)` callback. ([#TBD](https://github.com/getsentry/sentry-unity/pull/TBD))
+
 ### Fixes
 
 - The SDK no longer sends screenshot attachments for events that were dropped during processing (e.g., by `BeforeSend` or sampling) ([#2661](https://github.com/getsentry/sentry-unity/pull/2661))

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -139,6 +139,7 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setEnableNdk", options.NdkIntegrationEnabled);
                 androidOptions.Call("setEnableScopeSync", options.NdkScopeSyncEnabled);
                 androidOptions.Call("setNativeSdkName", "sentry.native.android.unity");
+                androidOptions.Call("setAnrEnabled", options.AndroidAnrV2Enabled);
 
                 // Options that are not to be set by the user
                 // We're disabling some integrations as to not duplicate event or because the SDK relies on the .NET SDK
@@ -148,7 +149,6 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setAttachScreenshot", false);
                 androidOptions.Call("setEnableAutoSessionTracking", false);
                 androidOptions.Call("setEnableActivityLifecycleBreadcrumbs", false);
-                androidOptions.Call("setAnrEnabled", options.AndroidAnrV2Enabled);
                 androidOptions.Call("setEnableScopePersistence", false);
                 // Disable user interaction tracking to prevent conflicts with VR platforms (e.g., Oculus InputHooks)
                 androidOptions.Call("setEnableUserInteractionBreadcrumbs", false);

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -142,8 +142,8 @@ internal class SentryJava : ISentryJava
 
                 androidOptions.Call("setAnrEnabled", options.AndroidNativeAnrEnabled);
                 androidOptions.Call("setEnableScopePersistence", options.AndroidNativeAnrEnabled);
-                androidOptions.Call("setReportHistoricalAnrs", options.AndroidNativeAnrEnabled && options.AndroidReportHistoricalAnrs);
-                androidOptions.Call("setAttachAnrThreadDump", options.AndroidNativeAnrEnabled && options.AndroidAttachAnrThreadDump);
+                androidOptions.Call("setReportHistoricalAnrs", options.AndroidReportHistoricalAnrs);
+                androidOptions.Call("setAttachAnrThreadDump", options.AndroidAttachAnrThreadDump);
 
                 using (var logsOptions = androidOptions.Call<AndroidJavaObject>("getLogs"))
                 {

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -148,7 +148,7 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setAttachScreenshot", false);
                 androidOptions.Call("setEnableAutoSessionTracking", false);
                 androidOptions.Call("setEnableActivityLifecycleBreadcrumbs", false);
-                androidOptions.Call("setAnrEnabled", false);
+                androidOptions.Call("setAnrEnabled", options.AndroidAnrV2Enabled);
                 androidOptions.Call("setEnableScopePersistence", false);
                 // Disable user interaction tracking to prevent conflicts with VR platforms (e.g., Oculus InputHooks)
                 androidOptions.Call("setEnableUserInteractionBreadcrumbs", false);

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -139,7 +139,11 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setEnableNdk", options.NdkIntegrationEnabled);
                 androidOptions.Call("setEnableScopeSync", options.NdkScopeSyncEnabled);
                 androidOptions.Call("setNativeSdkName", "sentry.native.android.unity");
+
                 androidOptions.Call("setAnrEnabled", options.AndroidAnrV2Enabled);
+                androidOptions.Call("setEnableScopePersistence", options.AndroidAnrV2Enabled);
+                androidOptions.Call("setReportHistoricalAnrs", options.AndroidAnrV2Enabled && options.AndroidReportHistoricalAnrs);
+                androidOptions.Call("setAttachAnrThreadDump", options.AndroidAnrV2Enabled && options.AndroidAttachAnrThreadDump);
 
                 // Options that are not to be set by the user
                 // We're disabling some integrations as to not duplicate event or because the SDK relies on the .NET SDK
@@ -149,7 +153,6 @@ internal class SentryJava : ISentryJava
                 androidOptions.Call("setAttachScreenshot", false);
                 androidOptions.Call("setEnableAutoSessionTracking", false);
                 androidOptions.Call("setEnableActivityLifecycleBreadcrumbs", false);
-                androidOptions.Call("setEnableScopePersistence", false);
                 // Disable user interaction tracking to prevent conflicts with VR platforms (e.g., Oculus InputHooks)
                 androidOptions.Call("setEnableUserInteractionBreadcrumbs", false);
                 androidOptions.Call("setEnableUserInteractionTracing", false);

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -218,7 +218,7 @@ public class AndroidManifestConfiguration
         androidManifest.SetAutoTraceIdGeneration(false);
         androidManifest.SetAutoSessionTracking(false);
         androidManifest.SetAutoAppLifecycleBreadcrumbs(false);
-        androidManifest.SetAnr(false);
+        androidManifest.SetAnr(_options.AndroidAnrV2Enabled);
         androidManifest.SetPersistentScopeObserver(false);
         // Disable user interaction tracking to prevent conflicts with VR platforms (e.g., Oculus InputHooks)
         androidManifest.SetEnableUserInteractionBreadcrumbs(false);

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -220,7 +220,7 @@ public class AndroidManifestConfiguration
         androidManifest.SetAutoAppLifecycleBreadcrumbs(false);
         androidManifest.SetAnr(_options.AndroidNativeAnrEnabled);
         androidManifest.SetPersistentScopeObserver(_options.AndroidNativeAnrEnabled);
-        androidManifest.SetAttachAnrThreadDump(_options.AndroidNativeAnrEnabled && _options.AndroidAttachAnrThreadDump);
+        androidManifest.SetAttachAnrThreadDump(_options.AndroidAttachAnrThreadDump);
         // Disable user interaction tracking to prevent conflicts with VR platforms (e.g., Oculus InputHooks)
         androidManifest.SetEnableUserInteractionBreadcrumbs(false);
         androidManifest.SetEnableUserInteractionTracing(false);

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -219,7 +219,8 @@ public class AndroidManifestConfiguration
         androidManifest.SetAutoSessionTracking(false);
         androidManifest.SetAutoAppLifecycleBreadcrumbs(false);
         androidManifest.SetAnr(_options.AndroidAnrV2Enabled);
-        androidManifest.SetPersistentScopeObserver(false);
+        androidManifest.SetPersistentScopeObserver(_options.AndroidAnrV2Enabled);
+        androidManifest.SetAttachAnrThreadDump(_options.AndroidAnrV2Enabled && _options.AndroidAttachAnrThreadDump);
         // Disable user interaction tracking to prevent conflicts with VR platforms (e.g., Oculus InputHooks)
         androidManifest.SetEnableUserInteractionBreadcrumbs(false);
         androidManifest.SetEnableUserInteractionTracing(false);
@@ -494,6 +495,9 @@ internal class AndroidManifest : AndroidXmlDocument
 
     internal void SetPersistentScopeObserver(bool enableScopePersistence)
         => SetMetaData($"{SentryPrefix}.enable-scope-persistence", enableScopePersistence.ToString());
+
+    internal void SetAttachAnrThreadDump(bool attachAnrThreadDump)
+        => SetMetaData($"{SentryPrefix}.anr.attach-thread-dumps", attachAnrThreadDump.ToString());
 
     internal void SetNdkEnabled(bool enableNdk)
         => SetMetaData($"{SentryPrefix}.ndk.enable", enableNdk.ToString());

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -215,18 +215,21 @@ public sealed class SentryUnityOptions : SentryOptions
     public NativeInitializationType AndroidNativeInitializationType { get; set; } = NativeInitializationType.Runtime;
 
     /// <summary>
-    /// (Experimental) Enables ANR detection on Android through the native (sentry-java) SDK.
+    /// Enables ANR detection on Android through the native (sentry-java) SDK.
     /// On API ≥ 30 this uses Android's <c>ApplicationExitInfo</c> to report ANRs detected by the OS
-    /// in prior runs (ANR v2). On API &lt; 30, sentry-java falls back to its in-process watchdog,
-    /// which runs alongside the Unity SDK's C# ANR watchdog. The C# watchdog continues to run on all
-    /// API levels.
+    /// in prior runs (ANR v2). On API &lt; 30, sentry-java falls back to its in-process watchdog.
+    /// The Unity SDK's C# ANR watchdog continues to run on all API levels.
     /// </summary>
-    /// <remarks>This option is experimental and may change without notice.</remarks>
+    /// <remarks>
+    /// The Java and C# watchdogs observe different threads and are complementary: the Java watchdog
+    /// monitors the Android UI (Looper) main thread, while the C# watchdog monitors the Unity engine
+    /// main thread (the player loop). A hang that blocks both threads can produce one event from each.
+    /// </remarks>
     public bool AndroidAnrV2Enabled { get; set; } = false;
 
     /// <summary>
-    /// (Experimental) When ANR v2 is enabled, controls whether sentry-java reports historical ANRs
-    /// recorded by the OS (<c>ApplicationExitInfo</c>) from prior runs. Has no effect when
+    /// When ANR v2 is enabled, controls whether sentry-java reports historical ANRs recorded by the
+    /// OS (<c>ApplicationExitInfo</c>) from prior runs. Has no effect when
     /// <see cref="AndroidAnrV2Enabled"/> is <c>false</c>.
     /// </summary>
     /// <remarks>
@@ -236,8 +239,8 @@ public sealed class SentryUnityOptions : SentryOptions
     public bool AndroidReportHistoricalAnrs { get; set; } = true;
 
     /// <summary>
-    /// (Experimental) When ANR v2 is enabled, controls whether sentry-java attaches a thread dump
-    /// to ANR events. Has no effect when <see cref="AndroidAnrV2Enabled"/> is <c>false</c>.
+    /// When ANR v2 is enabled, controls whether sentry-java attaches a thread dump to ANR events.
+    /// Has no effect when <see cref="AndroidAnrV2Enabled"/> is <c>false</c>.
     /// </summary>
     public bool AndroidAttachAnrThreadDump { get; set; } = true;
 

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -225,7 +225,7 @@ public sealed class SentryUnityOptions : SentryOptions
     /// monitors the Android UI (Looper) main thread, while the C# watchdog monitors the Unity engine
     /// main thread (the player loop). A hang that blocks both threads can produce one event from each.
     /// </remarks>
-    public bool AndroidNativeAnrEnabled { get; set; } = false;
+    public bool AndroidNativeAnrEnabled { get; set; } = true;
 
     /// <summary>
     /// When <see cref="AndroidNativeAnrEnabled"/> is enabled, controls whether sentry-java reports historical ANRs

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -236,13 +236,13 @@ public sealed class SentryUnityOptions : SentryOptions
     /// Runtime-only. There is no <c>AndroidManifest</c> meta-data tag for this option, so it is only
     /// applied when <see cref="AndroidNativeInitializationType"/> is <see cref="NativeInitializationType.Runtime"/>.
     /// </remarks>
-    public bool AndroidReportHistoricalAnrs { get; set; } = true;
+    public bool AndroidReportHistoricalAnrs { get; set; } = false;
 
     /// <summary>
     /// When <see cref="AndroidNativeAnrEnabled"/> is enabled, controls whether sentry-java attaches a thread dump
     /// to ANR events. Has no effect when <see cref="AndroidNativeAnrEnabled"/> is <c>false</c>.
     /// </summary>
-    public bool AndroidAttachAnrThreadDump { get; set; } = true;
+    public bool AndroidAttachAnrThreadDump { get; set; } = false;
 
     /// <summary>
     /// Whether the SDK should add the NDK integration for Android

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -225,6 +225,23 @@ public sealed class SentryUnityOptions : SentryOptions
     public bool AndroidAnrV2Enabled { get; set; } = false;
 
     /// <summary>
+    /// (Experimental) When ANR v2 is enabled, controls whether sentry-java reports historical ANRs
+    /// recorded by the OS (<c>ApplicationExitInfo</c>) from prior runs. Has no effect when
+    /// <see cref="AndroidAnrV2Enabled"/> is <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// Runtime-only. There is no <c>AndroidManifest</c> meta-data tag for this option, so it is only
+    /// applied when <see cref="AndroidNativeInitializationType"/> is <see cref="NativeInitializationType.Runtime"/>.
+    /// </remarks>
+    public bool AndroidReportHistoricalAnrs { get; set; } = true;
+
+    /// <summary>
+    /// (Experimental) When ANR v2 is enabled, controls whether sentry-java attaches a thread dump
+    /// to ANR events. Has no effect when <see cref="AndroidAnrV2Enabled"/> is <c>false</c>.
+    /// </summary>
+    public bool AndroidAttachAnrThreadDump { get; set; } = true;
+
+    /// <summary>
     /// Whether the SDK should add the NDK integration for Android
     /// </summary>
     public bool NdkIntegrationEnabled { get; set; } = true;

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -215,6 +215,16 @@ public sealed class SentryUnityOptions : SentryOptions
     public NativeInitializationType AndroidNativeInitializationType { get; set; } = NativeInitializationType.Runtime;
 
     /// <summary>
+    /// (Experimental) Enables ANR detection on Android through the native (sentry-java) SDK.
+    /// On API ≥ 30 this uses Android's <c>ApplicationExitInfo</c> to report ANRs detected by the OS
+    /// in prior runs (ANR v2). On API &lt; 30, sentry-java falls back to its in-process watchdog,
+    /// which runs alongside the Unity SDK's C# ANR watchdog. The C# watchdog continues to run on all
+    /// API levels.
+    /// </summary>
+    /// <remarks>This option is experimental and may change without notice.</remarks>
+    public bool AndroidAnrV2Enabled { get; set; } = false;
+
+    /// <summary>
     /// Whether the SDK should add the NDK integration for Android
     /// </summary>
     public bool NdkIntegrationEnabled { get; set; } = true;

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -151,29 +151,42 @@ public class AndroidManifestTests
     }
 
     [Test]
-    public void ModifyManifest_AndroidAnrV2Enabled_True_WritesAnrEnableTrue()
+    public void ModifyManifest_AndroidAnrV2Enabled_True_WritesAnrV2MetadataEnabled()
     {
         _fixture.SentryUnityOptions!.AndroidAnrV2Enabled = true;
         var sut = _fixture.GetSut();
 
         var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
 
-        StringAssert.Contains(
-            "<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"True\" />",
-            manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"True\" />", manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.enable-scope-persistence\" android:value=\"True\" />", manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"True\" />", manifest);
     }
 
     [Test]
-    public void ModifyManifest_AndroidAnrV2Enabled_False_WritesAnrEnableFalse()
+    public void ModifyManifest_AndroidAnrV2Enabled_False_WritesAnrV2MetadataDisabled()
     {
         _fixture.SentryUnityOptions!.AndroidAnrV2Enabled = false;
         var sut = _fixture.GetSut();
 
         var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
 
-        StringAssert.Contains(
-            "<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"False\" />",
-            manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"False\" />", manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.enable-scope-persistence\" android:value=\"False\" />", manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"False\" />", manifest);
+    }
+
+    [Test]
+    public void ModifyManifest_AndroidAttachAnrThreadDumpFalse_OverridesUmbrella()
+    {
+        _fixture.SentryUnityOptions!.AndroidAnrV2Enabled = true;
+        _fixture.SentryUnityOptions!.AndroidAttachAnrThreadDump = false;
+        var sut = _fixture.GetSut();
+
+        var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
+
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"True\" />", manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"False\" />", manifest);
     }
 
     [Test]

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -151,6 +151,32 @@ public class AndroidManifestTests
     }
 
     [Test]
+    public void ModifyManifest_AndroidAnrV2Enabled_True_WritesAnrEnableTrue()
+    {
+        _fixture.SentryUnityOptions!.AndroidAnrV2Enabled = true;
+        var sut = _fixture.GetSut();
+
+        var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
+
+        StringAssert.Contains(
+            "<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"True\" />",
+            manifest);
+    }
+
+    [Test]
+    public void ModifyManifest_AndroidAnrV2Enabled_False_WritesAnrEnableFalse()
+    {
+        _fixture.SentryUnityOptions!.AndroidAnrV2Enabled = false;
+        var sut = _fixture.GetSut();
+
+        var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
+
+        StringAssert.Contains(
+            "<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"False\" />",
+            manifest);
+    }
+
+    [Test]
     public void ModifyManifest_ManifestHasDsn()
     {
         var expected = _fixture.SentryUnityOptions!.Dsn;

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -160,7 +160,6 @@ public class AndroidManifestTests
 
         StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"True\" />", manifest);
         StringAssert.Contains("<meta-data android:name=\"io.sentry.enable-scope-persistence\" android:value=\"True\" />", manifest);
-        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"True\" />", manifest);
     }
 
     [Test]
@@ -173,20 +172,17 @@ public class AndroidManifestTests
 
         StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"False\" />", manifest);
         StringAssert.Contains("<meta-data android:name=\"io.sentry.enable-scope-persistence\" android:value=\"False\" />", manifest);
-        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"False\" />", manifest);
     }
 
     [Test]
-    public void ModifyManifest_AndroidAttachAnrThreadDumpFalse_OverridesUmbrella()
+    public void ModifyManifest_AndroidAttachAnrThreadDump_FlowsThroughToManifest()
     {
-        _fixture.SentryUnityOptions!.AndroidNativeAnrEnabled = true;
-        _fixture.SentryUnityOptions!.AndroidAttachAnrThreadDump = false;
+        _fixture.SentryUnityOptions!.AndroidAttachAnrThreadDump = true;
         var sut = _fixture.GetSut();
 
         var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
 
-        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.enable\" android:value=\"True\" />", manifest);
-        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"False\" />", manifest);
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.anr.attach-thread-dumps\" android:value=\"True\" />", manifest);
     }
 
     [Test]


### PR DESCRIPTION
## Problem

Unity games can get stuck in multiple places and as of right now the SDK surfaces only the C# watchdog integration to capture ANRs. This comes with several limitations. `sentry-java` has its own ANR integrations that the SDK currently  hardcoded opts-out.

## Context

Unity games have their own main thread. The `sentry-java` SDK has a v1 and a v2 ANR integration that monitors the Android UI thread.

There are these native options:
- `enableAnr`
- `enableScopePersistence`
- `isReportHistoricalAnrs`
- `isAttachAnrThreadDump`

Since the work next to each other we keep the umbrella flags `AnrDetectionEnabled` and `AndroidNativeAnrEnabled` separated.

The way this works is on API >= 30 `sentry-java` will use `ApplicationExitInfo` to read OS-reported ANRs to generate events out of those. Since this happens on the next launch, `enableScopePersistence` allows the SDK to store the scope to disk to then enrich the event with the scope at the time of the ANR. 

### Proposal

We can surface these options and pass them to `sentry-java`. These are especially valuable if users have their own launcher, or plugins running outside of the Unity game loop.
`sentry-java` takes care of picking the supported ANR integration. On API < 30 this is "just" a watchdog, similar to what we have for C#.

### Follow Up

There are a couple of follow-ups:
1. The `sentry-java` manifest needs to accept the historic anr capture flag, see https://github.com/getsentry/sentry-java/pull/5387
2. Improvements to our C# anr capture mechanism see https://github.com/getsentry/sentry-unity/issues/1961
3. Add ANR capture to e2e tests
4. Add native ANR trigger to samples