### PR TITLE
chore: new integration test caching strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-v1
+          key: Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-v2
           restore-keys: |
             Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-
-            Library-IntegrationTest-${{ matrix.platform }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,17 +178,17 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Cache Unity Library
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-v2
+          key: it-library-ubuntu-${{ matrix.unity-version }}-${{ github.run_id }}
           restore-keys: |
-            Library-IntegrationTest-${{ matrix.platform }}-${{ matrix.unity-version }}-
+            it-library-ubuntu-${{ matrix.unity-version }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-${{ matrix.build_platform }}-${{ matrix.unity-version }}
@@ -198,6 +198,13 @@ jobs:
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "$env:BUILD_PLATFORM" -BuildDirName "Build-NoSentry"
         env:
           BUILD_PLATFORM: ${{ matrix.build_platform }}
+
+      - name: Save cached build without Sentry
+        if: github.ref == 'refs/heads/main' && steps.cache-build-nosentry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Build-NoSentry
+          key: build-nosentry-${{ matrix.build_platform }}-${{ matrix.unity-version }}
 
       - name: Download UPM package
         uses: ./.github/actions/wait-for-artifact
@@ -259,6 +266,8 @@ jobs:
           path: test-app-webgl.tar.gz
           retention-days: 14
           
+      # Library cache for the shared `ubuntu` flavour is written only by the Linux job
+      # (see test-build-linux.yml) - the other ubuntu targets are restore-only.
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -49,10 +49,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-Android-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -45,17 +45,17 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Cache Unity Library
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-v2
+          key: it-library-ubuntu-${{ env.UNITY_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            Library-IntegrationTest-Android-${{ env.UNITY_VERSION }}-
+            it-library-ubuntu-${{ env.UNITY_VERSION }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Android-${{ inputs.unity-version }}
@@ -63,6 +63,13 @@ jobs:
       - name: Build without Sentry SDK
         if: steps.cache-build-nosentry.outputs.cache-hit != 'true'
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -BuildDirName "Build-NoSentry"
+
+      - name: Save cached build without Sentry
+        if: github.ref == 'refs/heads/main' && steps.cache-build-nosentry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Build-NoSentry
+          key: build-nosentry-Android-${{ inputs.unity-version }}
 
       - name: Download UPM package
         uses: ./.github/actions/wait-for-artifact
@@ -144,6 +151,8 @@ jobs:
             samples/IntegrationTest/Build/sentry-mapping-upload.log
           retention-days: 14
 
+      # Library cache for the shared `ubuntu` flavour is written only by the Linux job
+      # (see test-build-linux.yml) - the other ubuntu targets are restore-only.
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -51,17 +51,17 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Cache Unity Library
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-v2
+          key: it-library-ubuntu-${{ env.UNITY_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-
+            it-library-ubuntu-${{ env.UNITY_VERSION }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-iOS-${{ inputs.unity-version }}
@@ -69,6 +69,13 @@ jobs:
       - name: Build without Sentry SDK
         if: steps.cache-build-nosentry.outputs.cache-hit != 'true'
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "iOS" -BuildDirName "Build-NoSentry"
+
+      - name: Save cached build without Sentry
+        if: github.ref == 'refs/heads/main' && steps.cache-build-nosentry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Build-NoSentry
+          key: build-nosentry-iOS-${{ inputs.unity-version }}
 
       - name: Create archive for build without Sentry
         shell: bash
@@ -157,6 +164,8 @@ jobs:
           path: test-app-buildtime.tar.gz
           retention-days: 14
           
+      # Library cache for the shared `ubuntu` flavour is written only by the Linux job
+      # (see test-build-linux.yml) - the other ubuntu targets are restore-only.
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-build-ios.yml
+++ b/.github/workflows/test-build-ios.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-iOS-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-iOS-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -60,10 +60,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-linux-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -56,17 +56,17 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Cache Unity Library
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-v2
+          key: it-library-ubuntu-${{ env.UNITY_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            Library-IntegrationTest-linux-${{ env.UNITY_VERSION }}-
+            it-library-ubuntu-${{ env.UNITY_VERSION }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Linux-${{ inputs.unity-version }}
@@ -74,6 +74,13 @@ jobs:
       - name: Build without Sentry SDK
         if: steps.cache-build-nosentry.outputs.cache-hit != 'true'
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Linux -BuildDirName "Build-NoSentry"
+
+      - name: Save cached build without Sentry
+        if: github.ref == 'refs/heads/main' && steps.cache-build-nosentry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Build-NoSentry
+          key: build-nosentry-Linux-${{ inputs.unity-version }}
 
       - name: Download UPM package
         uses: ./.github/actions/wait-for-artifact
@@ -152,6 +159,13 @@ jobs:
           if-no-files-found: error
           path: test-app-desktop.tar.gz
           retention-days: 14
+
+      - name: Save Unity Library cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Library
+          key: it-library-ubuntu-${{ env.UNITY_VERSION }}-${{ github.run_id }}
 
       - name: Docker diagnostics on failure
         if: ${{ failure() }}

--- a/.github/workflows/test-build-macos.yml
+++ b/.github/workflows/test-build-macos.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-macos-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-macos.yml
+++ b/.github/workflows/test-build-macos.yml
@@ -51,17 +51,17 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Cache Unity Library
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-v2
+          key: it-library-macos-${{ env.UNITY_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            Library-IntegrationTest-macos-${{ env.UNITY_VERSION }}-
+            it-library-macos-${{ env.UNITY_VERSION }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-MacOS-${{ inputs.unity-version }}
@@ -69,6 +69,13 @@ jobs:
       - name: Build without Sentry SDK
         if: steps.cache-build-nosentry.outputs.cache-hit != 'true'
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform MacOS -BuildDirName "Build-NoSentry"
+
+      - name: Save cached build without Sentry
+        if: github.ref == 'refs/heads/main' && steps.cache-build-nosentry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Build-NoSentry
+          key: build-nosentry-MacOS-${{ inputs.unity-version }}
 
       - name: Download UPM package
         uses: ./.github/actions/wait-for-artifact
@@ -147,6 +154,13 @@ jobs:
           if-no-files-found: error
           path: test-app-desktop.tar.gz
           retention-days: 14
+
+      - name: Save Unity Library cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Library
+          key: it-library-macos-${{ env.UNITY_VERSION }}-${{ github.run_id }}
 
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-v1
+          key: Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-v2
           restore-keys: |
             Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-
-            Library-IntegrationTest-windows-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -51,17 +51,17 @@ jobs:
       - name: Extract project archive
         run: tar -xvzf test-project.tar.gz
 
-      - name: Cache Unity Library
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Library
-          key: Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-v2
+          key: it-library-windows-${{ env.UNITY_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            Library-IntegrationTest-windows-${{ env.UNITY_VERSION }}-
+            it-library-windows-${{ env.UNITY_VERSION }}-
 
       - name: Restore cached build without Sentry
         id: cache-build-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: samples/IntegrationTest/Build-NoSentry
           key: build-nosentry-Windows-${{ inputs.unity-version }}
@@ -69,6 +69,13 @@ jobs:
       - name: Build without Sentry SDK
         if: steps.cache-build-nosentry.outputs.cache-hit != 'true'
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Windows -BuildDirName "Build-NoSentry"
+
+      - name: Save cached build without Sentry
+        if: github.ref == 'refs/heads/main' && steps.cache-build-nosentry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Build-NoSentry
+          key: build-nosentry-Windows-${{ inputs.unity-version }}
 
       - name: Download UPM package
         uses: ./.github/actions/wait-for-artifact
@@ -147,6 +154,13 @@ jobs:
           if-no-files-found: error
           path: test-app-desktop.tar.gz
           retention-days: 14
+
+      - name: Save Unity Library cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: samples/IntegrationTest/Library
+          key: it-library-windows-${{ env.UNITY_VERSION }}-${{ github.run_id }}
 
       - name: Upload IntegrationTest project on failure
         if: ${{ failure() }}

--- a/.github/workflows/test-compile-ios.yml
+++ b/.github/workflows/test-compile-ios.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Restore cached compiled iOS build without Sentry
         if: ${{ inputs.init-type == 'runtime' }}
         id: cache-compiled-nosentry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: IntegrationTest-NoSentry.app
           key: build-nosentry-iOS-compiled-${{ inputs.unity-version }}
@@ -56,6 +56,13 @@ jobs:
           Copy-Item -Path "samples/IntegrationTest/Build/archive/Unity-iPhone/Build/Products/Release-iphonesimulator/IntegrationTest.app" `
                     -Destination "IntegrationTest-NoSentry.app" -Recurse
           Remove-Item -Path "samples/IntegrationTest/Build" -Recurse -Force
+
+      - name: Save cached compiled iOS build without Sentry
+        if: ${{ inputs.init-type == 'runtime' && steps.cache-compiled-nosentry.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: IntegrationTest-NoSentry.app
+          key: build-nosentry-iOS-compiled-${{ inputs.unity-version }}
 
       - name: Download app project
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/test-create.yml
+++ b/.github/workflows/test-create.yml
@@ -30,9 +30,9 @@ jobs:
         username: ${{ env.GITHUB_ACTOR }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Cache IntegrationTest Project
+    - name: Restore IntegrationTest Project cache
       id: cache-project
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: samples/IntegrationTest
         key: IntegrationTest-Project-${{ env.UNITY_VERSION }}-${{ hashFiles('test/Scripts.Integration.Test/**') }}-v1
@@ -49,6 +49,13 @@ jobs:
     - name: Create new Project
       if: steps.cache-project.outputs.cache-hit != 'true'
       run: ./test/Scripts.Integration.Test/create-project.ps1 -UnityPath "$env:UNITY_PATH"
+
+    - name: Save IntegrationTest Project cache
+      if: github.ref == 'refs/heads/main' && steps.cache-project.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: samples/IntegrationTest
+        key: IntegrationTest-Project-${{ env.UNITY_VERSION }}-${{ hashFiles('test/Scripts.Integration.Test/**') }}-v1
 
     # We create tar explicitly because upload-artifact is slow for many files.
     - name: Create archive


### PR DESCRIPTION
## Why
I'm not even sure if the addition of 6.5 pushed us over the edge or if that was already happening but https://github.com/getsentry/sentry-unity/pull/2733 is a fix where the 2021 integration test tries to run with the 6.5 library and that fails horribly.
We're way over our cache limit and this aims to fix that.

## Who writes what — before / after

| Cache | Before | After |
| --- | --- | --- |
| **`Library` (per OS)** | 6 jobs (Android, iOS, Linux, WebGL, Windows, macOS) each write their own key, on every branch | **3 jobs, `main` only** — Linux→`ubuntu`, Windows→`windows`, macOS→`macos`. Android/iOS/WebGL → `ubuntu` but restore-only |
| **`Build-NoSentry`** | written on every branch | unchanged keys, **`main` only** |
| **`IntegrationTest-Project`** | written on every branch | unchanged key, **`main` only** |
| **PR runs** | fork a full set of copies (i.e. PR #2733 created **10 entries / 3.26 GB**) | **write nothing** — read `main`'s caches |

## How many cache entries — per Unity version

| Metric | Before | After |
| --- | --- | --- |
| `Library` keys | 6 (one per platform) | 3 (one per OS flavour) |
| `Library` writers | 6 jobs, any branch | 3 jobs, `main` only (`ubuntu` = Linux only) |
| Storage per version (ubuntu family) | ~2.6 GB (4 separate Libraries) | ~1.1 GB (1 shared) |

## Net effect

Library cache count roughly halves. The shared `ubuntu` entry is ~2.3× smaller than the four it replaces. Plus PRs stop consuming the budget entirely. This also means `main`'s caches stop getting evicted. Individual build steps might be slightly slower because the iterative build does not get cached, but way faster than having to rebuild the `/Library` from scratch.