### PR TITLE
chore: CI unity build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,10 @@ jobs:
         if: ${{ !startsWith(matrix.unity-version, '2021') }}
         run: ./test/Scripts.Integration.Test/add-dependency-conflict.ps1 -PackagePath "dependency-conflict-package"
 
+      - name: Disable DependencyConflict (WebGL 2021)
+        if: ${{ startsWith(matrix.unity-version, '2021') }}
+        run: ./test/Scripts.Integration.Test/add-dependency-conflict.ps1 -Disable
+
       - name: Configure Sentry
         run: ./test/Scripts.Integration.Test/configure-sentry.ps1 -UnityPath "$env:UNITY_PATH" -Platform "$env:BUILD_PLATFORM"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,8 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
-        ios-version: ["17.0", "latest"]
+        # On PRs only the newest simulator runs; `17.0` is an OS-compat axis (not SDK behavior) and runs on main.
+        ios-version: ${{ github.event_name == 'pull_request' && fromJSON('["latest"]') || fromJSON('["17.0", "latest"]') }}
         init-type: ["runtime", "buildtime"]
         # Check https://support.apple.com/en-us/HT201222 for the latest minor version for a given major one.
         # https://developer.apple.com/support/app-store/ shows that of all iOS devices
@@ -411,10 +412,6 @@ jobs:
       fail-fast: false
       matrix:
         unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
-        # The progressive lightmapper requires a GPU, which the Apple silicon CI runners don't have.
-        # On Unity 2021 this fails the player build outright (instead of warning), so skip macOS 2021.3.
-        exclude:
-          - unity-version: "2021.3"
     uses: ./.github/workflows/test-build-macos.yml
     with:
       unity-version: ${{ matrix.unity-version }}
@@ -461,10 +458,6 @@ jobs:
       matrix:
         unity-version: ${{ fromJSON(needs.create-unity-matrix.outputs.unity-matrix).unity-version }}
         backend: ["cocoa", "native"]
-        # See test-build-macos: the progressive lightmapper needs a GPU the Apple silicon
-        # CI runners lack, which fails the Unity 2021 player build. Skip macOS 2021.3.
-        exclude:
-          - unity-version: "2021.3"
     uses: ./.github/workflows/test-run-desktop.yml
     with:
       unity-version: ${{ matrix.unity-version }}

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -13,8 +13,9 @@ on:
         value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
 
 env:
-  # Unity versions used in PRs
-  PR_UNITY_VERSIONS: '["2022.3", "6000.3", "6000.5"]'
+  # Unity versions used in PRs - the compatibility envelope's bookends:
+  # 2021.3 (oldest supported) and 6000.5 (newest). The middle versions run on main.
+  PR_UNITY_VERSIONS: '["2021.3", "6000.5"]'
   # Unity versions used on main branch
   FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.3", "6000.5"]'
 

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -13,8 +13,7 @@ on:
         value: ${{ jobs.create-unity-matrix.outputs.unity-matrix }}
 
 env:
-  # Unity versions used in PRs - the compatibility envelope's bookends:
-  # 2021.3 (oldest supported) and 6000.5 (newest). The middle versions run on main.
+  # Unity versions used in PRs
   PR_UNITY_VERSIONS: '["2021.3", "6000.5"]'
   # Unity versions used on main branch
   FULL_UNITY_VERSIONS: '["2021.3", "2022.3", "6000.0", "6000.3", "6000.5"]'

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -127,7 +127,16 @@ public class Builder
     public static void BuildMacIl2CPPPlayer()
     {
         Debug.Log("Builder: Building macOS IL2CPP Player");
-        BuildIl2CPPPlayer(BuildTarget.StandaloneOSX, BuildTargetGroup.Standalone, BuildOptions.StrictMode,
+#if UNITY_2022_1_OR_NEWER
+        var buildOptions = BuildOptions.StrictMode;
+#else
+        // On 2021.3 the Apple silicon CI has no usable lightmapper (CPU unsupported, no OpenCL GPU
+        // device), so BuildPlayer always logs "Falling back to CPU lightmapper" as an error.
+        // StrictMode would escalate that unavoidable log to a build failure even though the build
+        // succeeds. Real failures are still caught via summary.result.
+        var buildOptions = BuildOptions.None;
+#endif
+        BuildIl2CPPPlayer(BuildTarget.StandaloneOSX, BuildTargetGroup.Standalone, buildOptions,
             defaultBuildPath: "./Builds/macOS/test.app");
     }
 
@@ -252,13 +261,9 @@ public class Builder
         serializedManager.ApplyModifiedProperties();
     }
 
