### PR TITLE
chore: validate symbol upload in ci

### DIFF
--- a/.github/workflows/test-build-android.yml
+++ b/.github/workflows/test-build-android.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Export APK - Runtime Initialization
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -UnityVersion "$env:UNITY_VERSION"
 
+      - name: Assert symbols and sources were uploaded (Runtime)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath samples/IntegrationTest/Logs/sentry-symbols-upload.log
+
       - name: Compare build sizes (Runtime)
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform "Android" -UnityVersion "$env:UNITY_VERSION"
 
@@ -134,6 +137,9 @@ jobs:
 
       - name: Export APK - Build-Time Initialization
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform "Android" -UnityVersion "$env:UNITY_VERSION"
+
+      - name: Assert symbols and sources were uploaded (Build-Time)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath samples/IntegrationTest/Logs/sentry-symbols-upload.log
 
       - name: Bundle build & symbol-upload logs with the APK (Build-Time)
         run: |

--- a/.github/workflows/test-build-linux.yml
+++ b/.github/workflows/test-build-linux.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Build with Sentry SDK (Breakpad backend)
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Linux -UnityVersion "$env:UNITY_VERSION"
 
+      - name: Assert symbols and sources were uploaded (Breakpad backend)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath unity.log
+
       - name: Compare build sizes
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform Linux -UnityVersion "$env:UNITY_VERSION"
 
@@ -144,6 +147,9 @@ jobs:
 
       - name: Build with Sentry SDK (Native backend)
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Linux -UnityVersion "$env:UNITY_VERSION"
+
+      - name: Assert symbols and sources were uploaded (Native backend)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath unity.log
 
       - name: Create archive (Native backend)
         run: |

--- a/.github/workflows/test-build-macos.yml
+++ b/.github/workflows/test-build-macos.yml
@@ -104,6 +104,11 @@ jobs:
 
       - name: Build with Sentry SDK (Cocoa backend)
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform MacOS -UnityVersion "$env:UNITY_VERSION"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Assert symbols and sources were uploaded (Cocoa backend)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath unity.log
 
       - name: Compare build sizes
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform MacOS -UnityVersion "$env:UNITY_VERSION"
@@ -139,6 +144,11 @@ jobs:
 
       - name: Build with Sentry SDK (Native backend)
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform MacOS -UnityVersion "$env:UNITY_VERSION"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Assert symbols and sources were uploaded (Native backend)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath unity.log
 
       - name: Create archive (Native backend)
         run: |

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -104,6 +104,11 @@ jobs:
 
       - name: Build with Sentry SDK (Crashpad backend)
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Windows -UnityVersion "$env:UNITY_VERSION"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Assert symbols and sources were uploaded (Crashpad backend)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath unity.log
 
       - name: Compare build sizes
         run: ./test/Scripts.Integration.Test/measure-build-size.ps1 -Path1 "samples/IntegrationTest/Build-NoSentry" -Path2 "samples/IntegrationTest/Build" -Platform Windows -UnityVersion "$env:UNITY_VERSION"
@@ -139,6 +144,11 @@ jobs:
 
       - name: Build with Sentry SDK (Native backend)
         run: ./test/Scripts.Integration.Test/build-project.ps1 -UnityPath "$env:UNITY_PATH" -Platform Windows -UnityVersion "$env:UNITY_VERSION"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Assert symbols and sources were uploaded (Native backend)
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath unity.log
 
       - name: Create archive (Native backend)
         run: |

--- a/.github/workflows/test-compile-ios.yml
+++ b/.github/workflows/test-compile-ios.yml
@@ -76,6 +76,9 @@ jobs:
         run: ./scripts/compile-xcode-project.ps1 -iOSMinVersion "17.0"
         timeout-minutes: 20
 
