### PR TITLE
chore: added bootstrapping for local development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,21 +3,23 @@
 ## Build
 
 ```sh
-dotnet workload restore
+pwsh bootstrap.ps1
 dotnet build
 ```
 
 - Run standard SDK builds from repository root.
+- Bootstrap initializes submodules, restores workloads, and attempts optional native, CLI, and sample setup.
 - Build outputs and native plugins live in `package-dev/`; do not hand-edit generated assemblies or downloaded native artifacts.
 - See `docs/agent-guides/build.md` for target ownership, Unity selection, and local native builds.
 
-## Prebuilt Native SDKs
+## Native SDKs
 
 ```sh
 dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity
 ```
 
-- Downloads prebuilt native SDKs from CI. Fastest bootstrap path; requires `gh`.
+- Downloads prebuilt native SDKs from CI. Bootstrap attempts this automatically; requires `gh`.
+- `dotnet build` never downloads or builds native SDKs. Use a dedicated target when artifacts are missing.
 
 ## Test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,7 @@ The following tools are **required** before you can build and develop the SDK:
 | Unity with iOS Build Support | The iOS module is required by `Sentry.Unity.Editor.iOS`. Install via Unity Hub. |
 | [.NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) | Version pinned in [`global.json`](global.json) |
 | PowerShell | Install via `dotnet tool install --global PowerShell` |
