### PR TITLE
fix: gracefully degrade with no native SDK on `Switch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- When targeting Nintendo Switch, the SDK will now properly log the state of the native support instead of silently swallowing any configuration issues ([#2753](https://github.com/getsentry/sentry-unity/pull/2753))
+
 ### Dependencies
 
 - Bump CLI from v3.5.1 to v3.6.0 ([#2741](https://github.com/getsentry/sentry-unity/pull/2741))

--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -45,8 +45,8 @@ void* sentry_options_new(void)
 
 int sentry_init(void* options)
 {
-    /* Return 0 to indicate success */
-    return 0;
+    /* Return -1 to indicate failure to let sentry-unity degrade gracefully */
+    return -1;
 }
 
 void sentry_close(void)


### PR DESCRIPTION
Without this the SDK silently swallows the error, calling into the stub with not even logs telling what's going on.