### PR TITLE
chore: fix `Library` caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-v1
+          key: Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-v2
           restore-keys: |
             Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-
-            Library-IntegrationTest-${{ matrix.platform }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -49,10 +49,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-Android-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-iOS-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -60,10 +60,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-linux-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-macos.yml
+++ b/.github/workflows/test-build-macos.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-macos-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-windows-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry


### PR DESCRIPTION
Looks like we're blowing through our cache limit and evicting "older" caches. This causes the fallback to a version agnostic key to kick in and that causes things like
```
Failed to load '.../Library/SplashScreenCache/08/08945fcc...'.
File may be corrupted or was serialized with a newer version of Unity.
```
and that causes builds to fail. See [this run](https://github.com/getsentry/sentry-unity/actions/runs/28154457347) and [that run](https://github.com/getsentry/sentry-unity/actions/runs/28146692363).

#skip-changelog