### PR TITLE
docs: fix grammar in log message and code comment

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -174,7 +174,7 @@ public class SentryWindow : EditorWindow
         // Make sure the actual config asset exists before validating/saving. Crashes the editor otherwise.
         if (!File.Exists(ScriptableSentryUnityOptions.GetConfigPath(SentryOptionsAssetName)))
         {
-            _logger.LogWarning("Options could not been saved. The configuration asset is missing.");
+            _logger.LogWarning("Options could not be saved. The configuration asset is missing.");
             return;
         }
 

--- a/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
+++ b/src/Sentry.Unity/Integrations/UnityApplicationLoggingIntegration.cs
@@ -120,7 +120,7 @@ internal class UnityApplicationLoggingIntegration : ISdkIntegration
             return;
         }
 
-        // Breadcrumb collection on top of structure log capture must be opted in
+        // Breadcrumb collection on top of structured log capture must be opted in
         if (_options is { EnableLogs: true, AddBreadcrumbsWithStructuredLogs: false })
         {
             return;


### PR DESCRIPTION
## Summary

Fix 2 grammar issues:

- "structure log capture" → "structured log capture"
- "could not been saved" → "could not be saved"

No functional changes — comment and log message text only.