### PR TITLE
fix: cleanup stale native sdk during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Ureleased
+
+### Fixes
+
+- When targeting macOS and switching between native backends, the SDK now correctly removes stale artifacts during the build process ([#2793](https://github.com/getsentry/sentry-unity/pull/2793))
+
 ## 4.8.0
 
 ### Behavioural Changes and Deprecations

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -247,7 +247,7 @@ public static class BuildPostProcess
     // (Sentry.dylib gets picked over libsentry.dylib, surfacing as
     // `sentry_options_new` not found at runtime). Wipe both candidates
     // before copying the current backend's files in.
-    private static void CleanupStaleMacOSArtifacts(IDiagnosticLogger logger, string executablePath)
+    internal static void CleanupStaleMacOSArtifacts(IDiagnosticLogger logger, string executablePath)
     {
         var contents = Path.Combine(executablePath, "Contents");
         foreach (var stale in new[]
@@ -262,6 +262,13 @@ public static class BuildPostProcess
                 logger.LogDebug("Removing stale Sentry artifact from prior build: '{0}'", stale);
                 File.Delete(stale);
             }
+        }
+
+        var staleDsym = Path.Combine(contents, "MacOS", "Sentry.dylib.dSYM");
+        if (Directory.Exists(staleDsym))
+        {
+            logger.LogDebug("Removing stale Sentry artifact from prior build: '{0}'", staleDsym);
+            Directory.Delete(staleDsym, recursive: true);
         }
     }
 

--- a/test/Sentry.Unity.Editor.Tests/Native/BuildPostProcessTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Native/BuildPostProcessTests.cs
@@ -80,4 +80,33 @@ public class BuildPostProcessTests
             l.logLevel == SentryLevel.Warning &&
             l.message.Contains("Required path not found")));
     }
+
+    [Test]
+    public void CleanupStaleMacOSArtifacts_RemovesAllStaleArtifacts()
+    {
+        var appPath = Path.Combine(_testDir, "Game.app");
+        var contents = Path.Combine(appPath, "Contents");
+        var staleArtifacts = new[]
+        {
+            Path.Combine(contents, "PlugIns", "Sentry.dylib"),
+            Path.Combine(contents, "PlugIns", "libsentry.dylib"),
+            Path.Combine(contents, "MacOS", "sentry-crash"),
+        };
+        foreach (var staleArtifact in staleArtifacts)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(staleArtifact)!);
+            File.WriteAllText(staleArtifact, "stale");
+        }
+
+        var staleDsym = Path.Combine(contents, "MacOS", "Sentry.dylib.dSYM");
+        Directory.CreateDirectory(staleDsym);
+
+        BuildPostProcess.CleanupStaleMacOSArtifacts(_logger, appPath);
+
+        foreach (var staleArtifact in staleArtifacts)
+        {
+            Assert.False(File.Exists(staleArtifact));
+        }
+        Assert.False(Directory.Exists(staleDsym));
+    }
 }


### PR DESCRIPTION
Fixes an issue when switching native backend from cocoa to native or the other way around.