### PR TITLE
Windows mono native dll clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Native crash capture no longer fails on Windows with the Mono scripting backend. Mono probes the calling assembly's own directory first, so `DllImport("sentry")` from `Sentry.Unity.Native.dll` resolved to the managed `Sentry.dll` sitting beside it in `Managed/` and native init failed with `EntryPointNotFoundException: sentry_options_new`. The native library is now copied into the build as `sentry-native` on desktop, which nothing else answers to ([#2818](https://github.com/getsentry/sentry-unity/issues/2818))
+
 ## 4.9.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Native crash capture no longer fails on Windows with the Mono scripting backend. Mono probes the calling assembly's own directory first, so `DllImport("sentry")` from `Sentry.Unity.Native.dll` resolved to the managed `Sentry.dll` sitting beside it in `Managed/` and native init failed with `EntryPointNotFoundException: sentry_options_new`. The native library is now copied into the build as `sentry-native` on desktop, which nothing else answers to ([#2818](https://github.com/getsentry/sentry-unity/issues/2818))
+- Fixed native crash capture on Windows with the Mono scripting backend. The native library is now copied into the player as `sentry-native`, so `DllImport` can no longer resolve to the managed `Sentry.dll` sitting beside it in `Managed/` ([#2818](https://github.com/getsentry/sentry-unity/issues/2818))
 
 ## 4.9.0
 

--- a/docs/agent-guides/platform-native.md
+++ b/docs/agent-guides/platform-native.md
@@ -8,6 +8,7 @@
 - Native backend reinstalls before first scene after Unity takes crash/signal handlers.
 - Native logger forwarding to C# exists only under IL2CPP.
 - The native library is copied into the player as `sentry-native`, not `sentry`, because `sentry` resolves to the managed `Sentry.dll` on Windows.
+- Android is the exception: its `libsentry.so` comes from the sentry-android-ndk AAR, so it keeps `sentry` and gets its own `Sentry.Unity.Native.Android.dll` built from the same sources.
 
 ## Backend Choices
 

--- a/docs/agent-guides/platform-native.md
+++ b/docs/agent-guides/platform-native.md
@@ -7,6 +7,7 @@
 - `sentry_get_crashed_last_run` clears native state; SDK caches its result for the process lifetime. Do not make it repeatable.
 - Native backend reinstalls before first scene after Unity takes crash/signal handlers.
 - Native logger forwarding to C# exists only under IL2CPP.
+- The native library is copied into the player as `sentry-native`, not `sentry`, because `sentry` resolves to the managed `Sentry.dll` on Windows.
 
 ## Backend Choices
 
@@ -22,9 +23,9 @@ Experimental native modes raise minimum shutdown timeout to 10 seconds.
 
 `Sentry.Unity.Editor/Native/BuildPostProcess.cs` selects legacy `Sentry~` or experimental `SentryNative~`, clears stale handler artifacts when switching backend, copies runtime libraries to player locations, and leaves symbols in package for upload.
 
-- Windows: runtime files beside player `.exe`.
-- Linux: `libsentry.so` under `<Player>_Data/Plugins/x86_64`; native daemon beside executable.
-- macOS: dylib in `.app/Contents/PlugIns`; handler in `.app/Contents/MacOS`.
+- Windows: runtime files beside player `.exe`; the native library lands as `sentry-native.dll`.
+- Linux: `libsentry-native.so` under `<Player>_Data/Plugins/x86_64`; native daemon beside executable.
+- macOS: dylib in `.app/Contents/PlugIns` as `libsentry-native.dylib`; handler in `.app/Contents/MacOS`. The Cocoa backend's `Sentry.dylib` keeps its name, it is dlopened rather than P/Invoked.
 
 ## Console Plugins
 

--- a/package-dev/Runtime/Sentry.Unity.Native.Android.dll.meta
+++ b/package-dev/Runtime/Sentry.Unity.Native.Android.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bb324dd170e76fb4bbe06f959c323cbd
+guid: c5bff87923964bd3827bb7a2c0d7f4e3
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -16,28 +16,24 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
-        Exclude GameCoreScarlett: 1
-        Exclude GameCoreXboxOne: 1
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
-        Exclude PS4: 1
-        Exclude PS5: 1
-        Exclude Switch: 1
+        Exclude Linux64: 1
+        Exclude Lumin: 1
+        Exclude OSXUniversal: 1
         Exclude WebGL: 1
-        Exclude Win: 0
-        Exclude Win64: 0
+        Exclude Win: 1
+        Exclude Win64: 1
         Exclude iOS: 1
         Exclude tvOS: 1
   - first:
       Android: Android
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: ARMv7
   - first:
-      Any:
+      Any: 
     second:
       enabled: 0
       settings: {}
@@ -50,51 +46,29 @@ PluginImporter:
         DefaultValueInitialized: true
         OS: AnyOS
   - first:
-      GameCoreScarlett: GameCoreScarlett
-    second:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-  - first:
-      GameCoreXboxOne: GameCoreXboxOne
-    second:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-  - first:
-      PS5: PS5
-    second:
-      enabled: 0
-      settings: {}
-  - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: Win
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: Win64
     second:
-      enabled: 1
-      settings:
-        CPU: AnyCPU
-  - first:
-      Switch: Switch
-    second:
       enabled: 0
-      settings: {}
+      settings:
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
@@ -108,16 +82,16 @@ PluginImporter:
       settings:
         AddToEmbeddedBinaries: false
         CPU: AnyCPU
-        CompileFlags:
-        FrameworkDependencies:
+        CompileFlags: 
+        FrameworkDependencies: 
   - first:
       tvOS: tvOS
     second:
       enabled: 0
       settings:
         CPU: AnyCPU
-        CompileFlags:
-        FrameworkDependencies:
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Sentry.Unity.Android/Sentry.Unity.Android.csproj
+++ b/src/Sentry.Unity.Android/Sentry.Unity.Android.csproj
@@ -6,7 +6,9 @@
   <ItemGroup>
     <ProjectReference Include="../sentry-dotnet/src/Sentry/Sentry.csproj" Private="false" />
     <ProjectReference Include="../Sentry.Unity/Sentry.Unity.csproj" Private="false" />
-    <ProjectReference Include="../Sentry.Unity.Native/Sentry.Unity.Native.csproj" Private="false" PrivateAssets="all" />
+    <!-- Build order only. The types come from the Android variant, which keeps DllImport("sentry") -->
+    <ProjectReference Include="../Sentry.Unity.Native/Sentry.Unity.Native.csproj" Private="false" PrivateAssets="all" ReferenceOutputAssembly="false" />
+    <Reference Include="$(PackageRuntimePath)/Sentry.Unity.Native.Android.dll" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -166,7 +166,7 @@ public static class BuildPostProcess
                         $"Sentry Windows plugin directory not found: {windowsBackendSourcePath}\n" +
                         $"Run 'dotnet msbuild /t:{buildTarget} src/Sentry.Unity' (or 'dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity') to populate it.");
                 }
