### PR TITLE
chore: fixed debug symbol upload in CI

### DIFF
--- a/test/Scripts.Integration.Test/Scripts/CliConfiguration.cs
+++ b/test/Scripts.Integration.Test/Scripts/CliConfiguration.cs
@@ -14,7 +14,7 @@ public class CliConfiguration : SentryCliOptionsConfiguration
         cliOptions.Auth = authToken;
 
         cliOptions.Organization = "sentry-sdks";
-        cliOptions.Project = "sentry-unity";
+        cliOptions.Project = "sentry-unity-integration-tests";
 
         Debug.Log("Sentry: CliConfiguration::Configure() finished");
     }


### PR DESCRIPTION
We're uploading the debug symbols to the wrong project.

#skip-changelog