### PR TITLE
chore: automatic test run resolving

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,6 @@ pwsh bootstrap.ps1
 dotnet build
 ```
 
-- Run standard SDK builds from repository root.
-- Bootstrap initializes submodules, restores workloads, and attempts optional native, CLI, and sample setup.
 - Build outputs and native plugins live in `package-dev/`; do not hand-edit generated assemblies or downloaded native artifacts.
 - See `docs/agent-guides/build.md` for target ownership, Unity selection, and local native builds.
 
@@ -18,17 +16,20 @@ dotnet build
 dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity
 ```
 
-- Downloads prebuilt native SDKs from CI. Bootstrap attempts this automatically; requires `gh`.
-- `dotnet build` never downloads or builds native SDKs. Use a dedicated target when artifacts are missing.
+- Requires `gh`. Use when native artifacts are missing; `dotnet build` does not download them.
 
 ## Test
 
-```sh
-dotnet msbuild /t:UnityPlayModeTest test/Sentry.Unity.Tests
-dotnet msbuild /t:UnityEditModeTest test/Sentry.Unity.Editor.Tests
+```pwsh
+pwsh scripts/run-tests.ps1
+pwsh scripts/run-tests.ps1 -Mode PlayMode -Filter "MyTest"
+pwsh scripts/run-tests.ps1 -Mode EditMode
 ```
 
-- See `docs/agent-guides/testing.md` before connected-editor or integration tests.
+- The harness targets `samples/unity-of-bugs-local`, using Pipeline for an open Editor or `unity test` headlessly when none is running.
+- Make `unity` available on `PATH`. To reuse an Editor, open the sample in Unity 6.6+ with `com.unity.pipeline` and leave play mode stopped.
+- Run `dotnet build` before tests after SDK changes. `Filter` narrows selected tests.
+- Use batch MSBuild test targets only when Unity CLI is unavailable. See `docs/agent-guides/testing.md` for commands and integration tests.
 
 ## Area Guides
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ The following tools are **required** before you can build and develop the SDK:
 | [.NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) | Version pinned in [`global.json`](global.json) |
 | PowerShell | Install via `dotnet tool install --global PowerShell` |
 | [GitHub CLI](https://github.com/cli/cli/releases) | Recommended for downloading prebuilt native SDKs. On macOS: `brew install gh` |
+| Unity CLI | Required for the Unity test harness; add `unity` to `PATH` |
 
 ### Optional Unity Modules
 
@@ -85,19 +86,17 @@ Required tools:
 
 ### Unit Tests (PlayMode and EditMode)
 
-Run locally with the connected-editor harness. Open the tracked Unity 6
-`samples/unity-of-bugs-local` project after bootstrap, then run the connected-editor
-test harness:
+The harness uses Pipeline when `samples/unity-of-bugs-local` is open, otherwise it runs
+tests headlessly through Unity CLI. Add `unity` to `PATH`; to reuse an Editor, open the
+sample in Unity 6.6+ with `com.unity.pipeline` and leave play mode stopped.
 
 ```pwsh
 pwsh scripts/run-tests.ps1
+pwsh scripts/run-tests.ps1 -Mode PlayMode -Filter "MyTest"
+pwsh scripts/run-tests.ps1 -Mode EditMode
 ```
 
-It builds the SDK, waits for Unity to compile, runs EditMode and PlayMode tests
-separately, and exits with code `1` for failed, inconclusive, or empty runs.
-Use `-Mode EditMode`, `-Mode PlayMode`, or `-Filter "TestClassName"` to narrow
-the run. The command exits with `0` when all selected tests pass and `1`
-otherwise.
+Run `dotnet build` before tests after SDK changes. `Filter` narrows selected tests.
 
 ### Integration Tests
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -77,10 +77,26 @@ else {
     Add-Result -Status "FAIL" -Name "dotnet" -Detail "dotnet is not available on PATH." -Fix "Install the SDK pinned in global.json, then rerun: pwsh bootstrap.ps1"
 }
 
-if ($hasDotnet -and (Test-Command "gh")) {
+$hasGh = Test-Command "gh"
+if ($hasGh) {
+    Add-Result -Status "PASS" -Name "GitHub CLI" -Detail "Found gh."
+}
+else {
+    Add-Result -Status "WARN" -Name "GitHub CLI" -Detail "gh is not available on PATH." -Fix "Install gh and run 'gh auth login' to download prebuilt native SDKs."
+}
+
+$hasUnityCli = Test-Command "unity"
+if ($hasUnityCli) {
+    Add-Result -Status "PASS" -Name "Unity CLI" -Detail "Found unity."
+}
+else {
+    Add-Result -Status "WARN" -Name "Unity CLI" -Detail "unity is not available on PATH." -Fix "Install Unity CLI and add it to PATH before running: pwsh scripts/run-tests.ps1"
+}
+
+if ($hasDotnet -and $hasGh) {
     Invoke-Stage -Name "Prebuilt native SDKs" -Action { dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity } -FailureStatus "WARN" -Fix "Authenticate with 'gh auth login' and rerun, or build a platform SDK with: dotnet msbuild /t:Build<Platform>SDK src/Sentry.Unity"
 }
-elseif (-not (Test-Command "gh")) {
+elseif (-not $hasGh) {
     Add-Result -Status "WARN" -Name "Prebuilt native SDKs" -Detail "GitHub CLI is not available." -Fix "Install gh and run 'gh auth login', then rerun: pwsh bootstrap.ps1"
 }
 else {

--- a/docs/agent-guides/build.md
+++ b/docs/agent-guides/build.md
@@ -28,7 +28,7 @@ Run from repository root:
 pwsh bootstrap.ps1
 ```
 
