### PR TITLE
chore: extend unity cli wrapper to build sample

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,9 @@ Build the Unity 6 sample for a specific platform through Unity CLI:
 pwsh scripts/build-sample.ps1 -Target Android
 ```
 
+When the local sample is open in a Pipeline-enabled Unity Editor, the CLI uses
+that Editor. Otherwise it starts a batch-mode Editor without opening its UI.
+
 Supported targets are `StandaloneWindows64`, `StandaloneOSX`, `StandaloneLinux64`,
 `Android`, `iOS`, and `WebGL`. Build output is under
 `samples/unity-of-bugs-local/Builds/<Target>/`.

--- a/docs/agent-guides/testing.md
+++ b/docs/agent-guides/testing.md
@@ -20,6 +20,8 @@ pwsh scripts/build-sample.ps1 -Target Android
 
 - Requires a target: `StandaloneWindows64`, `StandaloneOSX`, `StandaloneLinux64`,
   `Android`, `iOS`, or `WebGL`.
+- Reuses a Pipeline-connected Editor; otherwise Unity CLI runs the sample builder
+  in batch mode.
 - Outputs under `samples/unity-of-bugs-local/Builds/<Target>/`.
 
 ## Batch Unity Tests

--- a/samples/unity-of-bugs-local/README.md
+++ b/samples/unity-of-bugs-local/README.md
@@ -23,6 +23,9 @@ Build a target through Unity CLI:
 pwsh scripts/build-sample.ps1 -Target Android
 ```
 
+When this project is open in a Pipeline-enabled Unity Editor, the CLI uses that
+Editor. Otherwise it starts a batch-mode Editor without opening its UI.
+
 Supported targets are `StandaloneWindows64`, `StandaloneOSX`,
 `StandaloneLinux64`, `Android`, `iOS`, and `WebGL`. Output is written under
 `Builds/<Target>/`.

--- a/samples/unity-of-bugs/Assets/Editor/SampleBuilder.cs
+++ b/samples/unity-of-bugs/Assets/Editor/SampleBuilder.cs
@@ -20,8 +20,7 @@ namespace Editor
                 scenes = scenes,
                 locationPathName = outputPath,
                 target = target,
-                targetGroup = GetBuildTargetGroup(target),
-                options = BuildOptions.StrictMode
+                targetGroup = GetBuildTargetGroup(target)
             });
 
             if (report.summary.result != BuildResult.Succeeded)

--- a/scripts/build-sample.ps1
+++ b/scripts/build-sample.ps1
@@ -1,6 +1,10 @@
 <#
 .SYNOPSIS
     Builds a player from the local Unity 6 sample through Unity CLI.