-                // Flat copy of every non-PDB file next to the player .exe — the native library and the
+                // Flat copy of every non-PDB file next to the player .exe. The native library and the
                 // crash handler (crashpad_handler.exe / sentry-crash.exe) all sit at the build root.
                 // PDBs stay in the package and are consumed at symbol-upload time only.
                 foreach (var file in Directory.GetFiles(windowsBackendSourcePath))
@@ -197,8 +197,8 @@ public static class BuildPostProcess
                     var isDylib = name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase);
                     // The .dylibs need to go into the `*.app/Contents/Plugins` dirctory and will be picked
                     // up by unity. The crash handler (sentry-native) needs to be next to the game's executable
-                    // Only sentry-native answers to the P/Invoke. The Cocoa backend ships Sentry.dylib
-                    // and SentryNativeBridge.m dlopens it by that name, so leave it alone.
+                    // Only libsentry.dylib is the P/Invoke target. The Cocoa backend's Sentry.dylib is
+                    // dlopened by SentryNativeBridge.m under that exact name, so leave it alone.
                     var dylibName = name.Equals("libsentry.dylib", StringComparison.OrdinalIgnoreCase) ? MacosLibName : name;
                     var desination = Path.Combine(contents, isDylib ? "PlugIns" : "MacOS", dylibName);
                     yield return new NativePluginArtifact(
@@ -233,10 +233,11 @@ public static class BuildPostProcess
                         continue;
                     }
                     var isSharedObject = name.EndsWith(".so", StringComparison.OrdinalIgnoreCase);
+                    var soName = name.Equals("libsentry.so", StringComparison.OrdinalIgnoreCase) ? LinuxLibName : name;
                     yield return new NativePluginArtifact(
                         file,
                         isSharedObject
-                            ? Path.Combine(linuxPluginDir, LinuxLibName)
+                            ? Path.Combine(linuxPluginDir, soName)
                             : Path.Combine(buildOutputDir, name),
                         isExecutable: !isSharedObject);
                 }
