### PR TITLE
fix: Sync breadcrumb data to native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Dependencies
 
-- Bump Java SDK from v8.43.0 to v8.43.2 ([#2706](https://github.com/getsentry/sentry-unity/pull/2706), [#2711](https://github.com/getsentry/sentry-unity/pull/2711))
+- Bump Java SDK from v8.43.0 to v8.44.1 ([#2706](https://github.com/getsentry/sentry-unity/pull/2706), [#2711](https://github.com/getsentry/sentry-unity/pull/2711), [#2720](https://github.com/getsentry/sentry-unity/pull/2720))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8432)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.43.0...8.43.2)
 - Bump Cocoa SDK from v9.15.0 to v9.17.1 ([#2705](https://github.com/getsentry/sentry-unity/pull/2705), [#2713](https://github.com/getsentry/sentry-unity/pull/2713))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,9 @@
 
 ### Dependencies
 
-- Bump Java SDK from v8.43.0 to v8.44.1 ([#2706](https://github.com/getsentry/sentry-unity/pull/2706), [#2711](https://github.com/getsentry/sentry-unity/pull/2711), [#2720](https://github.com/getsentry/sentry-unity/pull/2720))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8432)
-  - [diff](https://github.com/getsentry/sentry-java/compare/8.43.0...8.43.2)
-- Bump Cocoa SDK from v9.15.0 to v9.17.1 ([#2705](https://github.com/getsentry/sentry-unity/pull/2705), [#2713](https://github.com/getsentry/sentry-unity/pull/2713))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9171)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.15.0...9.17.1)
-- Bump Native SDK from v0.14.2 to v0.15.0 ([#2714](https://github.com/getsentry/sentry-unity/pull/2714))
-  - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0150)
-  - [diff](https://github.com/getsentry/sentry-native/compare/0.14.2...0.15.0)
-- Bump Java SDK from v8.43.0 to v8.44.0 ([#2706](https://github.com/getsentry/sentry-unity/pull/2706), [#2711](https://github.com/getsentry/sentry-unity/pull/2711), [#2723](https://github.com/getsentry/sentry-unity/pull/2723))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8440)
-  - [diff](https://github.com/getsentry/sentry-java/compare/8.43.0...8.44.0)
+- Bump Java SDK from v8.43.0 to v8.44.1 ([#2706](https://github.com/getsentry/sentry-unity/pull/2706), [#2711](https://github.com/getsentry/sentry-unity/pull/2711), [#2723](https://github.com/getsentry/sentry-unity/pull/2723), [#2720](https://github.com/getsentry/sentry-unity/pull/2720))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8441)
+  - [diff](https://github.com/getsentry/sentry-java/compare/8.43.0...8.44.1)
 - Bump Cocoa SDK from v9.15.0 to v9.18.0 ([#2705](https://github.com/getsentry/sentry-unity/pull/2705), [#2713](https://github.com/getsentry/sentry-unity/pull/2713), [#2724](https://github.com/getsentry/sentry-unity/pull/2724))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9180)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.15.0...9.18.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- The SDK now also syncs breadcrumb data to the native layer so they are available on events coming from the native SDKs ([#2720](https://github.com/getsentry/sentry-unity/pull/2720))
 - Removed `Lumin` and `Stadia` platforms from the package's assembly definition to resolve compilation errors. ([#2716](https://github.com/getsentry/sentry-unity/pull/2716))
 
 ### Features

--- a/package-dev/Plugins/iOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridge.m
@@ -107,8 +107,8 @@ int SentryNativeBridgeCrashedLastRun() { return [SentrySDK crashedLastRun] ? 1 :
 
 void SentryNativeBridgeClose() { [SentrySDK close]; }
 
-void SentryNativeBridgeAddBreadcrumb(
-    const char *timestamp, const char *message, const char *type, const char *category, int level)
+void SentryNativeBridgeAddBreadcrumb(const char *timestamp, const char *message, const char *type,
+    const char *category, int level, const char **dataKeys, const char **dataValues, int dataCount)
 {
     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
         return;
@@ -137,6 +137,18 @@ void SentryNativeBridgeAddBreadcrumb(
 
         if (typeString != nil) {
             breadcrumb.type = typeString;
+        }
+
+        if (dataCount > 0 && dataKeys != NULL && dataValues != NULL) {
+            NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:dataCount];
+            for (int i = 0; i < dataCount; i++) {
+                NSString *key = _NSStringOrNil(dataKeys[i]);
+                NSString *value = _NSStringOrNil(dataValues[i]);
+                if (key != nil && value != nil) {
+                    data[key] = value;
+                }
+            }
+            breadcrumb.data = data;
         }
 
         [scope addBreadcrumb:breadcrumb];

--- a/package-dev/Plugins/iOS/SentryNativeBridgeNoOp.m
+++ b/package-dev/Plugins/iOS/SentryNativeBridgeNoOp.m
@@ -16,8 +16,8 @@ int SentryNativeBridgeCrashedLastRun() { return 0; }
 
 void SentryNativeBridgeClose() { }
 
-void SentryNativeBridgeAddBreadcrumb(
-    const char *timestamp, const char *message, const char *type, const char *category, int level) { }
+void SentryNativeBridgeAddBreadcrumb(const char *timestamp, const char *message, const char *type,
+    const char *category, int level, const char **dataKeys, const char **dataValues, int dataCount) { }
 
 void SentryNativeBridgeSetExtra(const char *key, const char *value) { }
 

--- a/package-dev/Plugins/macOS/SentryNativeBridge.m
+++ b/package-dev/Plugins/macOS/SentryNativeBridge.m
@@ -208,8 +208,8 @@ void SentryNativeBridgeClose()
     }
 }
 
-void SentryNativeBridgeAddBreadcrumb(
-    const char *timestamp, const char *message, const char *type, const char *category, int level)
+void SentryNativeBridgeAddBreadcrumb(const char *timestamp, const char *message, const char *type,
+    const char *category, int level, const char **dataKeys, const char **dataValues, int dataCount)
 {
     if (timestamp == NULL && message == NULL && type == NULL && category == NULL) {
         return;
@@ -243,6 +243,18 @@ void SentryNativeBridgeAddBreadcrumb(
         }
 
         [breadcrumb setValue:[NSNumber numberWithInt:level] forKey:@"level"];
+
+        if (dataCount > 0 && dataKeys != NULL && dataValues != NULL) {
+            NSMutableDictionary *data = [NSMutableDictionary dictionaryWithCapacity:dataCount];
+            for (int i = 0; i < dataCount; i++) {
+                NSString *key = _NSStringOrNil(dataKeys[i]);
+                NSString *value = _NSStringOrNil(dataValues[i]);
+                if (key != nil && value != nil) {
+                    data[key] = value;
+                }
+            }
+            [breadcrumb setValue:data forKey:@"data"];
+        }
 
         [scope performSelector:@selector(addBreadcrumb:) withObject:breadcrumb];
     });

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -304,6 +304,13 @@ internal class SentryJava : ISentryJava
             javaBreadcrumb.Set("category", breadcrumb.Category);
             using var javaLevel = breadcrumb.Level.ToJavaSentryLevel();
             javaBreadcrumb.Set("level", javaLevel);
+            if (breadcrumb.Data is { Count: > 0 })
+            {
+                foreach (var kvp in breadcrumb.Data)
+                {
+                    javaBreadcrumb.Call("setData", kvp.Key, kvp.Value);
+                }
+            }
             sentry.CallStatic("addBreadcrumb", javaBreadcrumb, null);
         });
     }

--- a/src/Sentry.Unity.Native/NativeScopeObserver.cs
+++ b/src/Sentry.Unity.Native/NativeScopeObserver.cs
@@ -17,6 +17,15 @@ public class NativeScopeObserver : ScopeObserver
         C.sentry_value_set_by_key(crumb, "level", C.sentry_value_new_string(breadcrumb.Level.ToString().ToLower()));
         C.sentry_value_set_by_key(crumb, "timestamp", C.sentry_value_new_string(GetTimestamp(breadcrumb.Timestamp)));
         C.SetValueIfNotNull(crumb, "category", breadcrumb.Category);
+        if (breadcrumb.Data is { Count: > 0 })
+        {
+            var data = C.sentry_value_new_object();
+            foreach (var kvp in breadcrumb.Data)
+            {
+                C.SetValueIfNotNull(data, kvp.Key, kvp.Value);
+            }
+            _ = C.sentry_value_set_by_key(crumb, "data", data);
+        }
         C.sentry_add_breadcrumb(crumb);
     }
 

--- a/src/Sentry.Unity.iOS/NativeScopeObserver.cs
+++ b/src/Sentry.Unity.iOS/NativeScopeObserver.cs
@@ -11,7 +11,34 @@ public class NativeScopeObserver : ScopeObserver
         var level = GetBreadcrumbLevel(breadcrumb.Level);
         var timestamp = GetTimestamp(breadcrumb.Timestamp);
 
-        SentryCocoaBridgeProxy.AddBreadcrumb(timestamp, breadcrumb.Message, breadcrumb.Type, breadcrumb.Category, level);
+        var dataCount = GetBreadcrumbData(breadcrumb, out var dataKeys, out var dataValues);
+
+        SentryCocoaBridgeProxy.AddBreadcrumb(timestamp, breadcrumb.Message, breadcrumb.Type, breadcrumb.Category, level,
+            dataKeys, dataValues, dataCount);
+    }
+
+    // Flattens breadcrumb.Data into parallel key/value arrays for the __Internal P/Invoke boundary.
+    // Returns 0 and null arrays when there is no data, so the common case pays no marshalling cost.
+    internal static int GetBreadcrumbData(Breadcrumb breadcrumb, out string[]? keys, out string[]? values)
+    {
+        if (breadcrumb.Data is not { Count: > 0 } data)
+        {
+            keys = null;
+            values = null;
+            return 0;
+        }
+
+        keys = new string[data.Count];
+        values = new string[data.Count];
+        var i = 0;
+        foreach (var kvp in data)
+        {
+            keys[i] = kvp.Key;
+            values[i] = kvp.Value;
+            i++;
+        }
+
+        return data.Count;
     }
 
     public override void SetExtraImpl(string key, string? value) =>

--- a/src/Sentry.Unity.iOS/NativeScopeObserver.cs
+++ b/src/Sentry.Unity.iOS/NativeScopeObserver.cs
@@ -11,14 +11,13 @@ public class NativeScopeObserver : ScopeObserver
         var level = GetBreadcrumbLevel(breadcrumb.Level);
         var timestamp = GetTimestamp(breadcrumb.Timestamp);
 
+        // Pass breadcrumb.Data as two parallel key/value arrays for the __Internal P/Invoke boundary.
         var dataCount = GetBreadcrumbData(breadcrumb, out var dataKeys, out var dataValues);
 
         SentryCocoaBridgeProxy.AddBreadcrumb(timestamp, breadcrumb.Message, breadcrumb.Type, breadcrumb.Category, level,
             dataKeys, dataValues, dataCount);
     }
 
-    // Flattens breadcrumb.Data into parallel key/value arrays for the __Internal P/Invoke boundary.
-    // Returns 0 and null arrays when there is no data, so the common case pays no marshalling cost.
     internal static int GetBreadcrumbData(Breadcrumb breadcrumb, out string[]? keys, out string[]? values)
     {
         if (breadcrumb.Data is not { Count: > 0 } data)

--- a/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
+++ b/src/Sentry.Unity.iOS/SentryCocoaBridgeProxy.cs
@@ -128,7 +128,8 @@ internal static class SentryCocoaBridgeProxy
     public static extern void Close();
 
     [DllImport("__Internal", EntryPoint = "SentryNativeBridgeAddBreadcrumb")]
-    public static extern void AddBreadcrumb(string timestamp, string? message, string? type, string? category, int level);
+    public static extern void AddBreadcrumb(string timestamp, string? message, string? type, string? category, int level,
+        string[]? dataKeys, string[]? dataValues, int dataCount);
 
     [DllImport("__Internal", EntryPoint = "SentryNativeBridgeSetExtra")]
     public static extern void SetExtra(string key, string? value);

--- a/test/IntegrationTest/CommonTestCases.ps1
+++ b/test/IntegrationTest/CommonTestCases.ps1
@@ -72,13 +72,10 @@ $CommonTestCases = @(
             $SentryEvent.breadcrumbs.values | Should -Not -BeNullOrEmpty
             $SentryEvent.breadcrumbs.values | Where-Object { $_.message -eq "Integration test started" } | Should -Not -BeNullOrEmpty
             $SentryEvent.breadcrumbs.values | Where-Object { $_.message -eq "Context configuration finished" } | Should -Not -BeNullOrEmpty
-        }
-    }
-    @{ Name = "Syncs breadcrumb data"; TestBlock = {
-            param($TestSetup, $TestType, $SentryEvent, $RunResult)
-            $crumb = $SentryEvent.breadcrumbs.values | Where-Object { $_.message -eq "Breadcrumb with data" }
-            $crumb | Should -Not -BeNullOrEmpty
-            $crumb.data.integration_test_key | Should -Be "integration_test_value"
+
+            $dataCrumb = $SentryEvent.breadcrumbs.values | Where-Object { $_.message -eq "Context configuration finished" }
+            $dataCrumb | Should -Not -BeNullOrEmpty
+            $dataCrumb.data.integration_test_key | Should -Be "integration_test_value"
         }
     }
     @{ Name = "Contains SDK information"; TestBlock = {

--- a/test/IntegrationTest/CommonTestCases.ps1
+++ b/test/IntegrationTest/CommonTestCases.ps1
@@ -74,6 +74,13 @@ $CommonTestCases = @(
             $SentryEvent.breadcrumbs.values | Where-Object { $_.message -eq "Context configuration finished" } | Should -Not -BeNullOrEmpty
         }
     }
+    @{ Name = "Syncs breadcrumb data"; TestBlock = {
+            param($TestSetup, $TestType, $SentryEvent, $RunResult)
+            $crumb = $SentryEvent.breadcrumbs.values | Where-Object { $_.message -eq "Breadcrumb with data" }
+            $crumb | Should -Not -BeNullOrEmpty
+            $crumb.data.integration_test_key | Should -Be "integration_test_value"
+        }
+    }
     @{ Name = "Contains SDK information"; TestBlock = {
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
             $SentryEvent.sdk | Should -Not -BeNullOrEmpty

--- a/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
@@ -99,6 +99,14 @@ public class IntegrationTester : MonoBehaviour
         });
 
         SentrySdk.AddBreadcrumb("Context configuration finished");
+
+        // Carries data so the e2e tests can verify breadcrumb data is synced from managed to native.
+        // On a native crash the event is assembled by the native SDK, so this only round-trips if the
+        // C#->native breadcrumb data sync works.
+        SentrySdk.AddBreadcrumb("Breadcrumb with data", data: new Dictionary<string, string>
+        {
+            { "integration_test_key", "integration_test_value" }
+        });
     }
 
     private IEnumerator MessageCapture()

--- a/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
@@ -98,12 +98,7 @@ public class IntegrationTester : MonoBehaviour
             };
         });
 
-        SentrySdk.AddBreadcrumb("Context configuration finished");
-
-        // Carries data so the e2e tests can verify breadcrumb data is synced from managed to native.
-        // On a native crash the event is assembled by the native SDK, so this only round-trips if the
-        // C#->native breadcrumb data sync works.
-        SentrySdk.AddBreadcrumb("Breadcrumb with data", data: new Dictionary<string, string>
+        SentrySdk.AddBreadcrumb("Context configuration finished", data: new Dictionary<string, string>
         {
             { "integration_test_key", "integration_test_value" }
         });

--- a/test/Sentry.Unity.iOS.Tests/NativeScopeObserverTests.cs
+++ b/test/Sentry.Unity.iOS.Tests/NativeScopeObserverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using NUnit.Framework;
 
@@ -28,5 +29,37 @@ public class IosNativeScopeObserverTests
         var actualLevel = NativeScopeObserver.GetBreadcrumbLevel(level);
 
         Assert.AreEqual(actualLevel, expectedNativeLevel);
+    }
+
+    [Test]
+    public void GetBreadcrumbData_WithData_BuildsParallelArrays()
+    {
+        var breadcrumb = new Breadcrumb("message", "type", new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" },
+        });
+
+        var count = NativeScopeObserver.GetBreadcrumbData(breadcrumb, out var keys, out var values);
+
+        Assert.AreEqual(2, count);
+        Assert.IsNotNull(keys);
+        Assert.IsNotNull(values);
+        Assert.AreEqual("key1", keys![0]);
+        Assert.AreEqual("value1", values![0]);
+        Assert.AreEqual("key2", keys[1]);
+        Assert.AreEqual("value2", values[1]);
+    }
+
+    [Test]
+    public void GetBreadcrumbData_WithoutData_ReturnsZeroAndNullArrays()
+    {
+        var breadcrumb = new Breadcrumb("message", "type");
+
+        var count = NativeScopeObserver.GetBreadcrumbData(breadcrumb, out var keys, out var values);
+
+        Assert.AreEqual(0, count);
+        Assert.IsNull(keys);
+        Assert.IsNull(values);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2718
Relies on https://github.com/getsentry/sentry-native/pull/1808