-    // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI.
-    // BuildPlayer otherwise kicks off a GI bake when opening the scene, which dead-ends and
-    // fails the build under StrictMode. Switch GI to OnDemand and clear any baked data so no
-    // bake is ever attempted.
+    // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI
     private static void DisableProgressiveLightMapper()
     {
-        Lightmapping.giWorkflowMode = Lightmapping.GIWorkflowMode.OnDemand;
 #if UNITY_2021_1_OR_NEWER
         Lightmapping.lightingSettings = new LightingSettings
         {
@@ -266,7 +271,5 @@ public class Builder
             realtimeGI = false
         };
 #endif
-        Lightmapping.ClearLightingDataAsset();
-        Lightmapping.Clear();
     }
 }

--- a/test/Scripts.Integration.Test/Editor/Builder.cs
+++ b/test/Scripts.Integration.Test/Editor/Builder.cs
@@ -252,9 +252,13 @@ public class Builder
         serializedManager.ApplyModifiedProperties();
     }
 
-    // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI
+    // The Progressive Lightmapper does not work on silicone CPUs and there is no GPU in CI.
+    // BuildPlayer otherwise kicks off a GI bake when opening the scene, which dead-ends and
+    // fails the build under StrictMode. Switch GI to OnDemand and clear any baked data so no
+    // bake is ever attempted.
     private static void DisableProgressiveLightMapper()
     {
+        Lightmapping.giWorkflowMode = Lightmapping.GIWorkflowMode.OnDemand;
 #if UNITY_2021_1_OR_NEWER
         Lightmapping.lightingSettings = new LightingSettings
         {
@@ -262,5 +266,7 @@ public class Builder
             realtimeGI = false
         };
 #endif
+        Lightmapping.ClearLightingDataAsset();
+        Lightmapping.Clear();
     }
 }

--- a/test/Scripts.Integration.Test/Scenes/Test.unity
+++ b/test/Scripts.Integration.Test/Scenes/Test.unity
@@ -24,15 +24,15 @@ RenderSettings:
   m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
-  m_AmbientMode: 0
+  m_AmbientMode: 3
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_SkyboxMaterial: {fileID: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3
   m_HaloTexture: {fileID: 0}
   m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
-  m_DefaultReflectionMode: 0
+  m_DefaultReflectionMode: 1
   m_DefaultReflectionResolution: 128
   m_ReflectionBounces: 1
   m_ReflectionIntensity: 1

--- a/test/Scripts.Integration.Test/Scenes/Test.unity
+++ b/test/Scripts.Integration.Test/Scenes/Test.unity
@@ -24,15 +24,15 @@ RenderSettings:
   m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
-  m_AmbientMode: 3
+  m_AmbientMode: 0
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 0}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3
   m_HaloTexture: {fileID: 0}
   m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
-  m_DefaultReflectionMode: 1
+  m_DefaultReflectionMode: 0
   m_DefaultReflectionResolution: 128
   m_ReflectionBounces: 1
   m_ReflectionIntensity: 1
@@ -51,7 +51,7 @@ LightmapSettings:
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
     m_EnvironmentLightingMode: 0
-    m_EnableBakedLightmaps: 0
+    m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
     serializedVersion: 12
@@ -382,6 +382,98 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1263241751
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1263241754}
+  - component: {fileID: 1263241753}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1263241753
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1263241751}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1263241754
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1263241751}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &1482558919
 GameObject:
   m_ObjectHideFlags: 0

--- a/test/Scripts.Integration.Test/Scenes/Test.unity
+++ b/test/Scripts.Integration.Test/Scenes/Test.unity
@@ -51,7 +51,7 @@ LightmapSettings:
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
     m_EnvironmentLightingMode: 0
-    m_EnableBakedLightmaps: 1
+    m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
     serializedVersion: 12