@@ -256,8 +257,8 @@ public static class BuildPostProcess
         }
     }
 
-    // Wipe the other backend's dylib before copying the current backend's files in, so an
-    // iterative build does not leave both libraries sitting in PlugIns.
+    // Wipe both backends' leftovers before copying the current one in, so an iterative
+    // build does not leave two libraries sitting in PlugIns.
     private static void CleanupStaleMacOSArtifacts(IDiagnosticLogger logger, string executablePath)
     {
         var contents = Path.Combine(executablePath, "Contents");

--- a/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
+++ b/src/Sentry.Unity.Editor/Native/BuildPostProcess.cs
@@ -134,6 +134,12 @@ public static class BuildPostProcess
         _ => false,
     };
 
+    // Mono probes the calling assembly's own folder first, so on Windows DllImport("sentry")
+    // binds to the managed Sentry.dll sitting next to it in Managed/
+    private const string WindowsLibName = "sentry-native.dll";
+    private const string LinuxLibName = "libsentry-native.so";
+    private const string MacosLibName = "libsentry-native.dylib";
+
     private readonly struct NativePluginArtifact(string source, string destination, bool isExecutable = false)
     {
         public readonly string Source = source;
@@ -160,7 +166,7 @@ public static class BuildPostProcess
                         $"Sentry Windows plugin directory not found: {windowsBackendSourcePath}\n" +
                         $"Run 'dotnet msbuild /t:{buildTarget} src/Sentry.Unity' (or 'dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity') to populate it.");
                 }
-                // Flat copy of every non-PDB file next to the player .exe — sentry.dll and the
+                // Flat copy of every non-PDB file next to the player .exe — the native library and the
                 // crash handler (crashpad_handler.exe / sentry-crash.exe) all sit at the build root.
                 // PDBs stay in the package and are consumed at symbol-upload time only.
                 foreach (var file in Directory.GetFiles(windowsBackendSourcePath))
@@ -169,9 +175,14 @@ public static class BuildPostProcess
                     {
                         continue;
                     }
+                    var windowsName = Path.GetFileName(file);
+                    if (windowsName.Equals("sentry.dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        windowsName = WindowsLibName;
+                    }
                     yield return new NativePluginArtifact(
                         file,
-                        Path.Combine(buildOutputDir, Path.GetFileName(file)));
+                        Path.Combine(buildOutputDir, windowsName));
                 }
                 break;
 
@@ -186,7 +197,10 @@ public static class BuildPostProcess
                     var isDylib = name.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase);
                     // The .dylibs need to go into the `*.app/Contents/Plugins` dirctory and will be picked
                     // up by unity. The crash handler (sentry-native) needs to be next to the game's executable
-                    var desination = Path.Combine(contents, isDylib ? "PlugIns" : "MacOS", name);
+                    // Only sentry-native answers to the P/Invoke. The Cocoa backend ships Sentry.dylib
+                    // and SentryNativeBridge.m dlopens it by that name, so leave it alone.
+                    var dylibName = name.Equals("libsentry.dylib", StringComparison.OrdinalIgnoreCase) ? MacosLibName : name;
+                    var desination = Path.Combine(contents, isDylib ? "PlugIns" : "MacOS", dylibName);
                     yield return new NativePluginArtifact(
                         file,
                         desination,
@@ -205,8 +219,8 @@ public static class BuildPostProcess
                         $"Sentry Linux plugin directory not found: {linuxBackendSourcePath}\n" +
                         $"Run 'dotnet msbuild /t:{buildTarget} src/Sentry.Unity' (or 'dotnet msbuild /t:DownloadNativeSDKs src/Sentry.Unity') to populate it.");
                 }
-                // libsentry.so must sit in the player's native plugin dir (<name>_Data/Plugins/x86_64) where the
-                // Linux player resolves DllImport("sentry"). The crash daemon (sentry-crash, native backend only)
+                // The native library must sit in the player's native plugin dir (<name>_Data/Plugins/x86_64)
+                // where the Linux player resolves the P/Invoke. The crash daemon (sentry-crash, native backend only)
                 // sits next to the player executable so sentry-native can spawn it on crash.
                 // The .dbg.so / .dbg debug sidecars stay in the package and are consumed at symbol-upload time only.
                 var linuxPluginDir = GetLinuxPluginDir(buildOutputDir);
