### PR TITLE
chore: no lightmapper in CI

### DIFF
--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -254,10 +254,11 @@ public class Builder
     // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI
     private static void DisableProgressiveLightMapper()
     {
-#if UNITY_2021_OR_NEWER
+#if UNITY_2021_1_OR_NEWER
         Lightmapping.lightingSettings = new LightingSettings
         {
-            bakedGI = false
+            bakedGI = false,
+            realtimeGI = false
         };
 #endif
     }


### PR DESCRIPTION
This should fix the `Falling back to CPU lightmapper` errors when building for Unity 2021 targeting macOS.

#skip-changelog

