### PR TITLE
fix(CI): Skip DependencyConflict package on WebGL 2021.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
           path: dependency-conflict-package
 
       - name: Add DependencyConflict to the project
+        if: ${{ !startsWith(matrix.unity-version, '2021') }}
         run: ./test/Scripts.Integration.Test/add-dependency-conflict.ps1 -PackagePath "dependency-conflict-package"
 
       - name: Configure Sentry


### PR DESCRIPTION
Unity 2021.3's WebGL plugin resolver rejects duplicate unaliased BCL assemblies (System.Buffers, System.Memory, etc.) shipped by both the Sentry SDK and the DependencyConflict test package. Other platforms and newer Unity versions are unaffected.

See CI failure in https://github.com/getsentry/sentry-unity/actions/runs/28182962245/job/83498147613#step:17:471

#skip-changelog