-- Initializes submodules, restores workloads, downloads missing native artifacts and Sentry CLI, builds the managed SDK, and configures samples when matching environment variables are available.
+- Checks for Git, .NET, GitHub CLI, and Unity CLI before initializing submodules, restoring workloads, downloading missing native artifacts and Sentry CLI, building the managed SDK, and configuring samples when matching environment variables are available.
 - Continues past recoverable failures and prints remediation for each stage.
 - `APPLE_ID` configures both sample projects' Apple Developer Team ID. `SENTRY_AUTH_TOKEN` configures shared Sentry CLI options.
 

--- a/docs/agent-guides/testing.md
+++ b/docs/agent-guides/testing.md
@@ -1,39 +1,27 @@
 # Testing
 
+## Unity CLI Harness
+
+```pwsh
+pwsh scripts/run-tests.ps1
+pwsh scripts/run-tests.ps1 -Mode EditMode
+pwsh scripts/run-tests.ps1 -Mode PlayMode -Filter "Throttler"
+```
+
+- Targets `samples/unity-of-bugs-local`. It uses Pipeline for an open Editor or `unity test` headlessly when no Editor is running.
+- Make `unity` available on `PATH`. To reuse an Editor, open the sample in Unity 6.6+ with `com.unity.pipeline` and leave play mode stopped.
+- Run `dotnet build` before tests after SDK changes. `Filter` narrows selected tests.
+
 ## Batch Unity Tests
 
-Run from repository root with a discoverable Unity installation:
+Use only when Unity CLI harness is unavailable:
 
 ```sh
 dotnet msbuild /t:UnityPlayModeTest test/Sentry.Unity.Tests
 dotnet msbuild /t:UnityEditModeTest test/Sentry.Unity.Editor.Tests
 ```
 
-- PlayMode target applies only to `Sentry.Unity.Tests`.
-- EditMode target applies only to `Sentry.Unity.Editor.Tests`.
-- Results are written to `artifacts/test/playmode/results.xml` or `artifacts/test/editmode/results.xml`; the target validates the result XML.
-
-## Connected Editor Harness
-
-```pwsh
-pwsh scripts/run-tests.ps1
-pwsh scripts/run-tests.ps1 -Mode EditMode
-pwsh scripts/run-tests.ps1 -Mode PlayMode -Filter "Throttler"
-pwsh scripts/run-tests.ps1 -SkipBuild -Filter "MyTest"
-```
-
-Before running:
-
-- Create and open `samples/unity-of-bugs-local` in Unity `6000.6` or newer.
-- Install `com.unity.pipeline`.
-- Add `io.sentry.unity.dev` as a local `file:` dependency pointing to this checkout's `package-dev`.
-- Stop the Unity editor, connect Pipeline, and make `unity` available on `PATH`.
-
-The harness builds by default, then recompiles and runs selected Editor/PlayMode tests. It fails for failed, inconclusive, empty, malformed, timed-out, or command-error results.
-
 ## Integration Tests
-
-Use the local wrapper:
 
 ```pwsh
 pwsh ./test/Scripts.Integration.Test/dev-integration-test.ps1 `