@@ -222,7 +236,7 @@ public static class BuildPostProcess
                     yield return new NativePluginArtifact(
                         file,
                         isSharedObject
-                            ? Path.Combine(linuxPluginDir, name)
+                            ? Path.Combine(linuxPluginDir, LinuxLibName)
                             : Path.Combine(buildOutputDir, name),
                         isExecutable: !isSharedObject);
                 }
@@ -242,11 +256,8 @@ public static class BuildPostProcess
         }
     }
 
-    // On case-insensitive APFS, leftover artifacts from a prior build with
-    // the *other* macOS backend break DllImport("sentry") resolution
-    // (Sentry.dylib gets picked over libsentry.dylib, surfacing as
-    // `sentry_options_new` not found at runtime). Wipe both candidates
-    // before copying the current backend's files in.
+    // Wipe the other backend's dylib before copying the current backend's files in, so an
+    // iterative build does not leave both libraries sitting in PlugIns.
     private static void CleanupStaleMacOSArtifacts(IDiagnosticLogger logger, string executablePath)
     {
         var contents = Path.Combine(executablePath, "Contents");
@@ -254,6 +265,7 @@ public static class BuildPostProcess
         {
             Path.Combine(contents, "PlugIns", "Sentry.dylib"),
             Path.Combine(contents, "PlugIns", "libsentry.dylib"),
+            Path.Combine(contents, "PlugIns", MacosLibName),
             Path.Combine(contents, "MacOS", "sentry-crash"),
         })
         {
@@ -277,6 +289,8 @@ public static class BuildPostProcess
             Path.Combine(buildOutputDir, "crashpad_wer.dll"),
             Path.Combine(buildOutputDir, "sentry-crash.exe"),
             Path.Combine(buildOutputDir, "sentry-wer.dll"),
+            Path.Combine(buildOutputDir, "sentry.dll"),
+            Path.Combine(buildOutputDir, WindowsLibName),
         })
         {
             if (File.Exists(stale))
@@ -311,6 +325,7 @@ public static class BuildPostProcess
         if (dataDir is not null)
         {
             stalePaths.Add(Path.Combine(dataDir, "Plugins", "x86_64", "libsentry.so"));
+            stalePaths.Add(Path.Combine(dataDir, "Plugins", "x86_64", LinuxLibName));
         }
 
         foreach (var stale in stalePaths)

--- a/src/Sentry.Unity.Native/CFunctions.cs
+++ b/src/Sentry.Unity.Native/CFunctions.cs
@@ -10,8 +10,12 @@ internal static class C
 {
 #if SENTRY_NATIVE_SWITCH
     private const string SentryLib = "__Internal";
-#else
+#elif SENTRY_NATIVE_PLAYSTATION || SENTRY_NATIVE_XBOX
     private const string SentryLib = "sentry";
+#else
+    // "sentry" would bind to the managed Sentry.dll on Windows, so BuildPostProcess copies the
+    // native library in under this name
+    private const string SentryLib = "sentry-native";
 #endif
 
     internal static void SetValueIfNotNull(sentry_value_t obj, string key, string? value)

--- a/src/Sentry.Unity.Native/CFunctions.cs
+++ b/src/Sentry.Unity.Native/CFunctions.cs
@@ -10,11 +10,11 @@ internal static class C
 {
 #if SENTRY_NATIVE_SWITCH
     private const string SentryLib = "__Internal";
-#elif SENTRY_NATIVE_PLAYSTATION || SENTRY_NATIVE_XBOX
+#elif SENTRY_NATIVE_ANDROID || SENTRY_NATIVE_PLAYSTATION || SENTRY_NATIVE_XBOX
     private const string SentryLib = "sentry";
 #else
     // "sentry" would bind to the managed Sentry.dll on Windows, so BuildPostProcess copies the
-    // native library in under this name
+    // native library in under this name. Android and the consoles ship theirs from elsewhere
     private const string SentryLib = "sentry-native";
 #endif
 

--- a/src/Sentry.Unity.Native/Sentry.Unity.Native.csproj
+++ b/src/Sentry.Unity.Native/Sentry.Unity.Native.csproj
@@ -65,4 +65,24 @@
     />
   </Target>
 
+  <!-- Build Android version after the Xbox build. Android's libsentry.so comes from the
+       sentry-android-ndk AAR, so it keeps the original import name -->
+  <Target Name="BuildAndroidAssembly" AfterTargets="BuildXboxAssembly">
+    <Message Importance="High" Text="Building Android-specific native assembly." />
+
+    <Csc
+      Sources="@(Compile)"
+      References="@(ReferencePath)"
+      OutputAssembly="$(OutDir)Sentry.Unity.Native.Android.dll"
+      DefineConstants="$(DefineConstants);SENTRY_NATIVE_ANDROID"
+      TargetType="library"
+      EmitDebugInformation="true"
+      DebugType="portable"
+      Nullable="$(Nullable)"
+      LangVersion="$(LangVersion)"
+      TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
+      WarningLevel="$(WarningLevel)"
+    />
+  </Target>
+
 </Project>

--- a/src/Sentry.Unity.Native/SentryNative.cs
+++ b/src/Sentry.Unity.Native/SentryNative.cs
@@ -140,7 +140,7 @@ public static class SentryNative
         }
         catch (EntryPointNotFoundException e)
         {
-            Logger?.LogError(e, "Native dependency not found. Did you delete sentry.dll or move files around?");
+            Logger?.LogError(e, "Native dependency not found. Did you delete the native Sentry library or move files around?");
         }
     }
 }

