### PR TITLE
chore: unity bumps trigger ci run on that version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/create-unity-matrix.yml
     with:
       event-name: ${{ github.event_name }}
+      head-ref: ${{ github.head_ref }}
 
   sdk:
     strategy:

--- a/.github/workflows/create-unity-matrix.yml
+++ b/.github/workflows/create-unity-matrix.yml
@@ -7,6 +7,11 @@ on:
         description: 'Event name (pull_request, push, etc.)'
         required: true
         type: string
+      head-ref:
+        description: 'PR head branch name'
+        required: false
+        type: string
+        default: ''
     outputs:
       unity-matrix:
         description: 'Unity version matrix'
@@ -29,10 +34,15 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ inputs.event-name }}
+          HEAD_REF: ${{ inputs.head-ref }}
           PR_UNITY_VERSIONS_VALUE: ${{ env.PR_UNITY_VERSIONS }}
           FULL_UNITY_VERSIONS_VALUE: ${{ env.FULL_UNITY_VERSIONS }}
         run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          # Unity-bump PRs follow the naming convention `chore/unity-<version>`
+          # The bumps only need to run on those specific versions
+          if [[ "$EVENT_NAME" == "pull_request" && "$HEAD_REF" =~ ^chore/unity-([0-9]+\.[0-9]+)\. ]]; then
+            versions="[\"${BASH_REMATCH[1]}\"]"
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
             versions="$PR_UNITY_VERSIONS_VALUE"
           else
             versions="$FULL_UNITY_VERSIONS_VALUE"


### PR DESCRIPTION
When bumping Unity versions we have the problem of having pinned the versions that actually run on a PR vs `main`. But on top of that, when bumping we need to run on that one version only anyway. So here we go.

#skip-changelog