### PR TITLE
fix(switch): add missing `shutdown_timeout` stub

### DIFF
--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -120,6 +120,12 @@ void sentry_options_set_enable_logs(void* options, int enable_logs)
     (void)enable_logs;
 }
 
+void sentry_options_set_shutdown_timeout(void* options, uint64_t shutdown_timeout)
+{
+    (void)options;
+    (void)shutdown_timeout;
+}
+
 void sentry_options_set_logger(void* options, void* logger, void* userdata)
 {
     (void)options;


### PR DESCRIPTION
CI is failing in https://github.com/getsentry/sentry-switch/actions/runs/26637874357/job/79287085831#step:7:3960 ; the DLLImport was added in https://github.com/getsentry/sentry-unity/pull/2687/changes#diff-eb63ac1b51fac5d112760d161c136ca07a5a628272dd68ae33e298b1ae5c8f48R188 but is missing the respective entry in `sentry_native_stubs.c`.

#skip-changelog