@@ -41,11 +29,6 @@ pwsh ./test/Scripts.Integration.Test/dev-integration-test.ps1 `
   -Platform "MacOS" `
   -Repack
 ```
-
-- The wrapper locates Unity, builds, optionally repacks/extracts the package, then invokes the core script.
-- `-Clean`, `-Recreate`, `-Rebuild`, `-SkipTests`, and `-NativeSDKPath` are available.
-- `integration-test.ps1` is lower-level: it requires `-UnityPath`, `-UnityVersion`, `-Platform`, and `-PackagePath`.
-- Automated Pester execution covers desktop, Android, iOS, WebGL, and Xbox. Switch and PS5 are build-only.
 
 ## Relevant Tests
 

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -1,29 +1,17 @@
 <#
 .SYNOPSIS
-    Builds and runs Unity tests through an open Unity Pipeline Editor.
+    Runs Unity tests through a connected Editor or Unity CLI.
 
 .DESCRIPTION
-    This local test harness connects to the Unity Editor already running the
-    target project. It validates the test result payload and exits with code 1
-    for failed, inconclusive, empty, or malformed test runs.
-    Filter accepts literal, case-insensitive partial test names. Unity CLI does
-    not support regular expression filters.
-
-.EXAMPLE
-    pwsh scripts/run-tests.ps1
-
-.EXAMPLE
-    pwsh scripts/run-tests.ps1 -Mode EditMode -Filter "EditorModeTests"
-
-.EXAMPLE
-    pwsh scripts/run-tests.ps1 -Mode PlayMode -SkipBuild
+    This local test harness uses an open Unity Pipeline Editor when available.
+    When the target project has no running Editor, Unity CLI launches the test
+    runner headlessly instead.
 #>
 
 param(
     [ValidateSet("All", "EditMode", "PlayMode")]
     [string] $Mode = "All",
-    [string] $Filter,
-    [switch] $SkipBuild
+    [string] $Filter
 )
 
 Set-StrictMode -Version latest
@@ -31,255 +19,10 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $testTimeout = 300
+$headlessResultsDirectory = Join-Path $repoRoot "artifacts/test/unity-cli"
 
-function Limit-Text([object] $Value) {
-    $text = [string] $Value
-    if ($text.Length -le 2000) {
-        return $text
-    }
-
-    return "$($text.Substring(0, 2000))`n... truncated"
-}
-
-function Test-UnityProject([string] $Path) {
-    $projectVersionFile = Join-Path $Path "ProjectSettings/ProjectVersion.txt"
-    if (-not (Test-Path $projectVersionFile -PathType Leaf)) {
-        throw "Unity project at $Path has no ProjectSettings/ProjectVersion.txt."
-    }
-
-    $projectVersionMatch = [regex]::Match((Get-Content $projectVersionFile -Raw), "m_EditorVersion:\s*(.+)")
-    if (-not $projectVersionMatch.Success) {
-        throw "Could not parse Unity version from $projectVersionFile."
-    }
-
-    $projectVersion = $projectVersionMatch.Groups[1].Value.Trim()
-    $versionMatch = [regex]::Match($projectVersion, "^(?<major>\d+)\.(?<minor>\d+)")
-    if (-not $versionMatch.Success) {
-        throw "Could not parse Unity version '$projectVersion' from $projectVersionFile."
-    }
-
-    $major = [int]$versionMatch.Groups["major"].Value
-    $minor = [int]$versionMatch.Groups["minor"].Value
-    if (($major -ne 6 -and $major -ne 6000) -or $minor -lt 6) {
-        throw "Unity project at $Path uses $projectVersion. This harness requires Unity 6.6 (6000.6) or newer."
-    }
-
-    $manifestFile = Join-Path $Path "Packages/manifest.json"
-    if (-not (Test-Path $manifestFile -PathType Leaf)) {
-        throw "Unity project at $Path has no Packages/manifest.json."
-    }
-
-    $manifest = Get-Content $manifestFile -Raw | ConvertFrom-Json
-
-    if (-not $manifest.dependencies."com.unity.pipeline") {
-        throw "Unity project at $Path must install com.unity.pipeline before this harness can connect."
-    }
-
-    $packageSource = $manifest.dependencies."io.sentry.unity.dev"
-    if (-not $packageSource -or -not $packageSource.StartsWith("file:")) {
-        throw "Unity project at $Path must install io.sentry.unity.dev from this checkout's package-dev directory."
-    }
-
-    if ($packageSource.StartsWith("file://")) {
-        $packagePath = ([Uri]$packageSource).LocalPath
-    }
-    else {
-        $packagePath = [Uri]::UnescapeDataString($packageSource.Substring("file:".Length))
-    }
-
-    if (-not [IO.Path]::IsPathRooted($packagePath)) {
-        $packagePath = Join-Path $Path $packagePath
-    }
-
-    if (-not (Test-Path $packagePath -PathType Container)) {
-        throw "io.sentry.unity.dev points to missing package-dev directory $packagePath."
-    }
-
-    $expectedPackagePath = (Resolve-Path (Join-Path $repoRoot "package-dev")).Path
-    $packagePath = (Resolve-Path $packagePath).Path
-    if ($packagePath -ne $expectedPackagePath) {
-        throw "io.sentry.unity.dev points to $packagePath. This harness requires $expectedPackagePath so it tests this checkout's SDK build."
-    }
-}
-
-function Invoke-UnityCommand([string] $Command, [string[]] $CommandArguments = @(), [int] $CommandTimeout = 30) {
-    $arguments = @(
-        "--json", "command", $Command,
-        "--project-path", $ProjectPath,
-        "--timeout", $CommandTimeout
-    ) + $CommandArguments
-
-    $output = & unity @arguments 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "Unity command '$Command' failed:`n$($output | Out-String)"
-    }
-
-    try {
-        $response = $output | Out-String | ConvertFrom-Json
-    }
-    catch {
-        throw "Unity command '$Command' returned invalid JSON:`n$($output | Out-String)"
-    }
-
-    if (-not $response.success -or -not $response.data.success) {
-        throw "Unity command '$Command' failed:`n$($output | Out-String)"
-    }
-
-    return $response.data.result
-}
-
-function Wait-ForEditorReady {
-    $deadline = (Get-Date).AddSeconds($testTimeout)
-    $lastError = $null
-
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $status = Invoke-UnityCommand "editor_status"
-        }
-        catch {
-            $lastError = $_
-            Start-Sleep -Seconds 1
-            continue
-        }
-
-        if ($status.status -eq "ready" -and -not $status.compiling -and -not $status.domainReloadInProgress) {
-            if ($status.playMode -ne "stopped") {
-                throw "Unity Editor must be stopped before running tests. Current play mode: $($status.playMode)."
-            }
-
-            if ((Resolve-Path $status.projectPath).Path -ne $ProjectPath) {
-                throw "Unity Pipeline is connected to $($status.projectPath), not $ProjectPath."
-            }
-
-            return
-        }
-
-        Start-Sleep -Seconds 1
-    }
-
-    if ($lastError) {
-        throw "Unity Editor did not become ready within $testTimeout seconds. $lastError"
-    }
-
-    throw "Unity Editor did not become ready within $testTimeout seconds."
-}
-
-function Wait-ForRecompile {
-    $recompile = Invoke-UnityCommand "recompile" @() $testTimeout
-    if ($recompile.status -eq "up_to_date") {
-        return
-    }
-
-    $deadline = (Get-Date).AddSeconds($testTimeout)
-    $lastError = $null
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $status = Invoke-UnityCommand "recompile_status"
-            if ($status -is [string]) {
-                $status = $status | ConvertFrom-Json
-            }
-        }
-        catch {
-            $lastError = $_
-            Start-Sleep -Seconds 1
-            continue
-        }
-
-        if ($status.failed) {
-            throw "Unity script recompilation failed:`n$($status.errors -join "`n")"
-        }
-
-        if ($status.status -in @("completed", "up_to_date", "idle")) {
-            return
-        }
-
-        Start-Sleep -Seconds 1
-    }
-
-    if ($lastError) {
-        throw "Unity script recompilation did not finish within $testTimeout seconds. $lastError"
-    }
-
-    throw "Unity script recompilation did not finish within $testTimeout seconds."
-}
-
-function Wait-ForPlayModeTests {
-    $deadline = (Get-Date).AddSeconds($testTimeout)
-    $lastError = $null
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $status = Invoke-UnityCommand "test_status"
-            if ($status -is [string]) {
-                $status = $status | ConvertFrom-Json
-            }
-        }
-        catch {
-            $lastError = $_
-            Start-Sleep -Seconds 1
-            continue
-        }
-
-        if ($status.status -eq "completed") {
-            return [pscustomobject]@{
-                Mode = "PlayMode"
-                Duration = $status.duration
-                Summary = [pscustomobject]@{
-                    Total = $status.summary.total
-                    Passed = $status.summary.passed
-                    Failed = $status.summary.failed
-                    Skipped = $status.summary.skipped
-                    Inconclusive = $status.summary.inconclusive
-                }
-                Results = $status.results
-            }
-        }
-
-        if ($status.status -notin @("running", "queued")) {
-            throw "Unity PlayMode tests ended with status '$($status.status)': $($status.message)"
-        }
-
-        Start-Sleep -Seconds 1
-    }
-
-    if ($lastError) {
-        throw "Unity PlayMode tests did not finish within $testTimeout seconds. $lastError"
-    }
-
-    throw "Unity PlayMode tests did not finish within $testTimeout seconds."
-}
-
-function Get-TestSummary([string] $RequestedMode, [object] $Result) {
-    if ($null -eq $Result -or $null -eq $Result.Summary) {
-        throw "Unity did not return a test summary for $RequestedMode tests."
-    }
-
-    $commandSuccess = $Result.PSObject.Properties["success"]
-    if ($commandSuccess -and -not $commandSuccess.Value -and $Result.error) {
-        throw "Unity $RequestedMode tests could not run: $($Result.error)"
-    }
-
-    $summary = $Result.Summary
-    $failedTests = @($Result.Results | Where-Object { $_.Status -eq "Failed" } | ForEach-Object {
-            [pscustomobject]@{
-                Name       = $_.FullName
-                Message    = Limit-Text $_.Message
-                StackTrace = Limit-Text $_.StackTrace
-            }
-        })
-
-    $success = $summary.Total -gt 0 -and $summary.Failed -eq 0 -and $summary.Inconclusive -eq 0
-    [pscustomobject]@{
-        Mode         = $Result.Mode
-        Duration     = $Result.Duration
-        Total        = $summary.Total
-        Passed       = $summary.Passed
-        Failed       = $summary.Failed
-        Skipped      = $summary.Skipped
-        Inconclusive = $summary.Inconclusive
-        FailedTests  = $failedTests
-        Success      = $success
-    }
-}
+. $PSScriptRoot/unity-test-cli.ps1
+. $PSScriptRoot/unity-test-pipeline.ps1
 
 if (-not (Get-Command unity -ErrorAction SilentlyContinue)) {
     throw "Unity CLI executable 'unity' was not found on PATH."
@@ -287,48 +30,28 @@ if (-not (Get-Command unity -ErrorAction SilentlyContinue)) {
 
 $ProjectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
 if (-not (Test-Path $ProjectPath -PathType Container)) {
-    throw "Local test project was not found at $ProjectPath. Create it with Unity 6.6+, com.unity.pipeline, and io.sentry.unity.dev linked to $repoRoot/package-dev."
+    throw "Local test project was not found at $ProjectPath."
 }
 
 $ProjectPath = (Resolve-Path $ProjectPath).Path
 Test-UnityProject $ProjectPath
 
-$modes = switch ($Mode) {
-    "EditMode" { @("editor") }
-    "PlayMode" { @("playmode") }
-    default { @("editor", "playmode") }
-}
-
-Wait-ForEditorReady
-
-if (-not $SkipBuild) {
-    $buildOutput = & dotnet build $repoRoot --configuration Release --verbosity quiet 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "SDK build failed:`n$($buildOutput | Out-String)"
-    }
-}
-
-Wait-ForRecompile
+$executionMode = Get-TestExecutionMode
 
 $runs = @()
