### PR TITLE
fix(switch): add `sentry_options_set_enable_logs` stub

### DIFF
--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -114,6 +114,12 @@ void sentry_options_set_enable_metrics(void* options, int enable_metrics)
     (void)enable_metrics;
 }
 
+void sentry_options_set_enable_logs(void* options, int enable_logs)
+{
+    (void)options;
+    (void)enable_logs;
+}
+
 void sentry_options_set_logger(void* options, void* logger, void* userdata)
 {
     (void)options;


### PR DESCRIPTION
Cursor very helpfully added this comment https://github.com/getsentry/sentry-unity/pull/2662#pullrequestreview-4235633834 after the PR was already merged to warn about a missing stub (better late than never 😅 ).

This PR just cleans up #2662 by adding it to `sentry_native_stubs.c`.  This will fix failing CI in [sentry-switch](https://github.com/getsentry/sentry-switch/actions/runs/25811542105/job/75955987715).

#skip-changelog