### PR TITLE
chore: skip dependency conflict package 2021 when targeting webgl

### DIFF
--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -13,8 +13,9 @@ on:
         value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
 
 env:
+  # TEMPORARY: only run on Unity 2021
   # Unity versions used in PRs
-  PR_UNITY_VERSIONS: '["2022.3", "6000.3", "6000.5"]'
+  PR_UNITY_VERSIONS: '["2021.3"]'
   # Unity versions used on main branch
   FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.3", "6000.5"]'
 

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -13,9 +13,8 @@ on:
         value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
 
 env:
-  # TEMPORARY: only run on Unity 2021
   # Unity versions used in PRs
-  PR_UNITY_VERSIONS: '["2021.3"]'
+  PR_UNITY_VERSIONS: '["2022.3", "6000.3", "6000.5"]'
   # Unity versions used on main branch
   FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.3", "6000.5"]'
 

--- a/.github/workflows/test-run-webgl.yml
+++ b/.github/workflows/test-run-webgl.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           $env:SENTRY_TEST_PLATFORM = "WebGL"
           $env:SENTRY_TEST_APP = "samples/IntegrationTest/Build"
+          $env:SENTRY_TEST_UNITY_VERSION = "${{ inputs.unity-version }}"
           Invoke-Pester -Path test/IntegrationTest/Integration.Tests.ps1 -CI
 
       - name: Upload test results on failure

--- a/test/IntegrationTest/CommonTestCases.ps1
+++ b/test/IntegrationTest/CommonTestCases.ps1
@@ -22,6 +22,13 @@ $CommonTestCases = @(
             # sets coexist at runtime. The build already fails to compile/link if aliasing
             # regresses; this asserts the runtime path too, so a runtime conflict turns the
             # build red rather than being swallowed into a log line.
+
+            # The DependencyConflict package is not installed on Unity 2021 + WebGL
+            if ($TestSetup.Platform -eq "WebGL" -and $TestSetup.UnityVersion -like "2021*") {
+                Set-ItResult -Skipped -Because "DependencyConflict is not installed on Unity 2021 + WebGL"
+                return
+            }
+
             $RunResult.Output | Where-Object { $_ -match "DependencyConflict: FAILED" } |
                 Should -BeNullOrEmpty -Because "the DependencyConflict package threw at runtime - assembly aliasing likely regressed"
             $RunResult.Output | Where-Object { $_ -match "DependencyConflict: Dependencies say hi" } |

--- a/test/IntegrationTest/Integration.Tests.ps1
+++ b/test/IntegrationTest/Integration.Tests.ps1
@@ -272,6 +272,7 @@ BeforeAll {
     # Initialize test parameters
     $script:TestSetup = [PSCustomObject]@{
         Platform = $script:Platform
+        UnityVersion = $env:SENTRY_TEST_UNITY_VERSION
         Dsn = $env:SENTRY_DSN
         AuthToken = $env:SENTRY_AUTH_TOKEN
     }

--- a/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using DependencyConflictPackage;
 using Sentry;
 using Sentry.Unity;
 using UnityEngine;
@@ -39,15 +38,17 @@ public class IntegrationTester : MonoBehaviour
     // the build red too instead of being swallowed into a log line.
     private void ExerciseConflictingDependencies()
     {
+#if !(UNITY_WEBGL && !UNITY_2022_1_OR_NEWER)
         try
         {
-            var greeting = DependencyConflictPackageClient.SayHiAsync().GetAwaiter().GetResult();
+            var greeting = DependencyConflictPackage.DependencyConflictPackageClient.SayHiAsync().GetAwaiter().GetResult();
             Logger.Log($"DependencyConflict: {greeting}");
         }
         catch (Exception ex)
         {
             Logger.LogError($"DependencyConflict: FAILED - {ex}");
         }
+#endif
     }
 
     public void Start()


### PR DESCRIPTION
#skip-changelog