-| [GitHub CLI](https://github.com/cli/cli/releases) | Required to download prebuilt native SDKs. On macOS: `brew install gh` |
-
-After installing the .NET SDK and PowerShell, restore the required workloads:
-
-```sh
-dotnet workload restore
-```
+| [GitHub CLI](https://github.com/cli/cli/releases) | Recommended for downloading prebuilt native SDKs. On macOS: `brew install gh` |
 
 ### Optional Unity Modules
 
@@ -34,25 +28,25 @@ git clone https://github.com/getsentry/sentry-unity.git
 cd sentry-unity
 ```
 
-### 2. Download Prebuilt Native SDKs
+### 2. Bootstrap
 
-This step downloads prebuilt Android, Cocoa/iOS/macOS, Windows, and Linux native artifacts from the latest successful CI build. This is the fastest way to get started.
+Run the bootstrap script to initialize submodules, restore workloads, download prebuilt native SDKs and Sentry CLI, build the managed SDK, and configure optional sample settings.
 
-```sh
-dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity
+```pwsh
+pwsh bootstrap.ps1
 ```
 
-### 3. Build
+Bootstrap continues after recoverable failures and prints the command needed to retry each step. Set `APPLE_ID` to configure Apple signing and `SENTRY_AUTH_TOKEN` to configure CLI symbol upload before running it.
+
+### 3. Build Changes
 
 ```sh
 dotnet build
 ```
 
-That's it! The SDK is now built and ready for development.
+`dotnet build` compiles the managed SDK only. It does not download dependencies or build native SDKs.
 
-> **Note:** Submodules ([sentry-dotnet](https://github.com/getsentry/sentry-dotnet), [Ben.Demystifier](https://github.com/benaadams/Ben.Demystifier)) are restored automatically. If this fails, run `git submodule update --init --recursive`.
-
-> **Note:** The build also downloads and caches Sentry CLI and the Sentry SDK for Cocoa automatically.
+> **Note:** Bootstrap initializes submodules. To recover from a failed submodule update, run `git submodule update --init --recursive`.
 
 ## Building Native SDKs Locally (Optional)
 
@@ -91,10 +85,9 @@ Required tools:
 
 ### Unit Tests (PlayMode and EditMode)
 
-Run locally with the connected-editor harness. Create `samples/unity-of-bugs-local`
-from a Unity 6.6 (6000.6) or newer project. Install `com.unity.pipeline`, link
-`io.sentry.unity.dev` to this checkout's `package-dev/`, open that project, then
-run the connected-editor test harness:
+Run locally with the connected-editor harness. Open the tracked Unity 6
+`samples/unity-of-bugs-local` project after bootstrap, then run the connected-editor
+test harness:
 
 ```pwsh
 pwsh scripts/run-tests.ps1
@@ -125,7 +118,8 @@ The wrapper locates Unity, builds and packages the SDK, then calls the core inte
 
 - `package-dev/` - Development UPM package
 - `package/` - Release package template (used for publishing)
-- `samples/unity-of-bugs/` - Sample Unity project for local testing
+- `samples/unity-of-bugs/` - Unity 2021 compatibility sample project
+- `samples/unity-of-bugs-local/` - Unity 6 development sample project with shared assets
 - `src/` - Source code
 - `test/` - Tests and integration test scripts
 
@@ -133,7 +127,7 @@ The wrapper locates Unity, builds and packages the SDK, then calls the core inte
 
 1. Open `Sentry.Unity.sln` in your IDE (e.g., Rider, Visual Studio)
 2. Build the solution — artifacts are placed in `package-dev/`
-3. Open `samples/unity-of-bugs` via Unity Hub
+3. Open `samples/unity-of-bugs-local` via Unity Hub
 4. Configure via Tools → Sentry and enter your DSN
 5. Click Play and test your changes
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -77,10 +77,6 @@
     <RemoveDir Directories="$(PlayerBuildPath)" />
   </Target>
 
-  <Target Name="DownloadCLI" BeforeTargets="BeforeBuild" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity' AND !Exists('$(RepoRoot)package-dev/Editor/sentry-cli')">
-    <Exec Command="pwsh &quot;$(RepoRoot)scripts/download-sentry-cli.ps1&quot;"></Exec>
-  </Target>
-
   <!-- Even with a successful build, Unity will error on 'usbmuxd' or log out to std-error which breaks msbuild.
 We need to run a unity build to restore the test packages and for that reason we'll ignore errors here and assume a later step will validate the build is actually working:
   The offending error:

--- a/before.Sentry.Unity.sln.targets
+++ b/before.Sentry.Unity.sln.targets
@@ -1,8 +1,0 @@
-<Project InitialTargets="RestoreSubmodules">
-  <!-- If files within submodules are not found, restore git submodules -->
-  <Target Name="RestoreSubmodules"
-    Condition="!Exists('src/sentry-dotnet/src/Sentry/Sentry.csproj')">
-    <Message Importance="High" Text="Restoring git submodules."></Message>
-    <Exec Command="git submodule update --init --recursive"></Exec>
-  </Target>
-</Project>

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,149 @@
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+$repoRoot = $PSScriptRoot
+$results = @()
+$hardFailure = $false
+
+function Add-Result {
+    param(
+        [Parameter(Mandatory)][ValidateSet("PASS", "WARN", "SKIP", "FAIL")][string] $Status,
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $Detail,
+        [string] $Fix = ""
+    )
+
+    $script:results += [PSCustomObject]@{
+        Status = $Status
+        Name = $Name
+        Detail = $Detail
+        Fix = $Fix
+    }
+
+    if ($Status -eq "FAIL") {
+        $script:hardFailure = $true
+    }
+}
+
+function Invoke-Stage {
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][scriptblock] $Action,
+        [ValidateSet("WARN", "FAIL")][string] $FailureStatus = "FAIL",
+        [string] $Fix = ""
+    )
+
+    try {
+        $global:LASTEXITCODE = 0
+        & $Action
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command exited with code $LASTEXITCODE."
+        }
+        Add-Result -Status "PASS" -Name $Name -Detail "Completed."
+    }
+    catch {
+        Add-Result -Status $FailureStatus -Name $Name -Detail $_.Exception.Message -Fix $Fix
+    }
+}
+
+function Test-Command {
+    param([Parameter(Mandatory)][string] $Name)
+
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+Write-Host "Bootstrapping Sentry Unity from '$repoRoot'"
+
+if (-not (Test-Path (Join-Path $repoRoot ".git"))) {
+    Add-Result -Status "FAIL" -Name "Repository" -Detail "Run this script from a repository checkout." -Fix "Run: pwsh bootstrap.ps1 from the repository root."
+}
+
+$hasGit = Test-Command "git"
+if ($hasGit) {
+    Add-Result -Status "PASS" -Name "Git" -Detail "Found git."
+    Invoke-Stage -Name "Submodules" -Action { git -C $repoRoot submodule update --init --recursive } -Fix "Run: git submodule update --init --recursive"
+}
+else {
+    Add-Result -Status "FAIL" -Name "Git" -Detail "git is not available on PATH." -Fix "Install Git, then rerun: pwsh bootstrap.ps1"
+}
+
+$hasDotnet = Test-Command "dotnet"
+if ($hasDotnet) {
+    Add-Result -Status "PASS" -Name "dotnet" -Detail "Found dotnet."
+    Invoke-Stage -Name "Workloads" -Action { dotnet workload restore } -FailureStatus "WARN" -Fix "Run: dotnet workload restore. On macOS or Linux, elevate it if dotnet reports inadequate permissions."
+}
+else {
+    Add-Result -Status "FAIL" -Name "dotnet" -Detail "dotnet is not available on PATH." -Fix "Install the SDK pinned in global.json, then rerun: pwsh bootstrap.ps1"
+}
+
+if ($hasDotnet -and (Test-Command "gh")) {
+    Invoke-Stage -Name "Prebuilt native SDKs" -Action { dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity } -FailureStatus "WARN" -Fix "Authenticate with 'gh auth login' and rerun, or build a platform SDK with: dotnet msbuild /t:Build<Platform>SDK src/Sentry.Unity"
+}
+elseif (-not (Test-Command "gh")) {
+    Add-Result -Status "WARN" -Name "Prebuilt native SDKs" -Detail "GitHub CLI is not available." -Fix "Install gh and run 'gh auth login', then rerun: pwsh bootstrap.ps1"
+}
+else {
+    Add-Result -Status "WARN" -Name "Prebuilt native SDKs" -Detail "dotnet is unavailable." -Fix "Install the SDK pinned in global.json, then rerun: pwsh bootstrap.ps1"
+}
+
+$cliDirectory = Join-Path $repoRoot "package-dev/Editor/sentry-cli"
+if (Test-Path $cliDirectory) {
+    Add-Result -Status "PASS" -Name "Sentry CLI" -Detail "Already downloaded."
+}
+elseif (Test-Path (Join-Path $repoRoot "modules/sentry-cli.properties")) {
+    Invoke-Stage -Name "Sentry CLI" -Action { & (Join-Path $repoRoot "scripts/download-sentry-cli.ps1") } -FailureStatus "WARN" -Fix "Check network access, then rerun: pwsh bootstrap.ps1"
+}
+else {
+    Add-Result -Status "WARN" -Name "Sentry CLI" -Detail "sentry-cli submodule files are unavailable." -Fix "Run: git submodule update --init --recursive, then rerun: pwsh bootstrap.ps1"
+}
+
+if ($hasDotnet) {
+    Invoke-Stage -Name "Managed SDK build" -Action { dotnet build } -Fix "Fix the reported build error, then rerun: dotnet build"
+}
+else {
+    Add-Result -Status "FAIL" -Name "Managed SDK build" -Detail "dotnet is unavailable." -Fix "Install the SDK pinned in global.json, then run: dotnet build"
+}
+
+$appleSettings = Join-Path $repoRoot "samples/unity-of-bugs-local/ProjectSettings/ProjectSettings.asset"
+if (-not $Env:APPLE_ID) {
+    Add-Result -Status "SKIP" -Name "Apple Developer Team ID" -Detail "APPLE_ID is not set." -Fix "Set APPLE_ID, then rerun: pwsh bootstrap.ps1"
+}
+elseif (-not (Test-Path $appleSettings)) {
+    Add-Result -Status "WARN" -Name "Apple Developer Team ID" -Detail "Local sample project settings are unavailable." -Fix "Restore samples/unity-of-bugs-local, then rerun: pwsh bootstrap.ps1"
+}
+else {
+    Invoke-Stage -Name "Apple Developer Team ID" -Action { & (Join-Path $repoRoot "scripts/samples-setup-apple-id.ps1") } -FailureStatus "WARN" -Fix "Confirm APPLE_ID is a valid Apple Developer Team ID, then rerun: pwsh bootstrap.ps1"
+}
+
+$sentryAssemblyMeta = Join-Path $repoRoot "package-dev/Runtime/Sentry.Unity.dll.meta"
+if (-not $Env:SENTRY_AUTH_TOKEN) {
+    Add-Result -Status "SKIP" -Name "Sentry CLI auth" -Detail "SENTRY_AUTH_TOKEN is not set." -Fix "Set SENTRY_AUTH_TOKEN, then rerun: pwsh bootstrap.ps1"
+}
+elseif (-not (Test-Path $sentryAssemblyMeta)) {
+    Add-Result -Status "WARN" -Name "Sentry CLI auth" -Detail "Managed SDK build output is unavailable." -Fix "Run: dotnet build, then rerun: pwsh bootstrap.ps1"
+}
+else {
+    Invoke-Stage -Name "Sentry CLI auth" -Action { & (Join-Path $repoRoot "scripts/samples-setup-cli-options.ps1") } -FailureStatus "WARN" -Fix "Confirm SENTRY_AUTH_TOKEN is valid, then rerun: pwsh bootstrap.ps1"
+}
+
+$localAssets = Join-Path $repoRoot "samples/unity-of-bugs-local/Assets"
+if ((Test-Path $localAssets) -and (Get-Item $localAssets).LinkType -eq "SymbolicLink") {
+    Add-Result -Status "PASS" -Name "Local sample assets" -Detail "Assets symlink is available."
+}
+else {
+    Add-Result -Status "WARN" -Name "Local sample assets" -Detail "Assets symlink is unavailable." -Fix "Enable Git symlink support and restore samples/unity-of-bugs-local/Assets."
+}
+
+Write-Host ""
+Write-Host "Bootstrap summary"
+foreach ($result in $results) {
+    Write-Host "[$($result.Status)] $($result.Name): $($result.Detail)"
+    if ($result.Fix) {
+        Write-Host "       $($result.Fix)"
+    }
+}
+
+if ($hardFailure) {
+    exit 1
+}

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -87,11 +87,7 @@ else {
     Add-Result -Status "WARN" -Name "Prebuilt native SDKs" -Detail "dotnet is unavailable." -Fix "Install the SDK pinned in global.json, then rerun: pwsh bootstrap.ps1"
 }
 
-$cliDirectory = Join-Path $repoRoot "package-dev/Editor/sentry-cli"
-if (Test-Path $cliDirectory) {
-    Add-Result -Status "PASS" -Name "Sentry CLI" -Detail "Already downloaded."
-}
-elseif (Test-Path (Join-Path $repoRoot "modules/sentry-cli.properties")) {
+if (Test-Path (Join-Path $repoRoot "modules/sentry-cli.properties")) {
     Invoke-Stage -Name "Sentry CLI" -Action { & (Join-Path $repoRoot "scripts/download-sentry-cli.ps1") } -FailureStatus "WARN" -Fix "Check network access, then rerun: pwsh bootstrap.ps1"
 }
 else {
@@ -105,12 +101,16 @@ else {
     Add-Result -Status "FAIL" -Name "Managed SDK build" -Detail "dotnet is unavailable." -Fix "Install the SDK pinned in global.json, then run: dotnet build"
 }
 
-$appleSettings = Join-Path $repoRoot "samples/unity-of-bugs-local/ProjectSettings/ProjectSettings.asset"
+$appleSettings = @(
+    (Join-Path $repoRoot "samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset"),
+    (Join-Path $repoRoot "samples/unity-of-bugs-local/ProjectSettings/ProjectSettings.asset")
+)
+$missingAppleSettings = @($appleSettings | Where-Object { -not (Test-Path $_) })
 if (-not $Env:APPLE_ID) {
     Add-Result -Status "SKIP" -Name "Apple Developer Team ID" -Detail "APPLE_ID is not set." -Fix "Set APPLE_ID, then rerun: pwsh bootstrap.ps1"
 }
-elseif (-not (Test-Path $appleSettings)) {
-    Add-Result -Status "WARN" -Name "Apple Developer Team ID" -Detail "Local sample project settings are unavailable." -Fix "Restore samples/unity-of-bugs-local, then rerun: pwsh bootstrap.ps1"
+elseif ($missingAppleSettings.Count -gt 0) {
+    Add-Result -Status "WARN" -Name "Apple Developer Team ID" -Detail "Sample project settings are unavailable: $($missingAppleSettings -join ', ')." -Fix "Restore the sample projects, then rerun: pwsh bootstrap.ps1"
 }
 else {
     Invoke-Stage -Name "Apple Developer Team ID" -Action { & (Join-Path $repoRoot "scripts/samples-setup-apple-id.ps1") } -FailureStatus "WARN" -Fix "Confirm APPLE_ID is a valid Apple Developer Team ID, then rerun: pwsh bootstrap.ps1"

--- a/build/local-dev.targets
+++ b/build/local-dev.targets
@@ -64,25 +64,4 @@
     <Exec Command="pwsh &quot;$(RepoRoot)scripts/download-native-sdks.ps1&quot; -RepoRoot &quot;$(RepoRoot)&quot;" />
   </Target>
 
-  <!--
-    When SENTRY_AUTH_TOKEN is set, create the SentryCliOptions.asset for the sample project.
-    Runs automatically after DownloadNativeSDKs.
-
-        dotnet msbuild /t:SamplesSetupCliOptions src/Sentry.Unity
-  -->
-  <Target Name="SamplesSetupCliOptions" AfterTargets="DownloadNativeSDKs" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity' AND '$(SENTRY_AUTH_TOKEN)' != ''">
-    <Message Importance="High" Text="Found environment variable 'SENTRY_AUTH_TOKEN'. Creating Sentry CLI options for sample project." />
-    <Exec Command="pwsh &quot;$(RepoRoot)scripts/samples-setup-cli-options.ps1&quot;" />
-  </Target>
-
-  <!--
-    When APPLE_ID is set, modify ProjectSettings.asset for the sample project.
-    Runs automatically after SamplesSetupCliOptions.
-
-        dotnet msbuild /t:SamplesSetupAppleId src/Sentry.Unity
-  -->
-  <Target Name="SamplesSetupAppleId" AfterTargets="SamplesSetupCliOptions" Condition="'$(MSBuildProjectName)' == 'Sentry.Unity' AND '$(APPLE_ID)' != ''">
-    <Message Importance="High" Text="Found environment variable 'APPLE_ID'. Setting Apple ID for sample project." />
-    <Exec Command="pwsh &quot;$(RepoRoot)scripts/samples-setup-apple-id.ps1&quot;" />
-  </Target>
 </Project>

--- a/build/native-sdks.targets
+++ b/build/native-sdks.targets
@@ -44,15 +44,6 @@
     <Error Condition="!Exists('$(SentrymacOSArtifactsDestination)Sentry.dylib') Or !Exists('$(SentrymacOSArtifactsDestination)Sentry.dylib.dSYM')" Text="Failed to set up the macOS SDK." />
   </Target>
 
-  <!-- Hooks into 'dotnet build' so a missing iOS/macOS plugin auto-triggers BuildCocoaSDK. -->
-  <Target Name="EnsureCocoaSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And !$([MSBuild]::IsOSPlatform('Windows'))
-            And (!Exists('$(SentryiOSArtifactsDestination)') Or !Exists('$(SentrymacOSArtifactsDestination)Sentry.dylib'))">
-    <CallTarget Targets="BuildCocoaSDK" />
-  </Target>
-
   <!--
     Build the Sentry Native SDK for Linux:
         dotnet msbuild /t:BuildLinuxSDK src/Sentry.Unity
@@ -80,15 +71,6 @@
     <Exec WorkingDirectory="$(SentryLinuxArtifactsDestination)" Command="objcopy --add-gnu-debuglink=libsentry.dbg.so libsentry.so" />
 
     <Error Condition="!Exists('$(SentryLinuxArtifactsDestination)libsentry.so')" Text="Failed to set up the Linux SDK." />
-  </Target>
-
-  <!-- Hooks into 'dotnet build' so a missing Linux plugin auto-triggers BuildLinuxSDK. -->
-  <Target Name="EnsureLinuxSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And $([MSBuild]::IsOSPlatform('Linux'))
-            And !Exists('$(SentryLinuxArtifactsDestination)libsentry.so')">
-    <CallTarget Targets="BuildLinuxSDK" />
   </Target>
 
   <!--
@@ -131,15 +113,6 @@
     <Error Condition="!Exists('$(SentryLinuxNativeArtifactsDestination)sentry-crash')" Text="Failed to set up the Linux Native SDK crash daemon." />
   </Target>
 
-  <!-- Hooks into 'dotnet build' so a missing Linux Native plugin auto-triggers BuildLinuxNativeSDK. -->
-  <Target Name="EnsureLinuxNativeSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And $([MSBuild]::IsOSPlatform('Linux'))
-            And !Exists('$(SentryLinuxNativeArtifactsDestination)libsentry.so')">
-    <CallTarget Targets="BuildLinuxNativeSDK" />
-  </Target>
-
   <!--
     Build the Sentry Native SDK for Windows:
         dotnet msbuild /t:BuildWindowsSDK src/Sentry.Unity
@@ -176,15 +149,6 @@
     <Copy SourceFiles="@(NativeSdkArtifacts)" DestinationFolder="$(SentryWindowsArtifactsDestination)" />
 
     <Error Condition="!Exists('$(SentryWindowsArtifactsDestination)sentry.dll')" Text="Failed to set up the Windows SDK." />
-  </Target>
-
-  <!-- Hooks into 'dotnet build' so a missing Windows plugin auto-triggers BuildWindowsSDK. -->
-  <Target Name="EnsureWindowsSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And $([MSBuild]::IsOSPlatform('Windows'))
-            And !Exists('$(SentryWindowsArtifactsDestination)sentry.dll')">
-    <CallTarget Targets="BuildWindowsSDK" />
   </Target>
 
   <!--
@@ -229,15 +193,6 @@
     <Error Condition="!Exists('$(SentryWindowsNativeArtifactsDestination)sentry.dll')" Text="Failed to set up the Windows Native SDK." />
   </Target>
 
-  <!-- Hooks into 'dotnet build' so a missing Windows Native plugin auto-triggers BuildWindowsNativeSDK. -->
-  <Target Name="EnsureWindowsNativeSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And $([MSBuild]::IsOSPlatform('Windows'))
-            And !Exists('$(SentryWindowsNativeArtifactsDestination)sentry.dll')">
-    <CallTarget Targets="BuildWindowsNativeSDK" />
-  </Target>
-
   <!--
     Build the Sentry Native SDK for macOS:
         dotnet msbuild /t:BuildMacOSNativeSDK src/Sentry.Unity
@@ -278,15 +233,6 @@
     <Exec Command="strip -x $(SentryMacOSNativeArtifactsDestination)sentry-crash" />
 
     <Error Condition="!Exists('$(SentryMacOSNativeArtifactsDestination)libsentry.dylib')" Text="Failed to set up the macOS Native SDK." />
-  </Target>
-
-  <!-- Hooks into 'dotnet build' so a missing macOS Native plugin auto-triggers BuildMacOSNativeSDK. -->
-  <Target Name="EnsureMacOSNativeSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And $([MSBuild]::IsOSPlatform('OSX'))
-            And !Exists('$(SentryMacOSNativeArtifactsDestination)libsentry.dylib')">
-    <CallTarget Targets="BuildMacOSNativeSDK" />
   </Target>
 
   <!--
@@ -371,14 +317,4 @@
     <Error Condition="!Exists('$(SentryAndroidArtifactsDestination)')" Text="Failed to set up the Android SDK." />
   </Target>
 
-  <!-- Hooks into 'dotnet build' so a missing/incomplete Android plugin auto-triggers BuildAndroidSDK.
-       BuildAndroidSDK copies exactly 4 artifacts into $(SentryAndroidArtifactsDestination); any
-       other count means the previous run was interrupted and we should rebuild. -->
-  <Target Name="EnsureAndroidSDK"
-          BeforeTargets="BeforeBuild"
-          Condition="'$(MSBuildProjectName)' == 'Sentry.Unity'
-            And (!Exists('$(SentryAndroidArtifactsDestination)')
-              Or $([System.IO.Directory]::GetFiles('$(SentryAndroidArtifactsDestination)').Length) != 4)">
-    <CallTarget Targets="BuildAndroidSDK" />
-  </Target>
 </Project>

--- a/docs/agent-guides/build.md
+++ b/docs/agent-guides/build.md
@@ -3,7 +3,7 @@
 ## Toolchain
 
 - Use .NET SDK `10.0.302`; `global.json` disables roll-forward.
-- Run `dotnet workload restore` after cloning or changing SDK workloads.
+- Run `pwsh bootstrap.ps1` after cloning. It restores workloads and attempts optional local setup.
 - Unity is resolved from `samples/unity-of-bugs/ProjectSettings/ProjectVersion.txt`; set `UNITY_VERSION` to override it.
 - `FindUnity` also honors `HubInstallDir` and `HubDefaultEditor` MSBuild properties.
 
@@ -18,17 +18,28 @@ dotnet build
 - Runtime assemblies are written to `package-dev/Runtime`.
 - Editor assemblies are written to `package-dev/Editor`.
 - `netstandard2.0` is the default runtime target; Unity `2022.*` and `6000.*` use `netstandard2.1`.
+- Does not download Sentry CLI or build native SDKs.
 
-## Native SDK Bootstrap
+## Bootstrap
 
-Fastest bootstrap path; requires `gh`:
+Run from repository root:
+
+```pwsh
+pwsh bootstrap.ps1
+```
+
+- Initializes submodules, restores workloads, downloads missing native artifacts and Sentry CLI, builds the managed SDK, and configures samples when matching environment variables are available.
+- Continues past recoverable failures and prints remediation for each stage.
+- `APPLE_ID` configures both sample projects' Apple Developer Team ID. `SENTRY_AUTH_TOKEN` configures shared Sentry CLI options.
+
+## Prebuilt Native SDKs
 
 ```sh
 dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity
 ```
 
 - Downloads missing artifacts from successful GitHub Actions CI runs, preferring `main` then current branch.
-- Missing plugins trigger host-specific local native builds during `dotnet build`; download is recommended, not required.
+- Refuses to overwrite tracked changes under `package-dev/Plugins/`.
 - Do not edit downloaded plugin artifacts in `package-dev/Plugins/`.
 
 ## Native Targets

--- a/scripts/download-native-sdks.ps1
+++ b/scripts/download-native-sdks.ps1
@@ -148,6 +148,12 @@ function Try-DownloadSDK {
     return $true
 }
 
+function Test-TrackedPluginChanges {
+    $unstaged = git -C $RepoRoot diff --name-only -- package-dev/Plugins
+    $staged = git -C $RepoRoot diff --cached --name-only -- package-dev/Plugins
+    return [bool]($unstaged -or $staged)
+}
+
 # Main logic
 Write-Host "Checking native SDK status..." -ForegroundColor Cyan
 Write-Host ""
@@ -169,6 +175,10 @@ Write-Host ""
 if ($sdksToDownload.Count -eq 0) {
     Write-Host "All native SDKs are already present." -ForegroundColor Green
     exit 0
+}
+
+if (Test-TrackedPluginChanges) {
+    throw "package-dev/Plugins has tracked changes. Commit, stash, or revert them before downloading native SDKs."
 }
 
 # Primary source is main's latest successful run. For artifacts not yet on
@@ -200,16 +210,6 @@ if ($failed.Count -gt 0) {
     $names = $failed -join ', '
     Write-Error "Could not download these SDK artifacts: $names. Push the branch so CI publishes the artifact, or build locally with Build<Name>SDK."
     exit 1
-}
-
-Write-Host ""
-Write-Host "Restoring package-dev/Plugins to latest git commit..." -ForegroundColor Yellow
-Push-Location $RepoRoot
-try {
-    git restore package-dev/Plugins
-}
-finally {
-    Pop-Location
 }
 
 Write-Host ""

--- a/scripts/download-sentry-cli.ps1
+++ b/scripts/download-sentry-cli.ps1
@@ -5,10 +5,19 @@ $conf = Get-Content "$PSScriptRoot/../modules/sentry-cli.properties" -Raw | Conv
 $platforms = @('Darwin-universal', 'Linux-x86_64', 'Windows-x86_64')
 $targetDir = "$PSScriptRoot/../package-dev/Editor/sentry-cli"
 $baseUrl = "$($conf.repo)/releases/download/$($conf.version)/sentry-cli-"
+$targetFiles = $platforms | ForEach-Object {
+    $name = if ($_.StartsWith('Windows')) { "$_.exe" } else { $_ }
+    Join-Path $targetDir "sentry-cli-$name"
+}
 
 if (Test-Path $targetDir) {
-    Write-Host "Sentry CLI already downloaded at $targetDir"
-    return
+    $missingTargetFiles = @($targetFiles | Where-Object { -not (Test-Path $_) })
+    if ($missingTargetFiles.Count -eq 0) {
+        Write-Host "Sentry CLI already downloaded at $targetDir"
+        return
+    }
+
+    Remove-Item -Recurse -Force $targetDir
 }
 
 New-Item -Path $targetDir -ItemType Directory > $null

--- a/scripts/download-sentry-cli.ps1
+++ b/scripts/download-sentry-cli.ps1
@@ -1,14 +1,16 @@
 Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
 
 $conf = Get-Content "$PSScriptRoot/../modules/sentry-cli.properties" -Raw | ConvertFrom-StringData
 $platforms = @('Darwin-universal', 'Linux-x86_64', 'Windows-x86_64')
 $targetDir = "$PSScriptRoot/../package-dev/Editor/sentry-cli"
 $baseUrl = "$($conf.repo)/releases/download/$($conf.version)/sentry-cli-"
 
-if (Test-Path $targetDir)
-{
-    Remove-Item -r $targetDir
+if (Test-Path $targetDir) {
+    Write-Host "Sentry CLI already downloaded at $targetDir"
+    return
 }
+
 New-Item -Path $targetDir -ItemType Directory > $null
 
 foreach ($name in $platforms)

--- a/scripts/samples-setup-apple-id.ps1
+++ b/scripts/samples-setup-apple-id.ps1
@@ -5,27 +5,27 @@ Write-Output "Setting up Apple Developer Team ID from environment variable"
 
 if (-not $Env:APPLE_ID)
 {
-    Write-Error "APPLE_ID environment variable is not set. Skipping..."
-    exit
+    throw "APPLE_ID environment variable is not set."
 }
 
 $appleId = $Env:APPLE_ID
-$projectSettingsPath = "$PSScriptRoot/../samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset"
-if (-not (Test-Path -Path $projectSettingsPath)) 
-{
-    Write-Error "ProjectSettings.asset not found at path: $projectSettingsPath"
-    exit
-}
+$projectSettingsPaths = @(
+    "$PSScriptRoot/../samples/unity-of-bugs/ProjectSettings/ProjectSettings.asset",
+    "$PSScriptRoot/../samples/unity-of-bugs-local/ProjectSettings/ProjectSettings.asset"
+)
 
-$content = Get-Content -Path $projectSettingsPath -Raw
-if ($content -match '(\s*)appleDeveloperTeamID:.*') 
-{
-    $updatedContent = $content -replace '(\s*)appleDeveloperTeamID:.*', "`${1}appleDeveloperTeamID: $appleId"
-    Set-Content -Path $projectSettingsPath -Value $updatedContent
-    Write-Output "Successfully updated appleDeveloperTeamID in ProjectSettings.asset"
-} 
-else 
-{
-    Write-Error "Could not find appleDeveloperTeamID property in ProjectSettings.asset"
-    exit
+foreach ($projectSettingsPath in $projectSettingsPaths) {
+    if (-not (Test-Path -Path $projectSettingsPath)) {
+        throw "ProjectSettings.asset not found at path: $projectSettingsPath"
+    }
+
+    $content = Get-Content -Path $projectSettingsPath -Raw
+    if ($content -match '(\s*)appleDeveloperTeamID:.*') {
+        $updatedContent = $content -replace '(\s*)appleDeveloperTeamID:.*', "`${1}appleDeveloperTeamID: $appleId"
+        Set-Content -Path $projectSettingsPath -Value $updatedContent
+        Write-Output "Successfully updated appleDeveloperTeamID in '$projectSettingsPath'"
+    }
+    else {
+        throw "Could not find appleDeveloperTeamID property in '$projectSettingsPath'"
+    }
 }


### PR DESCRIPTION
Added a new `bootstrap.ps1` that takes care of bootstrapping the local development environment.

- Initializes submodules
- Restores workload
- Downloads prebuilt native SDKs
- Downloads sentry-cli
- Builds the managed part of sentry-unity via `dotnet build`
- Reads the auth token from the environment and sets it on the cli options
- Reads the Apple developer ID from the environment and sets it on the project settings

There is no new functionality, the SDK did all of this already, just mingled up in MSBuild targets. It's now easier to reason about what does what, i.e. `dotnet build` no longer downloads sentry-cli if it's not there, because why should it.

#skip-changelog