--- a/src/Sentry.Unity.Native/SentryNativeBridge.cs
+++ b/src/Sentry.Unity.Native/SentryNativeBridge.cs
@@ -16,8 +16,12 @@ internal static class SentryNativeBridge
 {
 #if SENTRY_NATIVE_SWITCH
     private const string SentryLib = "__Internal";
-#else
+#elif SENTRY_NATIVE_PLAYSTATION || SENTRY_NATIVE_XBOX
     private const string SentryLib = "sentry";
+#else
+    // "sentry" would bind to the managed Sentry.dll on Windows, so BuildPostProcess copies the
+    // native library in under this name
+    private const string SentryLib = "sentry-native";
 #endif
 
     private static IDiagnosticLogger? Logger; // This is also the logger we're forwarding native messages to.

--- a/src/Sentry.Unity.Native/SentryNativeBridge.cs
+++ b/src/Sentry.Unity.Native/SentryNativeBridge.cs
@@ -16,11 +16,11 @@ internal static class SentryNativeBridge
 {
 #if SENTRY_NATIVE_SWITCH
     private const string SentryLib = "__Internal";
-#elif SENTRY_NATIVE_PLAYSTATION || SENTRY_NATIVE_XBOX
+#elif SENTRY_NATIVE_ANDROID || SENTRY_NATIVE_PLAYSTATION || SENTRY_NATIVE_XBOX
     private const string SentryLib = "sentry";
 #else
     // "sentry" would bind to the managed Sentry.dll on Windows, so BuildPostProcess copies the
-    // native library in under this name
+    // native library in under this name. Android and the consoles ship theirs from elsewhere
     private const string SentryLib = "sentry-native";
 #endif
 
@@ -169,7 +169,6 @@ internal static class SentryNativeBridge
 
     internal static void AppHangPause() => sentry_app_hang_pause();
 
-    // libsentry.so
     [DllImport(SentryLib)]
     private static extern IntPtr sentry_options_new();
 

--- a/src/Sentry.Unity/Properties/AssemblyInfo.cs
+++ b/src/Sentry.Unity/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Sentry.Unity.Native.PlayStation")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Native.Switch")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Native.Xbox")]
+[assembly: InternalsVisibleTo("Sentry.Unity.Native.Android")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Tests")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Editor")]
 [assembly: InternalsVisibleTo("Sentry.Unity.Editor.Tests")]

--- a/test/Scripts.Tests/package-release.zip.snapshot
+++ b/test/Scripts.Tests/package-release.zip.snapshot
@@ -321,6 +321,10 @@ Runtime/Sentry.Unity.MacOS.dll
 Runtime/Sentry.Unity.MacOS.dll.meta
 Runtime/Sentry.Unity.MacOS.pdb
 Runtime/Sentry.Unity.MacOS.pdb.meta
+Runtime/Sentry.Unity.Native.Android.dll
+Runtime/Sentry.Unity.Native.Android.dll.meta
+Runtime/Sentry.Unity.Native.Android.pdb
+Runtime/Sentry.Unity.Native.Android.pdb.meta
 Runtime/Sentry.Unity.Native.dll
 Runtime/Sentry.Unity.Native.dll.meta
 Runtime/Sentry.Unity.Native.pdb


### PR DESCRIPTION
Fixed native crash capture on Windows with the Mono scripting backend. The native library is now copied into the player as `sentry-native`, so `DllImport` can no longer resolve to the managed `Sentry.dll` sitting beside it in `Managed/` https://github.com/getsentry/sentry-unity/issues/2818


Built with fable, if you have a better idea of how to fix this, I would not complain 