### PR TITLE
fix(switch): add stub for `logger_enabled` option

### DIFF
--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -145,6 +145,12 @@ void sentry_options_set_logger(void* options, void* logger, void* userdata)
     (void)userdata;
 }
 
+void sentry_options_set_logger_enabled_when_crashed(void* options, int enabled)
+{
+    (void)options;
+    (void)enabled;
+}
+
 /*
  * =============================================================================
  * sentry_value_* Functions


### PR DESCRIPTION
follow-up to https://github.com/getsentry/sentry-unity/pull/2785 (noticed it only in https://github.com/getsentry/sentry-switch/actions/runs/30604131027/job/91109625089?pr=166#step:7:4162 😅 )

#skip-changelog