### PR TITLE
chore: switch stub tests

### DIFF
--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -145,6 +145,12 @@ void sentry_options_set_logger(void* options, void* logger, void* userdata)
     (void)userdata;
 }
 
+void sentry_options_set_logger_enabled_when_crashed(void* options, int enabled)
+{
+    (void)options;
+    (void)enabled;
+}
+
 /*
  * =============================================================================
  * sentry_value_* Functions
@@ -310,6 +316,25 @@ void sentry_set_environment(const char* environment)
     (void)environment;
 }
 
+void* sentry_attach_file(const char* path)
+{
+    (void)path;
+    return NULL;
+}
+
+void* sentry_attach_bytes(const char* buffer, size_t buffer_length, const char* filename)
+{
+    (void)buffer;
+    (void)buffer_length;
+    (void)filename;
+    return NULL;
+}
+
+void sentry_clear_attachments(void)
+{
+    /* No-op */
+}
+
 /*
  * =============================================================================
  * Crash Detection Functions
@@ -333,6 +358,11 @@ void sentry_reinstall_backend(void)
 }
 
 void sentry_app_hang_heartbeat(void)
+{
+    /* No-op */
+}
+
+void sentry_app_hang_pause(void)
 {
     /* No-op */
 }

--- a/test/Sentry.Unity.Editor.Tests/Native/SwitchNativeStubTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Native/SwitchNativeStubTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Sentry.Unity.Editor.Tests.Native;
+
+public class SwitchNativeStubTests
+{
+    [Test]
+    public void Stub_ContainsEverySwitchNativeBinding()
+    {
+        var packageRoot = Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "..", ".."));
+        var switchAssemblyPath = Path.Combine(packageRoot, "Runtime", "Sentry.Unity.Native.Switch.dll");
+        var stubPath = Path.Combine(packageRoot, "Plugins", "Switch", "sentry_native_stubs.c");
+
+        Assert.That(File.Exists(switchAssemblyPath), Is.True, $"Switch assembly not found at {switchAssemblyPath}");
+        Assert.That(File.Exists(stubPath), Is.True, $"Switch stubs not found at {stubPath}");
+
+        var switchAssembly = Assembly.LoadFrom(switchAssemblyPath);
+        var entryPoints = switchAssembly
+            .GetTypes()
+            .SelectMany(type => type.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static))
+            .Select(method => (Method: method, Import: method.GetCustomAttribute<DllImportAttribute>()))
+            .Where(binding => binding.Import?.Value == "__Internal")
+            .Select(binding => binding.Import!.EntryPoint is { Length: > 0 } entryPoint
+                ? entryPoint
+                : binding.Method.Name)
+            .Distinct()
+            .ToList();
+
+        Assert.That(entryPoints, Is.Not.Empty);
+
+        var stubContent = File.ReadAllText(stubPath);
+        foreach (var entryPoint in entryPoints)
+        {
+            Assert.That(Regex.IsMatch(stubContent, $@"\b{Regex.Escape(entryPoint)}\s*\("), Is.True,
+                $"Switch binding '{entryPoint}' not found in {stubPath}");
+        }
+    }
+}


### PR DESCRIPTION
So the native bindings and what we have on the stubs does no longer drift.

#skip-changelog