-foreach ($testPlatform in $modes) {
-    $commandArguments = @("--mode", $testPlatform)
-    if ($Filter) {
-        $commandArguments += "--filter", $Filter, "--filter_type", "testName"
+if ($executionMode -eq "Pipeline") {
+    $runs += Invoke-UnityPipelineTests $Mode
+}
+else {
+    $modes = switch ($Mode) {
+        "EditMode" { @("EditMode") }
+        "PlayMode" { @("PlayMode") }
+        default { @("EditMode", "PlayMode") }
     }
 
-    if ($testPlatform -eq "playmode") {
-        $started = Invoke-UnityCommand "run_tests" ($commandArguments + @("--async_tests", "true")) 30
-        if (-not $started.success) {
-            throw "Unity PlayMode tests could not start: $($started.error)"
-        }
-        $result = Wait-ForPlayModeTests
+    foreach ($testMode in $modes) {
+        $runs += Invoke-UnityHeadlessTest $testMode
     }
-    else {
-        $result = Invoke-UnityCommand "run_tests" $commandArguments ($testTimeout + 30)
-    }
-
-    $runs += Get-TestSummary $testPlatform $result
 }
 
 $success = @($runs | Where-Object { -not $_.Success }).Count -eq 0

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -34,7 +34,6 @@ if (-not (Test-Path $ProjectPath -PathType Container)) {
 }
 
 $ProjectPath = (Resolve-Path $ProjectPath).Path
-Test-UnityProject $ProjectPath
 
 $executionMode = Get-TestExecutionMode
 

--- a/scripts/test-utils.ps1
+++ b/scripts/test-utils.ps1
@@ -58,9 +58,14 @@ function Parse-TestResults([string] $Path) {
                 if ($_.failure -and $_.failure.message) {
                     $msg = $_.failure.message.InnerText
                 }
+                $stackTrace = $null
+                if ($_.failure -and $_.failure.'stack-trace') {
+                    $stackTrace = $_.failure.'stack-trace'.InnerText
+                }
                 @{
-                    Name    = $_.fullname
-                    Message = $msg
+                    Name       = $_.fullname
+                    Message    = $msg
+                    StackTrace = $stackTrace
                 }
             })
     }

--- a/scripts/unity-test-cli.ps1
+++ b/scripts/unity-test-cli.ps1
@@ -1,39 +1,5 @@
 . $PSScriptRoot/test-utils.ps1
 
-function Test-UnityProject([string] $Path) {
-    $manifestFile = Join-Path $Path "Packages/manifest.json"
-    if (-not (Test-Path $manifestFile -PathType Leaf)) {
-        throw "Unity project at $Path has no Packages/manifest.json."
-    }
-
-    $manifest = Get-Content $manifestFile -Raw | ConvertFrom-Json
-    $packageSource = $manifest.dependencies."io.sentry.unity.dev"
-    if (-not $packageSource -or -not $packageSource.StartsWith("file:")) {
-        throw "Unity project at $Path must install io.sentry.unity.dev from this checkout's package-dev directory."
-    }
-
-    if ($packageSource.StartsWith("file://")) {
-        $packagePath = ([Uri]$packageSource).LocalPath
-    }
-    else {
-        $packagePath = [Uri]::UnescapeDataString($packageSource.Substring("file:".Length))
-    }
-
-    if (-not [IO.Path]::IsPathRooted($packagePath)) {
-        $packagePath = Join-Path (Split-Path $manifestFile -Parent) $packagePath
-    }
-
-    if (-not (Test-Path $packagePath -PathType Container)) {
-        throw "io.sentry.unity.dev points to missing package-dev directory $packagePath."
-    }
-
-    $expectedPackagePath = (Resolve-Path (Join-Path $repoRoot "package-dev")).Path
-    $packagePath = (Resolve-Path $packagePath).Path
-    if ($packagePath -ne $expectedPackagePath) {
-        throw "io.sentry.unity.dev points to $packagePath. This harness requires $expectedPackagePath so it tests this checkout's SDK build."
-    }
-}
-
 function Invoke-UnityCli([string[]] $Arguments) {
     $output = & unity @Arguments 2>&1
     $text = $output | Out-String

--- a/scripts/unity-test-cli.ps1
+++ b/scripts/unity-test-cli.ps1
@@ -38,29 +38,6 @@ function Get-UnityCliErrorCode([object] $Response) {
     return $null
 }
 
-function Test-UnityProjectIsLocked {
-    $lockFile = Join-Path $ProjectPath "Temp/UnityLockfile"
-    if (-not (Test-Path $lockFile -PathType Leaf)) {
-        return $false
-    }
-
-    try {
-        $stream = [System.IO.File]::Open(
-            $lockFile,
-            [System.IO.FileMode]::Open,
-            [System.IO.FileAccess]::ReadWrite,
-            [System.IO.FileShare]::None)
-        $stream.Dispose()
-        return $false
-    }
-    catch [System.IO.IOException] {
-        return $true
-    }
-    catch [System.UnauthorizedAccessException] {
-        return $true
-    }
-}
-
 function Get-TestExecutionMode {
     $projectName = Split-Path $ProjectPath -Leaf
     $status = Invoke-UnityCli @("status", "--project", $projectName, "--format", "json")
@@ -75,10 +52,6 @@ function Get-TestExecutionMode {
 
     $errorCode = Get-UnityCliErrorCode $status.Response
     if ($errorCode -eq "STATUS_NO_INSTANCES") {
-        if (Test-UnityProjectIsLocked) {
-            return "Pipeline"
-        }
-
         return "Headless"
     }
 

--- a/scripts/unity-test-cli.ps1
+++ b/scripts/unity-test-cli.ps1
@@ -69,7 +69,7 @@ function Invoke-UnityHeadlessTest([string] $TestMode) {
 
     $arguments = @("test", $ProjectPath, "--mode", $TestMode, "--output", $resultPath, "--timeout", $testTimeout)
     if ($Filter) {
-        $arguments += "--filter", $Filter
+        $arguments += "--filter", ".*$([regex]::Escape($Filter)).*"
     }
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()

--- a/scripts/unity-test-cli.ps1
+++ b/scripts/unity-test-cli.ps1
@@ -1,0 +1,164 @@
+. $PSScriptRoot/test-utils.ps1
+
+function Test-UnityProject([string] $Path) {
+    $manifestFile = Join-Path $Path "Packages/manifest.json"
+    if (-not (Test-Path $manifestFile -PathType Leaf)) {
+        throw "Unity project at $Path has no Packages/manifest.json."
+    }
+
+    $manifest = Get-Content $manifestFile -Raw | ConvertFrom-Json
+    $packageSource = $manifest.dependencies."io.sentry.unity.dev"
+    if (-not $packageSource -or -not $packageSource.StartsWith("file:")) {
+        throw "Unity project at $Path must install io.sentry.unity.dev from this checkout's package-dev directory."
+    }
+
+    if ($packageSource.StartsWith("file://")) {
+        $packagePath = ([Uri]$packageSource).LocalPath
+    }
+    else {
+        $packagePath = [Uri]::UnescapeDataString($packageSource.Substring("file:".Length))
+    }
+
+    if (-not [IO.Path]::IsPathRooted($packagePath)) {
+        $packagePath = Join-Path (Split-Path $manifestFile -Parent) $packagePath
+    }
+
+    if (-not (Test-Path $packagePath -PathType Container)) {
+        throw "io.sentry.unity.dev points to missing package-dev directory $packagePath."
+    }
+
+    $expectedPackagePath = (Resolve-Path (Join-Path $repoRoot "package-dev")).Path
+    $packagePath = (Resolve-Path $packagePath).Path
+    if ($packagePath -ne $expectedPackagePath) {
+        throw "io.sentry.unity.dev points to $packagePath. This harness requires $expectedPackagePath so it tests this checkout's SDK build."
+    }
+}
+
+function Invoke-UnityCli([string[]] $Arguments) {
+    $output = & unity @Arguments 2>&1
+    $text = $output | Out-String
+    $response = $null
+
+    try {
+        $response = $text | ConvertFrom-Json
+    }
+    catch {
+        # Most CLI commands stream Unity logs rather than return JSON.
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = $text
+        Response = $response
+    }
+}
+
+function Get-UnityCliErrorCode([object] $Response) {
+    if ($null -eq $Response) {
+        return $null
+    }
+
+    $errorsProperty = $Response.PSObject.Properties["errors"]
+    if ($null -eq $errorsProperty -or $null -eq $errorsProperty.Value) {
+        return $null
+    }
+
+    foreach ($error in @($errorsProperty.Value)) {
+        if ($error.code) {
+            return $error.code
+        }
+    }
+
+    return $null
+}
+
+function Test-UnityProjectIsLocked {
+    $lockFile = Join-Path $ProjectPath "Temp/UnityLockfile"
+    if (-not (Test-Path $lockFile -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $stream = [System.IO.File]::Open(
+            $lockFile,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None)
+        $stream.Dispose()
+        return $false
+    }
+    catch [System.IO.IOException] {
+        return $true
+    }
+    catch [System.UnauthorizedAccessException] {
+        return $true
+    }
+}
+
+function Get-TestExecutionMode {
+    $projectName = Split-Path $ProjectPath -Leaf
+    $status = Invoke-UnityCli @("status", "--project", $projectName, "--format", "json")
+    $successProperty = $null
+    if ($status.Response) {
+        $successProperty = $status.Response.PSObject.Properties["success"]
+    }
+
+    if ($status.ExitCode -eq 0 -and $successProperty -and $successProperty.Value) {
+        return "Pipeline"
+    }
+
+    $errorCode = Get-UnityCliErrorCode $status.Response
+    if ($errorCode -eq "STATUS_NO_INSTANCES") {
+        if (Test-UnityProjectIsLocked) {
+            return "Pipeline"
+        }
+
+        return "Headless"
+    }
+
+    if ($errorCode -eq "STATUS_ALL_UNREACHABLE") {
+        throw "Unity Editor for '$ProjectPath' is running but its Pipeline server is unreachable. Close the Editor or restore the Pipeline connection before running tests."
+    }
+
+    throw "Unable to determine Unity Editor status for '$ProjectPath':`n$($status.Output)"
+}
+
+function Invoke-UnityHeadlessTest([string] $TestMode) {
+    New-Item -ItemType Directory -Force -Path $headlessResultsDirectory | Out-Null
+    $resultPath = Join-Path $headlessResultsDirectory "$($TestMode.ToLowerInvariant()).xml"
+    Remove-Item $resultPath -Force -ErrorAction Ignore
+
+    $arguments = @("test", $ProjectPath, "--mode", $TestMode, "--output", $resultPath, "--timeout", $testTimeout)
+    if ($Filter) {
+        $arguments += "--filter", $Filter
+    }
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $run = Invoke-UnityCli $arguments
+    $stopwatch.Stop()
+
+    $summary = Parse-TestResults $resultPath
+    if ($null -eq $summary) {
+        throw "Unity CLI $TestMode tests did not produce valid results at ${resultPath}:`n$($run.Output)"
+    }
+
+    if ($summary.Total -eq 0) {
+        throw "Unity CLI $TestMode test results are empty."
+    }
+
+    if ($run.ExitCode -ne 0 -and $summary.Success) {
+        throw "Unity CLI $TestMode tests exited with code $($run.ExitCode):`n$($run.Output)"
+    }
+
+    return [pscustomobject]@{
+        Mode         = $TestMode
+        Duration     = $stopwatch.Elapsed.TotalSeconds
+        Total        = $summary.Total
+        Passed       = $summary.Passed
+        Failed       = $summary.Failed
+        Skipped      = $summary.Skipped
+        Inconclusive = $summary.Inconclusive
+        FailedTests  = $summary.FailedTests
+        Success      = $run.ExitCode -eq 0 -and $summary.Success -and $summary.Inconclusive -eq 0
+    }
+}

--- a/scripts/unity-test-pipeline.ps1
+++ b/scripts/unity-test-pipeline.ps1
@@ -1,0 +1,222 @@
+function Limit-Text([object] $Value) {
+    $text = [string] $Value
+    if ($text.Length -le 2000) {
+        return $text
+    }
+
+    return "$($text.Substring(0, 2000))`n... truncated"
+}
+
+function Invoke-UnityCommand([string] $Command, [string[]] $CommandArguments = @(), [int] $CommandTimeout = 30) {
+    $arguments = @(
+        "--json", "command", $Command,
+        "--project-path", $ProjectPath,
+        "--timeout", $CommandTimeout
+    ) + $CommandArguments
+
+    $output = & unity @arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unity command '$Command' failed:`n$($output | Out-String)"
+    }
+
+    try {
+        $response = $output | Out-String | ConvertFrom-Json
+    }
+    catch {
+        throw "Unity command '$Command' returned invalid JSON:`n$($output | Out-String)"
+    }
+
+    if (-not $response.success -or -not $response.data.success) {
+        throw "Unity command '$Command' failed:`n$($output | Out-String)"
+    }
+
+    return $response.data.result
+}
+
+function Wait-ForEditorReady {
+    $deadline = (Get-Date).AddSeconds($testTimeout)
+    $lastError = $null
+
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $status = Invoke-UnityCommand "editor_status"
+        }
+        catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+            continue
+        }
+
+        if ($status.status -eq "ready" -and -not $status.compiling -and -not $status.domainReloadInProgress) {
+            if ($status.playMode -ne "stopped") {
+                throw "Unity Editor must be stopped before running tests. Current play mode: $($status.playMode)."
+            }
+
+            if ((Resolve-Path $status.projectPath).Path -ne $ProjectPath) {
+                throw "Unity Pipeline is connected to $($status.projectPath), not $ProjectPath."
+            }
+
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    if ($lastError) {
+        throw "Unity Editor did not become ready within $testTimeout seconds. $lastError"
+    }
+
+    throw "Unity Editor did not become ready within $testTimeout seconds."
+}
+
+function Wait-ForRecompile {
+    $recompile = Invoke-UnityCommand "recompile" @() $testTimeout
+    if ($recompile.status -eq "up_to_date") {
+        return
+    }
+
+    $deadline = (Get-Date).AddSeconds($testTimeout)
+    $lastError = $null
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $status = Invoke-UnityCommand "recompile_status"
+            if ($status -is [string]) {
+                $status = $status | ConvertFrom-Json
+            }
+        }
+        catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+            continue
+        }
+
+        if ($status.failed) {
+            throw "Unity script recompilation failed:`n$($status.errors -join "`n")"
+        }
+
+        if ($status.status -in @("completed", "up_to_date", "idle")) {
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    if ($lastError) {
+        throw "Unity script recompilation did not finish within $testTimeout seconds. $lastError"
+    }
+
+    throw "Unity script recompilation did not finish within $testTimeout seconds."
+}
+
+function Wait-ForPlayModeTests {
+    $deadline = (Get-Date).AddSeconds($testTimeout)
+    $lastError = $null
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $status = Invoke-UnityCommand "test_status"
+            if ($status -is [string]) {
+                $status = $status | ConvertFrom-Json
+            }
+        }
+        catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+            continue
+        }
+
+        if ($status.status -eq "completed") {
+            return [pscustomobject]@{
+                Mode = "PlayMode"
+                Duration = $status.duration
+                Summary = [pscustomobject]@{
+                    Total = $status.summary.total
+                    Passed = $status.summary.passed
+                    Failed = $status.summary.failed
+                    Skipped = $status.summary.skipped
+                    Inconclusive = $status.summary.inconclusive
+                }
+                Results = $status.results
+            }
+        }
+
+        if ($status.status -notin @("running", "queued")) {
+            throw "Unity PlayMode tests ended with status '$($status.status)': $($status.message)"
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    if ($lastError) {
+        throw "Unity PlayMode tests did not finish within $testTimeout seconds. $lastError"
+    }
+
+    throw "Unity PlayMode tests did not finish within $testTimeout seconds."
+}
+
+function Get-TestSummary([string] $RequestedMode, [object] $Result) {
+    if ($null -eq $Result -or $null -eq $Result.Summary) {
+        throw "Unity did not return a test summary for $RequestedMode tests."
+    }
+
+    $commandSuccess = $Result.PSObject.Properties["success"]
+    if ($commandSuccess -and -not $commandSuccess.Value -and $Result.error) {
+        throw "Unity $RequestedMode tests could not run: $($Result.error)"
+    }
+
+    $summary = $Result.Summary
+    $failedTests = @($Result.Results | Where-Object { $_.Status -eq "Failed" } | ForEach-Object {
+            [pscustomobject]@{
+                Name       = $_.FullName
+                Message    = Limit-Text $_.Message
+                StackTrace = Limit-Text $_.StackTrace
+            }
+        })
+
+    $success = $summary.Total -gt 0 -and $summary.Failed -eq 0 -and $summary.Inconclusive -eq 0
+    [pscustomobject]@{
+        Mode         = $Result.Mode
+        Duration     = $Result.Duration
+        Total        = $summary.Total
+        Passed       = $summary.Passed
+        Failed       = $summary.Failed
+        Skipped      = $summary.Skipped
+        Inconclusive = $summary.Inconclusive
+        FailedTests  = $failedTests
+        Success      = $success
+    }
+}
+
+function Invoke-UnityPipelineTests([string] $Mode) {
+    Wait-ForEditorReady
+    Invoke-UnityCommand "set_autotick" @("--enable", "true") | Out-Null
+    Wait-ForRecompile
+
+    $modes = switch ($Mode) {
+        "EditMode" { @("editor") }
+        "PlayMode" { @("playmode") }
+        default { @("editor", "playmode") }
+    }
+
+    $runs = @()
+    foreach ($testPlatform in $modes) {
+        $commandArguments = @("--mode", $testPlatform)
+        if ($Filter) {
+            $commandArguments += "--filter", $Filter, "--filter_type", "testName"
+        }
+
+        if ($testPlatform -eq "playmode") {
+            $started = Invoke-UnityCommand "run_tests" ($commandArguments + @("--async_tests", "true")) 30
+            if (-not $started.success) {
+                throw "Unity PlayMode tests could not start: $($started.error)"
+            }
+            $result = Wait-ForPlayModeTests
+        }
+        else {
+            $result = Invoke-UnityCommand "run_tests" $commandArguments ($testTimeout + 30)
+        }
+
+        $runs += Get-TestSummary $testPlatform $result
+    }
+
+    return $runs
+}


### PR DESCRIPTION
This change allows running the tests to automatically resolve to either connecting to a running editor instance or to run the tests headless.

Updated the agent docs to make it clear what to pick up.
Updated the bootstrapper to notify about missing tooling.

#skip-changelog