### PR TITLE
chore: Added docs to `CaptureFeedback`

### DIFF
--- a/src/Sentry.Unity/SentrySdk.Dotnet.cs
+++ b/src/Sentry.Unity/SentrySdk.Dotnet.cs
@@ -313,6 +313,10 @@ public static partial class SentrySdk
     /// <summary>
     /// Captures feedback from the user.
     /// </summary>
+    /// <param name="feedback">The feedback to send to Sentry.</param>
+    /// <param name="configureScope">The callback to configure the scope.</param>
+    /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <returns>The Id of the captured feedback. Returns <see cref="SentryId.Empty"/> when capture failed.</returns>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, Action<Scope> configureScope, SentryHint? hint = null)
         => Sentry.SentrySdk.CaptureFeedback(feedback, configureScope, hint);
@@ -328,6 +332,7 @@ public static partial class SentrySdk
     /// </param>
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <returns>The Id of the captured feedback. Returns <see cref="SentryId.Empty"/> when capture failed.</returns>
     /// <remarks>
     /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. Non-success 
     /// results inform only on whether the capture succeeded or failed on the client, i.e. empty message, 
@@ -341,6 +346,10 @@ public static partial class SentrySdk
     /// <summary>
     /// Captures feedback from the user.
     /// </summary>
+    /// <param name="feedback">The feedback to send to Sentry.</param>
+    /// <param name="scope">The scope to apply to the feedback.</param>
+    /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <returns>The Id of the captured feedback. Returns <see cref="SentryId.Empty"/> when capture failed.</returns>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, Scope? scope = null, SentryHint? hint = null)
         => Sentry.SentrySdk.CaptureFeedback(feedback, scope, hint);
@@ -356,6 +365,7 @@ public static partial class SentrySdk
     /// </param>
     /// <param name="scope">The scope to apply to the feedback.</param>
     /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <returns>The Id of the captured feedback. Returns <see cref="SentryId.Empty"/> when capture failed.</returns>
     /// <remarks>
     /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. Non-success 
     /// results inform only on whether the capture succeeded or failed on the client, i.e. empty message, 
@@ -369,6 +379,15 @@ public static partial class SentrySdk
     /// <summary>
     /// Captures feedback from the user.
     /// </summary>
+    /// <param name="message">The feedback message.</param>
+    /// <param name="contactEmail">The contact email of the user submitting the feedback.</param>
+    /// <param name="name">The name of the user submitting the feedback.</param>
+    /// <param name="replayId">The ID of the replay associated with the feedback.</param>
+    /// <param name="url">The URL of the page or screen the feedback relates to.</param>
+    /// <param name="associatedEventId">The ID of the event the feedback is associated with.</param>
+    /// <param name="scope">The scope to apply to the feedback.</param>
+    /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <returns>The Id of the captured feedback. Returns <see cref="SentryId.Empty"/> when capture failed.</returns>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(string message, string? contactEmail = null, string? name = null,
         string? replayId = null, string? url = null, SentryId? associatedEventId = null, Scope? scope = null,

--- a/src/Sentry.Unity/SentrySdk.Dotnet.cs
+++ b/src/Sentry.Unity/SentrySdk.Dotnet.cs
@@ -329,9 +329,9 @@ public static partial class SentrySdk
     /// <param name="configureScope">The callback to configure the scope.</param>
     /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
     /// <remarks>
-    /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. If enabled,
-    /// this also provides offline caching and retries. Non-success results inform only on whether the capture
-    /// succeeded or failed on the client, i.e. empty message, disabled SDK, dropped by an event processor.
+    /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. Non-success 
+    /// results inform only on whether the capture succeeded or failed on the client, i.e. empty message, 
+    /// disabled SDK, dropped by an event processor.
     /// </remarks>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,
@@ -357,9 +357,9 @@ public static partial class SentrySdk
     /// <param name="scope">The scope to apply to the feedback.</param>
     /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
     /// <remarks>
-    /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. If enabled,
-    /// this also provides offline caching and retries. Non-success results inform only on whether the capture
-    /// succeeded or failed on the client, i.e. empty message, disabled SDK, dropped by an event processor.
+    /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. Non-success 
+    /// results inform only on whether the capture succeeded or failed on the client, i.e. empty message, 
+    /// disabled SDK, dropped by an event processor.
     /// </remarks>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,

--- a/src/Sentry.Unity/SentrySdk.Dotnet.cs
+++ b/src/Sentry.Unity/SentrySdk.Dotnet.cs
@@ -320,6 +320,19 @@ public static partial class SentrySdk
     /// <summary>
     /// Captures feedback from the user.
     /// </summary>
+    /// <param name="feedback">The feedback to send to Sentry.</param>
+    /// <param name="result">
+    /// The outcome of capturing the feedback. <see cref="CaptureFeedbackResult.Success"/> means the
+    /// feedback was accepted and handed to the transport. It passed validation and event processors and
+    /// was queued for delivery. It does <b>not</b> confirm that the feedback was transmitted to Sentry.
+    /// </param>
+    /// <param name="configureScope">The callback to configure the scope.</param>
+    /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <remarks>
+    /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. If enabled,
+    /// this also provides offline caching and retries. Non-success results inform only on whether the capture
+    /// succeeded or failed on the client, i.e. empty message, disabled SDK, dropped by an event processor.
+    /// </remarks>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,
         Action<Scope> configureScope, SentryHint? hint = null)
@@ -335,6 +348,19 @@ public static partial class SentrySdk
     /// <summary>
     /// Captures feedback from the user.
     /// </summary>
+    /// <param name="feedback">The feedback to send to Sentry.</param>
+    /// <param name="result">
+    /// The outcome of capturing the feedback. <see cref="CaptureFeedbackResult.Success"/> means the
+    /// feedback was accepted and handed to the transport. It passed validation and event processors and
+    /// was queued for delivery. It does <b>not</b> confirm that the feedback was transmitted to Sentry.
+    /// </param>
+    /// <param name="scope">The scope to apply to the feedback.</param>
+    /// <param name="hint">An optional hint providing high-level context for the source of the event.</param>
+    /// <remarks>
+    /// Capturing is asynchronous and non-blocking. The envelope is handed to a background worker. If enabled,
+    /// this also provides offline caching and retries. Non-success results inform only on whether the capture
+    /// succeeded or failed on the client, i.e. empty message, disabled SDK, dropped by an event processor.
+    /// </remarks>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,
         Scope? scope = null, SentryHint? hint = null)


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2626

Because it is not obvious that `CaptureFeedbackResult` does not actually inform whether the feedback made it to Sentry.

#skip-changelog