+
+.DESCRIPTION
+    Uses an open Unity Pipeline Editor when available. Otherwise, Unity CLI
+    launches a batch-mode Editor to run the sample builder.
 #>
 
 param(
@@ -12,17 +16,25 @@ param(
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
 
+$buildTimeout = 1800
+# Pipeline helpers share the test harness timeout variable.
+$testTimeout = $buildTimeout
+
+. $PSScriptRoot/unity-test-cli.ps1
+. $PSScriptRoot/unity-test-pipeline.ps1
+
 if (-not (Get-Command unity -ErrorAction SilentlyContinue)) {
     throw "Unity CLI executable 'unity' was not found on PATH."
 }
 
 $repoRoot = (Resolve-Path "$PSScriptRoot/..").Path
-$projectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
-if (-not (Test-Path $projectPath -PathType Container)) {
-    throw "Local sample project was not found at $projectPath."
+$ProjectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
+if (-not (Test-Path $ProjectPath -PathType Container)) {
+    throw "Local sample project was not found at $ProjectPath."
 }
 
-$buildDirectory = Join-Path $projectPath "Builds/$Target"
+$ProjectPath = (Resolve-Path $ProjectPath).Path
+$buildDirectory = Join-Path $ProjectPath "Builds/$Target"
 $outputPath = switch ($Target) {
     "StandaloneWindows64" { Join-Path $buildDirectory "unity-of-bugs-local.exe" }
     "StandaloneOSX" { Join-Path $buildDirectory "unity-of-bugs-local.app" }
@@ -33,20 +45,68 @@ $outputPath = switch ($Target) {
 
 New-Item -ItemType Directory -Force -Path $buildDirectory | Out-Null
 
-$arguments = @(
-    "build", $projectPath,
-    "--target", $Target,
-    "--execute-method", "Editor.SampleBuilder.Build",
-    "--output-path", $outputPath
-)
+function Wait-ForUnityPipelineBuild {
+    $deadline = (Get-Date).AddSeconds($buildTimeout)
 
-& unity --non-interactive @arguments
-if ($LASTEXITCODE -ne 0) {
-    throw "Unity CLI build for $Target failed with exit code $LASTEXITCODE."
+    while ((Get-Date) -lt $deadline) {
+        $status = Invoke-UnityCommand "build_status"
+        if ($status -is [string]) {
+            $status = $status | ConvertFrom-Json
+        }
+
+        if ($status.status -eq "completed") {
+            if ($status.result -ne "Succeeded") {
+                $errorsProperty = $status.PSObject.Properties["errors"]
+                $errors = if ($errorsProperty) { @($errorsProperty.Value) } else { @() }
+                $details = if ($errors.Count) { "`n$($errors.message -join "`n")" } else { "" }
+                throw "Unity Pipeline build failed with result '$($status.result)': $($status.totalErrors) error(s).$details"
+            }
+
+            return
+        }
+
+        if ($status.status -notin @("queued", "building")) {
+            throw "Unity Pipeline build ended with status '$($status.status)'."
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    throw "Unity Pipeline build did not finish within $buildTimeout seconds."
+}
+
+$executionMode = Get-TestExecutionMode
+if ($executionMode -eq "Pipeline") {
+    Wait-ForEditorReady
+    Invoke-UnityCommand "set_autotick" @("--enable", "true") | Out-Null
+    Wait-ForRecompile
+    $started = Invoke-UnityCommand "build" @("--target", $Target, "--outputPath", $outputPath, "--confirm", "true") 30
+    if ($started.status -ne "queued") {
+        $errorsProperty = $started.PSObject.Properties["validationErrors"]
+        $errors = if ($errorsProperty) { @($errorsProperty.Value) } else { @() }
+        $details = if ($errors.Count) { "`n$($errors.message -join "`n")" } else { "" }
+        throw "Unity Pipeline build could not start: $($started.message)$details"
+    }
+
+    Wait-ForUnityPipelineBuild
+}
+else {
+    $arguments = @(
+        "build", $ProjectPath,
+        "--target", $Target,
+        "--execute-method", "Editor.SampleBuilder.Build",
+        "--output-path", $outputPath,
+        "--args", "-quit -batchmode -nographics"
+    )
+
+    & unity --non-interactive @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unity CLI build for $Target failed with exit code $LASTEXITCODE."
+    }
 }
 
 if (-not (Test-Path $outputPath)) {
-    throw "Unity CLI build for $Target completed without producing $outputPath."
+    throw "Unity build for $Target completed without producing $outputPath."
 }
 
 Write-Host "Build artifact: $outputPath"

--- a/scripts/build-sample.ps1
+++ b/scripts/build-sample.ps1
@@ -44,9 +44,18 @@ New-Item -ItemType Directory -Force -Path $buildDirectory | Out-Null
 
 function Wait-ForUnityPipelineBuild([string] $projectPath, [int] $timeoutSeconds) {
     $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    $lastError = $null
 
     while ((Get-Date) -lt $deadline) {
-        $status = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "build_status"
+        try {
+            $status = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "build_status"
+        }
+        catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+            continue
+        }
+
         if ($status -is [string]) {
             $status = $status | ConvertFrom-Json
         }
@@ -67,6 +76,10 @@ function Wait-ForUnityPipelineBuild([string] $projectPath, [int] $timeoutSeconds
         }
 
         Start-Sleep -Seconds 1
+    }
+
+    if ($lastError) {
+        throw "Unity Pipeline build did not finish within $timeoutSeconds seconds. $lastError"
     }
 
     throw "Unity Pipeline build did not finish within $timeoutSeconds seconds."

--- a/scripts/build-sample.ps1
+++ b/scripts/build-sample.ps1
@@ -16,25 +16,22 @@ param(
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
 
-$buildTimeout = 1800
-# Pipeline helpers share the test harness timeout variable.
-$testTimeout = $buildTimeout
+$timeoutSeconds = 1800
 
-. $PSScriptRoot/unity-test-cli.ps1
-. $PSScriptRoot/unity-test-pipeline.ps1
+. $PSScriptRoot/unity-pipeline.ps1
 
 if (-not (Get-Command unity -ErrorAction SilentlyContinue)) {
     throw "Unity CLI executable 'unity' was not found on PATH."
 }
 
 $repoRoot = (Resolve-Path "$PSScriptRoot/..").Path
-$ProjectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
-if (-not (Test-Path $ProjectPath -PathType Container)) {
-    throw "Local sample project was not found at $ProjectPath."
+$projectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
+if (-not (Test-Path $projectPath -PathType Container)) {
+    throw "Local sample project was not found at $projectPath."
 }
 
-$ProjectPath = (Resolve-Path $ProjectPath).Path
-$buildDirectory = Join-Path $ProjectPath "Builds/$Target"
+$projectPath = (Resolve-Path $projectPath).Path
+$buildDirectory = Join-Path $projectPath "Builds/$Target"
 $outputPath = switch ($Target) {
     "StandaloneWindows64" { Join-Path $buildDirectory "unity-of-bugs-local.exe" }
     "StandaloneOSX" { Join-Path $buildDirectory "unity-of-bugs-local.app" }
@@ -45,11 +42,11 @@ $outputPath = switch ($Target) {
 
 New-Item -ItemType Directory -Force -Path $buildDirectory | Out-Null
 
-function Wait-ForUnityPipelineBuild {
-    $deadline = (Get-Date).AddSeconds($buildTimeout)
+function Wait-ForUnityPipelineBuild([string] $projectPath, [int] $timeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
 
     while ((Get-Date) -lt $deadline) {
-        $status = Invoke-UnityCommand "build_status"
+        $status = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "build_status"
         if ($status -is [string]) {
             $status = $status | ConvertFrom-Json
         }
@@ -72,15 +69,13 @@ function Wait-ForUnityPipelineBuild {
         Start-Sleep -Seconds 1
     }
 
-    throw "Unity Pipeline build did not finish within $buildTimeout seconds."
+    throw "Unity Pipeline build did not finish within $timeoutSeconds seconds."
 }
 
-$executionMode = Get-TestExecutionMode
+$executionMode = Get-UnityExecutionMode -ProjectPath $projectPath
 if ($executionMode -eq "Pipeline") {
-    Wait-ForEditorReady
-    Invoke-UnityCommand "set_autotick" @("--enable", "true") | Out-Null
-    Wait-ForRecompile
-    $started = Invoke-UnityCommand "build" @("--target", $Target, "--outputPath", $outputPath, "--confirm", "true") 30
+    Prepare-UnityPipelineEditor -ProjectPath $projectPath -TimeoutSeconds $timeoutSeconds
+    $started = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "build" -CommandArguments @("--target", $Target, "--outputPath", $outputPath, "--confirm", "true")
     if ($started.status -ne "queued") {
         $errorsProperty = $started.PSObject.Properties["validationErrors"]
         $errors = if ($errorsProperty) { @($errorsProperty.Value) } else { @() }
@@ -88,20 +83,19 @@ if ($executionMode -eq "Pipeline") {
         throw "Unity Pipeline build could not start: $($started.message)$details"
     }
 
-    Wait-ForUnityPipelineBuild
+    Wait-ForUnityPipelineBuild -ProjectPath $projectPath -TimeoutSeconds $timeoutSeconds
 }
 else {
     $arguments = @(
-        "build", $ProjectPath,
+        "build", $projectPath,
         "--target", $Target,
         "--execute-method", "Editor.SampleBuilder.Build",
-        "--output-path", $outputPath,
-        "--args", "-quit -batchmode -nographics"
+        "--output-path", $outputPath
     )
 
-    & unity --non-interactive @arguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "Unity CLI build for $Target failed with exit code $LASTEXITCODE."
+    $run = Invoke-UnityCli -Arguments $arguments
+    if ($run.ExitCode -ne 0) {
+        throw "Unity CLI build for $Target failed with exit code $($run.ExitCode):`n$($run.Output)"
     }
 }
 

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -18,9 +18,10 @@ Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path "$PSScriptRoot/..").Path
-$testTimeout = 300
+$timeoutSeconds = 300
 $headlessResultsDirectory = Join-Path $repoRoot "artifacts/test/unity-cli"
 
+. $PSScriptRoot/unity-pipeline.ps1
 . $PSScriptRoot/unity-test-cli.ps1
 . $PSScriptRoot/unity-test-pipeline.ps1
 
@@ -28,18 +29,18 @@ if (-not (Get-Command unity -ErrorAction SilentlyContinue)) {
     throw "Unity CLI executable 'unity' was not found on PATH."
 }
 
-$ProjectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
-if (-not (Test-Path $ProjectPath -PathType Container)) {
-    throw "Local test project was not found at $ProjectPath."
+$projectPath = Join-Path $repoRoot "samples/unity-of-bugs-local"
+if (-not (Test-Path $projectPath -PathType Container)) {
+    throw "Local test project was not found at $projectPath."
 }
 
-$ProjectPath = (Resolve-Path $ProjectPath).Path
+$projectPath = (Resolve-Path $projectPath).Path
 
-$executionMode = Get-TestExecutionMode
+$executionMode = Get-UnityExecutionMode -ProjectPath $projectPath
 
 $runs = @()
 if ($executionMode -eq "Pipeline") {
-    $runs += Invoke-UnityPipelineTests $Mode
+    $runs += Invoke-UnityPipelineTests -ProjectPath $projectPath -Mode $Mode -TimeoutSeconds $timeoutSeconds -Filter $Filter
 }
 else {
     $modes = switch ($Mode) {
@@ -49,7 +50,7 @@ else {
     }
 
     foreach ($testMode in $modes) {
-        $runs += Invoke-UnityHeadlessTest $testMode
+        $runs += Invoke-UnityHeadlessTest -ProjectPath $projectPath -TestMode $testMode -ResultsDirectory $headlessResultsDirectory -TimeoutSeconds $timeoutSeconds -Filter $Filter
     }
 }
 

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -21,7 +21,6 @@ $repoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $timeoutSeconds = 300
 $headlessResultsDirectory = Join-Path $repoRoot "artifacts/test/unity-cli"
 
-. $PSScriptRoot/unity-pipeline.ps1
 . $PSScriptRoot/unity-test-cli.ps1
 . $PSScriptRoot/unity-test-pipeline.ps1
 

--- a/scripts/unity-pipeline.ps1
+++ b/scripts/unity-pipeline.ps1
@@ -1,0 +1,178 @@
+function Invoke-UnityCli([string[]] $arguments) {
+    $output = & unity @arguments 2>&1
+    $text = $output | Out-String
+    $response = $null
+
+    try {
+        $response = $text | ConvertFrom-Json
+    }
+    catch {
+        # Most CLI commands stream Unity logs rather than return JSON.
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = $text
+        Response = $response
+    }
+}
+
+function Get-UnityCliErrorCode([object] $response) {
+    if ($null -eq $response) {
+        return $null
+    }
+
+    $errorsProperty = $response.PSObject.Properties["errors"]
+    if ($null -eq $errorsProperty -or $null -eq $errorsProperty.Value) {
+        return $null
+    }
+
+    foreach ($error in @($errorsProperty.Value)) {
+        if ($error.code) {
+            return $error.code
+        }
+    }
+
+    return $null
+}
+
+function Get-UnityExecutionMode([string] $projectPath) {
+    $projectName = Split-Path $projectPath -Leaf
+    $status = Invoke-UnityCli @("status", "--project", $projectName, "--format", "json")
+    $successProperty = $null
+    if ($status.Response) {
+        $successProperty = $status.Response.PSObject.Properties["success"]
+    }
+
+    if ($status.ExitCode -eq 0 -and $successProperty -and $successProperty.Value) {
+        return "Pipeline"
+    }
+
+    $errorCode = Get-UnityCliErrorCode $status.Response
+    if ($errorCode -eq "STATUS_NO_INSTANCES") {
+        return "Headless"
+    }
+
+    if ($errorCode -eq "STATUS_ALL_UNREACHABLE") {
+        throw "Unity Editor for '$projectPath' is running but its Pipeline server is unreachable. Close the Editor or restore the Pipeline connection."
+    }
+
+    throw "Unable to determine Unity Editor status for '$projectPath':`n$($status.Output)"
+}
+
+function Invoke-UnityPipelineCommand(
+    [string] $projectPath,
+    [string] $command,
+    [string[]] $commandArguments = @(),
+    [int] $timeoutSeconds = 30
+) {
+    $arguments = @(
+        "--json", "command", $command,
+        "--project-path", $projectPath,
+        "--timeout", $timeoutSeconds
+    ) + $commandArguments
+
+    $output = & unity @arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unity command '$command' failed:`n$($output | Out-String)"
+    }
+
+    try {
+        $response = $output | Out-String | ConvertFrom-Json
+    }
+    catch {
+        throw "Unity command '$command' returned invalid JSON:`n$($output | Out-String)"
+    }
+
+    if (-not $response.success -or -not $response.data.success) {
+        throw "Unity command '$command' failed:`n$($output | Out-String)"
+    }
+
+    return $response.data.result
+}
+
+function Wait-ForUnityEditorReady([string] $projectPath, [int] $timeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    $lastError = $null
+
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $status = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "editor_status"
+        }
+        catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+            continue
+        }
+
+        if ($status.status -eq "ready" -and -not $status.compiling -and -not $status.domainReloadInProgress) {
+            if ($status.playMode -ne "stopped") {
+                throw "Unity Editor must be stopped before continuing. Current play mode: $($status.playMode)."
+            }
+
+            if ((Resolve-Path $status.projectPath).Path -ne $projectPath) {
+                throw "Unity Pipeline is connected to $($status.projectPath), not $projectPath."
+            }
+
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    if ($lastError) {
+        throw "Unity Editor did not become ready within $timeoutSeconds seconds. $lastError"
+    }
+
+    throw "Unity Editor did not become ready within $timeoutSeconds seconds."
+}
+
+function Enable-UnityPipelineAutoTick([string] $projectPath) {
+    Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "set_autotick" -CommandArguments @("--enable", "true") | Out-Null
+}
+
+function Wait-ForUnityRecompile([string] $projectPath, [int] $timeoutSeconds) {
+    $recompile = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "recompile" -TimeoutSeconds $timeoutSeconds
+    if ($recompile.status -eq "up_to_date") {
+        return
+    }
+
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    $lastError = $null
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $status = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "recompile_status"
+            if ($status -is [string]) {
+                $status = $status | ConvertFrom-Json
+            }
+        }
+        catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+            continue
+        }
+
+        if ($status.failed) {
+            throw "Unity script recompilation failed:`n$($status.errors -join "`n")"
+        }
+
+        if ($status.status -in @("completed", "up_to_date", "idle")) {
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    if ($lastError) {
+        throw "Unity script recompilation did not finish within $timeoutSeconds seconds. $lastError"
+    }
+
+    throw "Unity script recompilation did not finish within $timeoutSeconds seconds."
+}
+
+function Prepare-UnityPipelineEditor([string] $projectPath, [int] $timeoutSeconds) {
+    Wait-ForUnityEditorReady -ProjectPath $projectPath -TimeoutSeconds $timeoutSeconds
+    Enable-UnityPipelineAutoTick -ProjectPath $projectPath
+    Wait-ForUnityRecompile -ProjectPath $projectPath -TimeoutSeconds $timeoutSeconds
+    Enable-UnityPipelineAutoTick -ProjectPath $projectPath
+}

--- a/scripts/unity-test-cli.ps1
+++ b/scripts/unity-test-cli.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/unity-pipeline.ps1
 . $PSScriptRoot/test-utils.ps1
 
 function Invoke-UnityHeadlessTest(

--- a/scripts/unity-test-cli.ps1
+++ b/scripts/unity-test-cli.ps1
@@ -1,75 +1,19 @@
 . $PSScriptRoot/test-utils.ps1
 
-function Invoke-UnityCli([string[]] $Arguments) {
-    $output = & unity @Arguments 2>&1
-    $text = $output | Out-String
-    $response = $null
-
-    try {
-        $response = $text | ConvertFrom-Json
-    }
-    catch {
-        # Most CLI commands stream Unity logs rather than return JSON.
-    }
-
-    return [pscustomobject]@{
-        ExitCode = $LASTEXITCODE
-        Output   = $text
-        Response = $response
-    }
-}
-
-function Get-UnityCliErrorCode([object] $Response) {
-    if ($null -eq $Response) {
-        return $null
-    }
-
-    $errorsProperty = $Response.PSObject.Properties["errors"]
-    if ($null -eq $errorsProperty -or $null -eq $errorsProperty.Value) {
-        return $null
-    }
-
-    foreach ($error in @($errorsProperty.Value)) {
-        if ($error.code) {
-            return $error.code
-        }
-    }
-
-    return $null
-}
-
-function Get-TestExecutionMode {
-    $projectName = Split-Path $ProjectPath -Leaf
-    $status = Invoke-UnityCli @("status", "--project", $projectName, "--format", "json")
-    $successProperty = $null
-    if ($status.Response) {
-        $successProperty = $status.Response.PSObject.Properties["success"]
-    }
-
-    if ($status.ExitCode -eq 0 -and $successProperty -and $successProperty.Value) {
-        return "Pipeline"
-    }
-
-    $errorCode = Get-UnityCliErrorCode $status.Response
-    if ($errorCode -eq "STATUS_NO_INSTANCES") {
-        return "Headless"
-    }
-
-    if ($errorCode -eq "STATUS_ALL_UNREACHABLE") {
-        throw "Unity Editor for '$ProjectPath' is running but its Pipeline server is unreachable. Close the Editor or restore the Pipeline connection before running tests."
-    }
-
-    throw "Unable to determine Unity Editor status for '$ProjectPath':`n$($status.Output)"
-}
-
-function Invoke-UnityHeadlessTest([string] $TestMode) {
-    New-Item -ItemType Directory -Force -Path $headlessResultsDirectory | Out-Null
-    $resultPath = Join-Path $headlessResultsDirectory "$($TestMode.ToLowerInvariant()).xml"
+function Invoke-UnityHeadlessTest(
+    [string] $projectPath,
+    [string] $testMode,
+    [string] $resultsDirectory,
+    [int] $timeoutSeconds,
+    [string] $filter
+) {
+    New-Item -ItemType Directory -Force -Path $resultsDirectory | Out-Null
+    $resultPath = Join-Path $resultsDirectory "$($testMode.ToLowerInvariant()).xml"
     Remove-Item $resultPath -Force -ErrorAction Ignore
 
-    $arguments = @("test", $ProjectPath, "--mode", $TestMode, "--output", $resultPath, "--timeout", $testTimeout)
-    if ($Filter) {
-        $arguments += "--filter", ".*$([regex]::Escape($Filter)).*"
+    $arguments = @("test", $projectPath, "--mode", $testMode, "--output", $resultPath, "--timeout", $timeoutSeconds)
+    if ($filter) {
+        $arguments += "--filter", ".*$([regex]::Escape($filter)).*"
     }
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
@@ -78,19 +22,19 @@ function Invoke-UnityHeadlessTest([string] $TestMode) {
 
     $summary = Parse-TestResults $resultPath
     if ($null -eq $summary) {
-        throw "Unity CLI $TestMode tests did not produce valid results at ${resultPath}:`n$($run.Output)"
+        throw "Unity CLI $testMode tests did not produce valid results at ${resultPath}:`n$($run.Output)"
     }
 
     if ($summary.Total -eq 0) {
-        throw "Unity CLI $TestMode test results are empty."
+        throw "Unity CLI $testMode test results are empty."
     }
 
     if ($run.ExitCode -ne 0 -and $summary.Success) {
-        throw "Unity CLI $TestMode tests exited with code $($run.ExitCode):`n$($run.Output)"
+        throw "Unity CLI $testMode tests exited with code $($run.ExitCode):`n$($run.Output)"
     }
 
     return [pscustomobject]@{
-        Mode         = $TestMode
+        Mode         = $testMode
         Duration     = $stopwatch.Elapsed.TotalSeconds
         Total        = $summary.Total
         Passed       = $summary.Passed

--- a/scripts/unity-test-pipeline.ps1
+++ b/scripts/unity-test-pipeline.ps1
@@ -1,5 +1,5 @@
-function Limit-Text([object] $Value) {
-    $text = [string] $Value
+function Limit-Text([object] $value) {
+    $text = [string] $value
     if ($text.Length -le 2000) {
         return $text
     }
@@ -7,113 +7,12 @@ function Limit-Text([object] $Value) {
     return "$($text.Substring(0, 2000))`n... truncated"
 }
 
-function Invoke-UnityCommand([string] $Command, [string[]] $CommandArguments = @(), [int] $CommandTimeout = 30) {
-    $arguments = @(
-        "--json", "command", $Command,
-        "--project-path", $ProjectPath,
-        "--timeout", $CommandTimeout
-    ) + $CommandArguments
-
-    $output = & unity @arguments 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "Unity command '$Command' failed:`n$($output | Out-String)"
-    }
-
-    try {
-        $response = $output | Out-String | ConvertFrom-Json
-    }
-    catch {
-        throw "Unity command '$Command' returned invalid JSON:`n$($output | Out-String)"
-    }
-
-    if (-not $response.success -or -not $response.data.success) {
-        throw "Unity command '$Command' failed:`n$($output | Out-String)"
-    }
-
-    return $response.data.result
-}
-
-function Wait-ForEditorReady {
-    $deadline = (Get-Date).AddSeconds($testTimeout)
-    $lastError = $null
-
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $status = Invoke-UnityCommand "editor_status"
-        }
-        catch {
-            $lastError = $_
-            Start-Sleep -Seconds 1
-            continue
-        }
-
-        if ($status.status -eq "ready" -and -not $status.compiling -and -not $status.domainReloadInProgress) {
-            if ($status.playMode -ne "stopped") {
-                throw "Unity Editor must be stopped before running tests. Current play mode: $($status.playMode)."
-            }
-
-            if ((Resolve-Path $status.projectPath).Path -ne $ProjectPath) {
-                throw "Unity Pipeline is connected to $($status.projectPath), not $ProjectPath."
-            }
-
-            return
-        }
-
-        Start-Sleep -Seconds 1
-    }
-
-    if ($lastError) {
-        throw "Unity Editor did not become ready within $testTimeout seconds. $lastError"
-    }
-
-    throw "Unity Editor did not become ready within $testTimeout seconds."
-}
-
-function Wait-ForRecompile {
-    $recompile = Invoke-UnityCommand "recompile" @() $testTimeout
-    if ($recompile.status -eq "up_to_date") {
-        return
-    }
-
-    $deadline = (Get-Date).AddSeconds($testTimeout)
+function Wait-ForPlayModeTests([string] $projectPath, [int] $timeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
     $lastError = $null
     while ((Get-Date) -lt $deadline) {
         try {
-            $status = Invoke-UnityCommand "recompile_status"
-            if ($status -is [string]) {
-                $status = $status | ConvertFrom-Json
-            }
-        }
-        catch {
-            $lastError = $_
-            Start-Sleep -Seconds 1
-            continue
-        }
-
-        if ($status.failed) {
-            throw "Unity script recompilation failed:`n$($status.errors -join "`n")"
-        }
-
-        if ($status.status -in @("completed", "up_to_date", "idle")) {
-            return
-        }
-
-        Start-Sleep -Seconds 1
-    }
-
-    if ($lastError) {
-        throw "Unity script recompilation did not finish within $testTimeout seconds. $lastError"
-    }
-
-    throw "Unity script recompilation did not finish within $testTimeout seconds."
-}
-
-function Wait-ForPlayModeTests {
-    $deadline = (Get-Date).AddSeconds($testTimeout)
-    $lastError = $null
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $status = Invoke-UnityCommand "test_status"
+            $status = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "test_status"
             if ($status -is [string]) {
                 $status = $status | ConvertFrom-Json
             }
@@ -147,24 +46,24 @@ function Wait-ForPlayModeTests {
     }
 
     if ($lastError) {
-        throw "Unity PlayMode tests did not finish within $testTimeout seconds. $lastError"
+        throw "Unity PlayMode tests did not finish within $timeoutSeconds seconds. $lastError"
     }
 
-    throw "Unity PlayMode tests did not finish within $testTimeout seconds."
+    throw "Unity PlayMode tests did not finish within $timeoutSeconds seconds."
 }
 
-function Get-TestSummary([string] $RequestedMode, [object] $Result) {
-    if ($null -eq $Result -or $null -eq $Result.Summary) {
-        throw "Unity did not return a test summary for $RequestedMode tests."
+function Get-TestSummary([string] $requestedMode, [object] $result) {
+    if ($null -eq $result -or $null -eq $result.Summary) {
+        throw "Unity did not return a test summary for $requestedMode tests."
     }
 
-    $commandSuccess = $Result.PSObject.Properties["success"]
-    if ($commandSuccess -and -not $commandSuccess.Value -and $Result.error) {
-        throw "Unity $RequestedMode tests could not run: $($Result.error)"
+    $commandSuccess = $result.PSObject.Properties["success"]
+    if ($commandSuccess -and -not $commandSuccess.Value -and $result.error) {
+        throw "Unity $requestedMode tests could not run: $($result.error)"
     }
 
-    $summary = $Result.Summary
-    $failedTests = @($Result.Results | Where-Object { $_.Status -eq "Failed" } | ForEach-Object {
+    $summary = $result.Summary
+    $failedTests = @($result.Results | Where-Object { $_.Status -eq "Failed" } | ForEach-Object {
             [pscustomobject]@{
                 Name       = $_.FullName
                 Message    = Limit-Text $_.Message
@@ -174,8 +73,8 @@ function Get-TestSummary([string] $RequestedMode, [object] $Result) {
 
     $success = $summary.Total -gt 0 -and $summary.Failed -eq 0 -and $summary.Inconclusive -eq 0
     [pscustomobject]@{
-        Mode         = $Result.Mode
-        Duration     = $Result.Duration
+        Mode         = $result.Mode
+        Duration     = $result.Duration
         Total        = $summary.Total
         Passed       = $summary.Passed
         Failed       = $summary.Failed
@@ -186,12 +85,15 @@ function Get-TestSummary([string] $RequestedMode, [object] $Result) {
     }
 }
 
-function Invoke-UnityPipelineTests([string] $Mode) {
-    Wait-ForEditorReady
-    Invoke-UnityCommand "set_autotick" @("--enable", "true") | Out-Null
-    Wait-ForRecompile
+function Invoke-UnityPipelineTests(
+    [string] $projectPath,
+    [string] $mode,
+    [int] $timeoutSeconds,
+    [string] $filter
+) {
+    Prepare-UnityPipelineEditor -ProjectPath $projectPath -TimeoutSeconds $timeoutSeconds
 
-    $modes = switch ($Mode) {
+    $modes = switch ($mode) {
         "EditMode" { @("editor") }
         "PlayMode" { @("playmode") }
         default { @("editor", "playmode") }
@@ -200,22 +102,22 @@ function Invoke-UnityPipelineTests([string] $Mode) {
     $runs = @()
     foreach ($testPlatform in $modes) {
         $commandArguments = @("--mode", $testPlatform)
-        if ($Filter) {
-            $commandArguments += "--filter", $Filter, "--filter_type", "testName"
+        if ($filter) {
+            $commandArguments += "--filter", $filter, "--filter_type", "testName"
         }
 
         if ($testPlatform -eq "playmode") {
-            $started = Invoke-UnityCommand "run_tests" ($commandArguments + @("--async_tests", "true")) 30
+            $started = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "run_tests" -CommandArguments ($commandArguments + @("--async_tests", "true"))
             if (-not $started.success) {
                 throw "Unity PlayMode tests could not start: $($started.error)"
             }
-            $result = Wait-ForPlayModeTests
+            $result = Wait-ForPlayModeTests -ProjectPath $projectPath -TimeoutSeconds $timeoutSeconds
         }
         else {
-            $result = Invoke-UnityCommand "run_tests" $commandArguments ($testTimeout + 30)
+            $result = Invoke-UnityPipelineCommand -ProjectPath $projectPath -Command "run_tests" -CommandArguments $commandArguments -TimeoutSeconds ($timeoutSeconds + 30)
         }
 
-        $runs += Get-TestSummary $testPlatform $result
+        $runs += Get-TestSummary -RequestedMode $testPlatform -Result $result
     }
 
     return $runs

--- a/scripts/unity-test-pipeline.ps1
+++ b/scripts/unity-test-pipeline.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot/unity-pipeline.ps1
+
 function Limit-Text([object] $value) {
     $text = [string] $value
     if ($text.Length -le 2000) {


### PR DESCRIPTION
This allows to run `pwsh scripts/build-sample.ps1 -Target StandaloneOSX` to build the `unity-of-bugs` sample. Uses the pipeline if the Editor is running, runs headless if not.

#skip-changelog