@@ -382,98 +382,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1263241751
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1263241754}
-  - component: {fileID: 1263241753}
-  m_Layer: 0
-  m_Name: Directional Light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!108 &1263241753
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1263241751}
-  m_Enabled: 1
-  serializedVersion: 10
-  m_Type: 1
-  m_Shape: 0
-  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 1
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 2
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 4
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 6570
-  m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
---- !u!4 &1263241754
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1263241751}
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &1482558919
 GameObject:
   m_ObjectHideFlags: 0

--- a/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
+++ b/test/Scripts.Integration.Test/Scripts/IntegrationTester.cs
@@ -38,7 +38,7 @@ public class IntegrationTester : MonoBehaviour
     // the build red too instead of being swallowed into a log line.
     private void ExerciseConflictingDependencies()
     {
-#if !(UNITY_WEBGL && !UNITY_2022_1_OR_NEWER)
+#if !SENTRY_DISABLE_DEPENDENCY_CONFLICT
         try
         {
             var greeting = DependencyConflictPackage.DependencyConflictPackageClient.SayHiAsync().GetAwaiter().GetResult();

--- a/test/Scripts.Integration.Test/add-dependency-conflict.ps1
+++ b/test/Scripts.Integration.Test/add-dependency-conflict.ps1
@@ -5,7 +5,11 @@ param(
     # `dotnet build test/Scripts.Integration.Test/DependencyConflictPackage`. In CI the
     # DLLs are built in build.yml and downloaded as an artifact, so the caller
     # points this at the downloaded copy.
-    [string] $PackagePath
+    [string] $PackagePath,
+
+    # Skip installing the package and instead define SENTRY_DISABLE_DEPENDENCY_CONFLICT
+    # so IntegrationTester.cs compiles out its call into the package.
+    [switch] $Disable
 )
 
 if (-not $Global:NewProjectPathCache)
@@ -14,6 +18,14 @@ if (-not $Global:NewProjectPathCache)
 }
 
 . $PSScriptRoot/common.ps1
+
+if ($Disable)
+{
+    $cscRspPath = "$(GetNewProjectAssetsPath)/csc.rsp"
+    Write-Log "Defining SENTRY_DISABLE_DEPENDENCY_CONFLICT via '$cscRspPath'..."
+    Add-Content -Path $cscRspPath -Value "-define:SENTRY_DISABLE_DEPENDENCY_CONFLICT"
+    return
+}
 
 # The DependencyConflict package ships plain, UNALIASED System.*/Microsoft.*
 # assemblies at versions that differ from the ones the Sentry SDK ships aliased.

--- a/test/Scripts.Integration.Test/integration-test.ps1
+++ b/test/Scripts.Integration.Test/integration-test.ps1
@@ -46,13 +46,21 @@ If (-not(Test-Path -Path "$(GetNewProjectPath)")) {
     Write-PhaseSuccess "Sentry added"
 
     Write-PhaseHeader "Adding DependencyConflict (alias stress-test)"
-    dotnet build test/Scripts.Integration.Test/DependencyConflictPackage
-    if ($LASTEXITCODE -ne 0)
+    if ($Platform -eq "WebGL" -and $UnityVersion.StartsWith("2021"))
     {
-        Write-Error "Failed to build the DependencyConflict package."
+        ./test/Scripts.Integration.Test/add-dependency-conflict.ps1 -Disable
+        Write-PhaseSuccess "DependencyConflict disabled (WebGL 2021)"
     }
-    ./test/Scripts.Integration.Test/add-dependency-conflict.ps1
-    Write-PhaseSuccess "DependencyConflict added"
+    else
+    {
+        dotnet build test/Scripts.Integration.Test/DependencyConflictPackage
+        if ($LASTEXITCODE -ne 0)
+        {
+            Write-Error "Failed to build the DependencyConflict package."
+        }
+        ./test/Scripts.Integration.Test/add-dependency-conflict.ps1
+        Write-PhaseSuccess "DependencyConflict added"
+    }
 
     Write-PhaseHeader "Configuring Sentry"
     ./test/Scripts.Integration.Test/configure-sentry.ps1 "$UnityPath" -Platform $Platform


### PR DESCRIPTION
There are too many versions and too many platforms to run on every PR. So now we run everything on `main`, always. But on PRs, we limit to oldest + newest supported. 

#skip-changelog