+      - name: Assert symbols and sources were uploaded
+        run: ./test/Scripts.Integration.Test/assert-symbol-upload.ps1 -LogPath samples/IntegrationTest/Build/sentry-symbols-upload.log
+
       - name: Upload integration-test project on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/test/Scripts.Integration.Test/assert-symbol-upload.ps1
+++ b/test/Scripts.Integration.Test/assert-symbol-upload.ps1
@@ -1,0 +1,72 @@
+# Asserts that the build actually invoked sentry-cli to upload debug symbols AND
+# sources.
+#
+# Symbol/source upload is silent on failure: BuildPostProcess just logs a line and
+# moves on, so a misconfigured (or missing) auth token produces a green build with
+# unsymbolicated events. This turns that into a hard CI failure.
+#
+# We assert on the sentry-cli *invocation* rather than on uploaded-file counts:
+# uploads are deduplicated server-side by debug-id, so a re-run of the same build
+# legitimately reports "Nothing to upload" with zero uploaded files. The invocation
+# carrying '--include-sources' plus a clean terminal state is the reliable signal.
+#
+# Pass the Unity build log (desktop), or the gradle/Xcode sentry-symbols-upload.log.
+
+param(
+    [Parameter(Mandatory = $true)][string] $LogPath
+)
+
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+
+# A missing log is itself a failure: the iOS Xcode phase only writes the log when
+# upload is enabled, and the desktop/gradle paths always produce a log when they run.
+if (-not (Test-Path $LogPath))
+{
+    throw "Symbol-upload assertion failed: log file not found at '$LogPath'. " +
+        "Symbol upload likely did not run - check that SENTRY_AUTH_TOKEN is set on the build step."
+}
+
+$log = Get-Content $LogPath -Raw
+
+# Bail-out markers, in priority order:
+#   - "Automated symbols upload has been disabled" : SentryCliOptions.IsValid (desktop/Android)
+#   - "Sentry symbol upload has been disabled via build setting" : iOS Xcode phase
+# Both mean upload was turned off during the build - almost always a missing token.
+foreach ($disabledMarker in @(
+        "Automated symbols upload has been disabled",
+        "symbol upload has been disabled via build setting"))
+{
+    if ($log -match $disabledMarker)
+    {
+        throw "Symbol-upload assertion failed: '$LogPath' contains '$disabledMarker'. " +
+            "Symbol upload was turned off during the build - check that SENTRY_AUTH_TOKEN is set on the build step."
+    }
+}
+
+# sentry-cli must have been invoked for a debug-files upload that includes sources.
+# '--include-sources' is added only when SentryCliOptions.UploadSources is true, so
+# its presence in the invocation proves both symbol and source upload are configured.
+if ($log -notmatch "debug-files.{0,40}upload")
+{
+    throw "Symbol-upload assertion failed: no 'debug-files upload' sentry-cli invocation found in '$LogPath'."
+}
+
+if ($log -notmatch "--include-sources")
+{
+    throw "Symbol-upload assertion failed: sentry-cli was invoked without '--include-sources' in '$LogPath'. " +
+        "Source upload (UploadSources) is not enabled."
+}
+
+# Confirm the upload reached a terminal success state rather than erroring out.
+# "Uploaded N missing debug information files" on first upload; "Nothing to upload"
+# when the artifacts are already on the server (idempotent re-run / cache hit).
+$uploadSucceeded = $log -match "Uploaded \d+ missing debug information file" `
+    -or $log -match "Nothing to upload"
+if (-not $uploadSucceeded)
+{
+    throw "Symbol-upload assertion failed: sentry-cli upload did not reach a success state in '$LogPath'. " +
+        "Expected 'Uploaded N missing debug information files' or 'Nothing to upload'."
+}
+
+Write-Host "Symbol-upload assertion passed: sentry-cli uploaded debug symbols and sources ('$LogPath')." -ForegroundColor Green


### PR DESCRIPTION
Part of the integration test project cleanup. We want to make sure symbols are actually getting uploaded.

#skip-changelog