### PR TITLE
fix: harden the `UnityLogger` from throwing while logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- The `UnityLogger` no longer throws while logging an exception whose stack trace cannot be stringified. On Nintendo Switch this escaped from inside the handler that had already dealt with the original error, aborting SDK initialization and leaving the Unity integrations unregistered ([#2832](https://github.com/getsentry/sentry-unity/pull/2832))
+- Hardened the `UnityLogger` to no longer throw when failing to format a log message. ([#2832](https://github.com/getsentry/sentry-unity/pull/2832))
 - IL2CPP line numbers now work on Android x86/x86_64 builds. il2cpp fails to report the image UUID there, so the SDK falls back to looking the debug image up by name ([#2817](https://github.com/getsentry/sentry-unity/pull/2817))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- The `UnityLogger` no longer throws while logging an exception whose stack trace cannot be stringified. On Nintendo Switch this escaped from inside the handler that had already dealt with the original error, aborting SDK initialization and leaving the Unity integrations unregistered ([#2832](https://github.com/getsentry/sentry-unity/pull/2832))
 - IL2CPP line numbers now work on Android x86/x86_64 builds. il2cpp fails to report the image UUID there, so the SDK falls back to looking the debug image up by name ([#2817](https://github.com/getsentry/sentry-unity/pull/2817))
 
 ### Dependencies

--- a/src/Sentry.Unity/UnityLogger.cs
+++ b/src/Sentry.Unity/UnityLogger.cs
@@ -30,7 +30,59 @@ public class UnityLogger : IDiagnosticLogger
             return;
         }
 
-        _logger.Log(GetUnityLogType(logLevel), LogTag, $"({logLevel.ToString()}) {Format(message, args)} {exception}");
+        // A diagnostic logger must never take its caller down with it. Callers routinely log from
+        // inside a `catch` that already handled the failure - if logging throws there, a handled
+        // error turns into a fatal one. That is not hypothetical: on Nintendo Switch some
+        // exceptions throw again while their stack trace is being stringified, which aborted SDK
+        // initialization from inside the handler that had already dealt with the original problem.
+        string logMessage;
+        try
+        {
+            logMessage = $"({logLevel.ToString()}) {Format(message, args)} {Describe(exception)}";
+        }
+        catch (Exception e)
+        {
+            logMessage = $"({logLevel.ToString()}) Failed to format log message: {e.GetType().Name}";
+        }
+
+        try
+        {
+            _logger.Log(GetUnityLogType(logLevel), LogTag, logMessage);
+        }
+        catch
+        {
+            // Reporting a logging failure would have to go through the very thing that just failed.
+        }
+    }
+
+    /// <summary>
+    /// Renders an exception without trusting <see cref="Exception.ToString"/>, which walks the
+    /// stack trace and can throw on platforms with limited stack trace support.
+    /// </summary>
+    private static string Describe(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return Empty;
+        }
+
+        try
+        {
+            return exception.ToString();
+        }
+        catch (Exception e)
+        {
+            // Type and message are cheap to read and usually survive when the stack trace does not.
+            try
+            {
+                return $"{exception.GetType().FullName}: {exception.Message}" +
+                       $" (stack trace unavailable: {e.GetType().Name})";
+            }
+            catch
+            {
+                return "<exception details unavailable>";
+            }
+        }
     }
 
     internal static LogType GetUnityLogType(SentryLevel logLevel)

--- a/src/Sentry.Unity/UnityLogger.cs
+++ b/src/Sentry.Unity/UnityLogger.cs
@@ -31,10 +31,7 @@ public class UnityLogger : IDiagnosticLogger
         }
 
         // A diagnostic logger must never take its caller down with it. Callers routinely log from
-        // inside a `catch` that already handled the failure - if logging throws there, a handled
-        // error turns into a fatal one. That is not hypothetical: on Nintendo Switch some
-        // exceptions throw again while their stack trace is being stringified, which aborted SDK
-        // initialization from inside the handler that had already dealt with the original problem.
+        // inside a `catch` that already handled the failure.
         string logMessage;
         try
         {
@@ -42,7 +39,8 @@ public class UnityLogger : IDiagnosticLogger
         }
         catch (Exception e)
         {
-            logMessage = $"({logLevel.ToString()}) Failed to format log message: {e.GetType().Name}";
+            // Keep the raw message - a bad format string shouldn't erase what the caller wanted to say.
+            logMessage = $"({logLevel.ToString()}) {message} (formatting failed: {e.GetType().Name})";
         }
 
         try
@@ -57,7 +55,7 @@ public class UnityLogger : IDiagnosticLogger
 
     /// <summary>
     /// Renders an exception without trusting <see cref="Exception.ToString"/>, which walks the
-    /// stack trace and can throw on platforms with limited stack trace support.
+    /// stack trace and can throw on platforms with limited stack trace support, i.e. Nintendo Switch.
     /// </summary>
     private static string Describe(Exception? exception)
     {
@@ -72,7 +70,6 @@ public class UnityLogger : IDiagnosticLogger
         }
         catch (Exception e)
         {
-            // Type and message are cheap to read and usually survive when the stack trace does not.
             try
             {
                 return $"{exception.GetType().FullName}: {exception.Message}" +

--- a/test/Sentry.Unity.Tests/UnityLoggerTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLoggerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Sentry.Unity.Tests.SharedClasses;
 using UnityEngine;
@@ -49,5 +50,53 @@ public sealed class UnityLoggerTests
         Assert.AreEqual(1, testLogger.Logs.Count);
         // The format is: "(logType, tag, message)"
         StringAssert.AreEqualIgnoringCase(UnityLogger.LogTag, testLogger.Logs[0].Item2);
+    }
+
+    /// <summary>
+    /// Callers log from inside `catch` blocks that already handled the failure. If the logger
+    /// throws there, a handled error becomes a fatal one - which is how SDK initialization aborted
+    /// on Nintendo Switch, where stringifying certain exceptions throws again.
+    /// </summary>
+    [Test]
+    public void Log_ExceptionThrowsWhileBeingStringified_DoesNotPropagateAndStillLogs()
+    {
+        var testLogger = new UnityTestLogger();
+        var logger = new UnityLogger(new SentryOptions { DiagnosticLevel = SentryLevel.Debug }, testLogger);
+
+        Assert.DoesNotThrow(() =>
+            logger.Log(SentryLevel.Error, "Something failed", new ThrowingToStringException()));
+
+        Assert.AreEqual(1, testLogger.Logs.Count);
+        var message = testLogger.Logs[0].Item3;
+        StringAssert.Contains("Something failed", message);
+        StringAssert.Contains(nameof(ThrowingToStringException), message);
+    }
+
+    [Test]
+    public void Log_MessageAndArgumentsDoNotMatch_DoesNotPropagate()
+    {
+        var testLogger = new UnityTestLogger();
+        var logger = new UnityLogger(new SentryOptions { DiagnosticLevel = SentryLevel.Debug }, testLogger);
+
+        // More placeholders than arguments - string.Format throws on this.
+        Assert.DoesNotThrow(() => logger.Log(SentryLevel.Debug, "{0} {1} {2}", null, "only-one"));
+
+        Assert.AreEqual(1, testLogger.Logs.Count);
+    }
+
+    private sealed class ThrowingToStringException : Exception
+    {
+        public ThrowingToStringException()
+        { }
+
+        public ThrowingToStringException(string message) : base(message)
+        { }
+
+        public ThrowingToStringException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        public override string ToString() => throw new InvalidOperationException("cannot stringify");
+
+        public override string StackTrace => throw new InvalidOperationException("no stack trace here");
     }
 }

--- a/test/Sentry.Unity.Tests/UnityLoggerTests.cs
+++ b/test/Sentry.Unity.Tests/UnityLoggerTests.cs
@@ -53,9 +53,7 @@ public sealed class UnityLoggerTests
     }
 
     /// <summary>
-    /// Callers log from inside `catch` blocks that already handled the failure. If the logger
-    /// throws there, a handled error becomes a fatal one - which is how SDK initialization aborted
-    /// on Nintendo Switch, where stringifying certain exceptions throws again.
+    /// Callers log from inside `catch` blocks that already handled the failure.
     /// </summary>
     [Test]
     public void Log_ExceptionThrowsWhileBeingStringified_DoesNotPropagateAndStillLogs()
@@ -73,7 +71,7 @@ public sealed class UnityLoggerTests
     }
 
     [Test]
-    public void Log_MessageAndArgumentsDoNotMatch_DoesNotPropagate()
+    public void Log_MessageAndArgumentsDoNotMatch_DoesNotPropagateAndKeepsTheRawMessage()
     {
         var testLogger = new UnityTestLogger();
         var logger = new UnityLogger(new SentryOptions { DiagnosticLevel = SentryLevel.Debug }, testLogger);
@@ -82,6 +80,8 @@ public sealed class UnityLoggerTests
         Assert.DoesNotThrow(() => logger.Log(SentryLevel.Debug, "{0} {1} {2}", null, "only-one"));
 
         Assert.AreEqual(1, testLogger.Logs.Count);
+        // The unformatted message is still worth more than a bare "formatting failed".
+        StringAssert.Contains("{0} {1} {2}", testLogger.Logs[0].Item3);
     }
 
     private sealed class ThrowingToStringException : Exception


### PR DESCRIPTION
## The bug

A diagnostic logger must never take its caller down with it. I.e. when logging from inside a `catch` that has already handled the failure. Throwing inside the catch because logging? You're in for a bad time.

`UnityLogger.Log` interpolated the exception directly:

```csharp
_logger.Log(GetUnityLogType(logLevel), LogTag, $"({logLevel}) {Format(message, args)} {exception}");
```

So anything that threw while being stringified escaped from within the handler.

## The fix

Format the message and render the exception defensively, and never let the write to Unity's logger propagate. The exception falls back to type and message when the stack trace cannot be read, so the error stays legible instead of disappearing.

Example:
```
Sentry: (Error) Failed to resolve hardware installation ID.
  System.TypeInitializationException: The type initializer for
  'System.Net.NetworkInformation.SystemNetworkInterface' threw an exception.
  (stack trace unavailable: TypeInitializationException)
Sentry: (Debug) Registering integration: 'UnityLogHandlerIntegration'.
...
```