### PR TITLE
fix(switch): stop offline sends raising the system connection dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixes
 
 - IL2CPP line numbers now work on Android x86/x86_64 builds. il2cpp fails to report the image UUID there, so the SDK falls back to looking the debug image up by name ([#2817](https://github.com/getsentry/sentry-unity/pull/2817))
+### Fixes
+
+- The `UnityWebRequestTransport` no longer opens a connection while the platform reports no network, and backs off exponentially (1s up to 60s) after a connection error instead of retrying on every envelope. On Nintendo Switch each send attempt made while offline raises the system's "connect to the internet" dialog, so a game with logs or metrics enabled produced a prompt every few seconds ([#TBD](https://github.com/getsentry/sentry-unity/pull/TBD))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@
 ### Fixes
 
 - IL2CPP line numbers now work on Android x86/x86_64 builds. il2cpp fails to report the image UUID there, so the SDK falls back to looking the debug image up by name ([#2817](https://github.com/getsentry/sentry-unity/pull/2817))
-### Fixes
-
-- The `UnityWebRequestTransport` no longer opens a connection while the platform reports no network, and backs off exponentially (1s up to 60s) after a connection error instead of retrying on every envelope. On Nintendo Switch each send attempt made while offline raises the system's "connect to the internet" dialog, so a game with logs or metrics enabled produced a prompt every few seconds ([#TBD](https://github.com/getsentry/sentry-unity/pull/TBD))
+- The `UnityWebRequestTransport` no longer opens a connection while the platform reports no network, and backs off exponentially (1s up to 60s) after a connection error instead of retrying on every envelope. On Nintendo Switch each send attempt made while offline raises the system's "connect to the internet" dialog, so a game with logs or metrics enabled produced a prompt every few seconds ([#2833](https://github.com/getsentry/sentry-unity/pull/2833))
+- On Nintendo Switch the SDK now asks the native SDK whether the network is usable before sending, instead of relying on `Application.internetReachability`, which reports the console as reachable while it is offline. Every send attempted in that state raised the system's "connect to the internet" dialog. Requires a sentry-switch build exposing `sentry_switch_utils_is_network_available()` ([#2833](https://github.com/getsentry/sentry-unity/pull/2833))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Fixes
 
 - IL2CPP line numbers now work on Android x86/x86_64 builds. il2cpp fails to report the image UUID there, so the SDK falls back to looking the debug image up by name ([#2817](https://github.com/getsentry/sentry-unity/pull/2817))
-- The `UnityWebRequestTransport` no longer opens a connection while the platform reports no network, and backs off exponentially (1s up to 60s) after a connection error instead of retrying on every envelope. On Nintendo Switch each send attempt made while offline raises the system's "connect to the internet" dialog, so a game with logs or metrics enabled produced a prompt every few seconds ([#2833](https://github.com/getsentry/sentry-unity/pull/2833))
-- On Nintendo Switch the SDK now asks the native SDK whether the network is usable before sending, instead of relying on `Application.internetReachability`, which reports the console as reachable while it is offline. Every send attempted in that state raised the system's "connect to the internet" dialog. Requires a sentry-switch build exposing `sentry_switch_utils_is_network_available()` ([#2833](https://github.com/getsentry/sentry-unity/pull/2833))
+- When targeting WebGL or Nintendo Switch without native support, `UnityWebRequestTransport` no longer opens a connection while the platform reports no network, and backs off exponentially (1s up to 300s) after a connection error instead of retrying on every envelope. ([#2833](https://github.com/getsentry/sentry-unity/pull/2833))
+- When targeting Nintendo Switch, the SDK now utilizes sentry-switch to poll the network status before sending. ([#2833](https://github.com/getsentry/sentry-unity/pull/2833))
 
 ### Dependencies
 

--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -410,8 +410,7 @@ const char* sentry_switch_utils_get_default_user_id(void)
 
 int sentry_switch_utils_is_network_available(void)
 {
-    /* Return 1 - with no native SDK to ask, assume the network is usable and let the
-       transport fall back on its connection-error backoff */
+    /* No native SDK to ask - assume usable and let the transport's backoff take over */
     return 1;
 }
 

--- a/package-dev/Plugins/Switch/sentry_native_stubs.c
+++ b/package-dev/Plugins/Switch/sentry_native_stubs.c
@@ -408,6 +408,13 @@ const char* sentry_switch_utils_get_default_user_id(void)
     return "";
 }
 
+int sentry_switch_utils_is_network_available(void)
+{
+    /* Return 1 - with no native SDK to ask, assume the network is usable and let the
+       transport fall back on its connection-error backoff */
+    return 1;
+}
+
 /*
  * =============================================================================
  * Utility Functions

--- a/src/Sentry.Unity.Native/SentryNativeSwitch.cs
+++ b/src/Sentry.Unity.Native/SentryNativeSwitch.cs
@@ -28,7 +28,20 @@ public static class SentryNativeSwitch
     [DllImport("__Internal")]
     private static extern IntPtr sentry_switch_utils_get_default_user_id();
 
+    [DllImport("__Internal")]
+    private static extern int sentry_switch_utils_is_network_available();
+
     private static IDiagnosticLogger? Logger;
+
+    /// <summary>
+    /// Queries the network interface manager without submitting a network request.
+    /// </summary>
+    /// <remarks>
+    /// Unity's <c>Application.internetReachability</c> reports the console as reachable even while
+    /// it is offline, and every send attempted in that state raises the system's "connect to the
+    /// internet" dialog. Asking the native SDK first is what keeps the dialog off the screen.
+    /// </remarks>
+    internal static bool IsNetworkAvailable() => sentry_switch_utils_is_network_available() == 1;
 
     /// <summary>
     /// Configures the native support for Nintendo Switch.
@@ -71,6 +84,11 @@ public static class SentryNativeSwitch
             Logger?.LogDebug("Native support is disabled for '{0}'.", platform);
             return;
         }
+
+        // Wired up before the storage and native SDK setup below: the probe only needs the native
+        // library to be linked, so the transport keeps the benefit even if either of those fails.
+        Logger?.LogDebug("Using the native SDK to determine network availability.");
+        options.NetworkAvailabilityProbe = IsNetworkAvailable;
 
         Logger?.LogDebug("Mounting temporary storage for sentry-switch.");
 

--- a/src/Sentry.Unity.Native/SentryNativeSwitch.cs
+++ b/src/Sentry.Unity.Native/SentryNativeSwitch.cs
@@ -84,7 +84,6 @@ public static class SentryNativeSwitch
             return;
         }
 
-        // The probe only needs the native library linked, so it survives a failure of the setup below.
         Logger?.LogDebug("Using the native SDK to determine network availability.");
         options.NetworkAvailabilityProbe = IsNetworkAvailable;
 

--- a/src/Sentry.Unity.Native/SentryNativeSwitch.cs
+++ b/src/Sentry.Unity.Native/SentryNativeSwitch.cs
@@ -34,12 +34,11 @@ public static class SentryNativeSwitch
     private static IDiagnosticLogger? Logger;
 
     /// <summary>
-    /// Queries the network interface manager without submitting a network request.
+    /// Whether the console currently has a usable network.
     /// </summary>
     /// <remarks>
-    /// Unity's <c>Application.internetReachability</c> reports the console as reachable even while
-    /// it is offline, and every send attempted in that state raises the system's "connect to the
-    /// internet" dialog. Asking the native SDK first is what keeps the dialog off the screen.
+    /// <c>Application.internetReachability</c> reports the console as reachable while it is offline,
+    /// and every send attempted in that state raises the system's "connect to the internet" dialog.
     /// </remarks>
     internal static bool IsNetworkAvailable() => sentry_switch_utils_is_network_available() == 1;
 
@@ -85,8 +84,7 @@ public static class SentryNativeSwitch
             return;
         }
 
-        // Wired up before the storage and native SDK setup below: the probe only needs the native
-        // library to be linked, so the transport keeps the benefit even if either of those fails.
+        // The probe only needs the native library linked, so it survives a failure of the setup below.
         Logger?.LogDebug("Using the native SDK to determine network availability.");
         options.NetworkAvailabilityProbe = IsNetworkAvailable;
 

--- a/src/Sentry.Unity/Integrations/IApplication.cs
+++ b/src/Sentry.Unity/Integrations/IApplication.cs
@@ -17,6 +17,7 @@ internal interface IApplication
     string UnityVersion { get; }
     string PersistentDataPath { get; }
     RuntimePlatform Platform { get; }
+    NetworkReachability InternetReachability { get; }
 }
 
 /// <summary>
@@ -53,6 +54,8 @@ public sealed class ApplicationAdapter : IApplication
     public string PersistentDataPath => Application.persistentDataPath;
 
     public RuntimePlatform Platform => Application.platform;
+
+    public NetworkReachability InternetReachability => Application.internetReachability;
 
     private void OnLogMessageReceived(string condition, string stackTrace, LogType type)
         => LogMessageReceived?.Invoke(condition, stackTrace, type);

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -494,14 +494,11 @@ public sealed class SentryUnityOptions : SentryOptions
     internal Action? NativeSupportCloseCallback { get; set; } = null;
 
     /// <summary>
-    /// Reports whether the network is currently usable, when the platform can answer that more
-    /// reliably than <see cref="UnityEngine.Application.internetReachability"/>.
+    /// Reports whether the network is usable on platforms where
+    /// <see cref="UnityEngine.Application.internetReachability"/> cannot be trusted.
     /// </summary>
     /// <remarks>
-    /// Set by the platform configuration where a native probe exists. On Nintendo Switch this
-    /// matters twice over: reachability reports the console as reachable while it is offline, and
-    /// merely attempting a connection there raises the system's "connect to the internet" dialog.
-    /// Must not block - it is called on the main thread before each send.
+    /// Must not block - the transport calls this on the main thread before each send.
     /// </remarks>
     internal Func<bool>? NetworkAvailabilityProbe { get; set; } = null;
 

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -493,6 +493,18 @@ public sealed class SentryUnityOptions : SentryOptions
     /// </summary>
     internal Action? NativeSupportCloseCallback { get; set; } = null;
 
+    /// <summary>
+    /// Reports whether the network is currently usable, when the platform can answer that more
+    /// reliably than <see cref="UnityEngine.Application.internetReachability"/>.
+    /// </summary>
+    /// <remarks>
+    /// Set by the platform configuration where a native probe exists. On Nintendo Switch this
+    /// matters twice over: reachability reports the console as reachable while it is offline, and
+    /// merely attempting a connection there raises the system's "connect to the internet" dialog.
+    /// Must not block - it is called on the main thread before each send.
+    /// </remarks>
+    internal Func<bool>? NetworkAvailabilityProbe { get; set; } = null;
+
     internal List<string> SdkIntegrationNames { get; set; } = new();
 
     internal ISentryUnityInfo UnityInfo { get; private set; }

--- a/src/Sentry.Unity/SentryUnityOptions.cs
+++ b/src/Sentry.Unity/SentryUnityOptions.cs
@@ -493,13 +493,6 @@ public sealed class SentryUnityOptions : SentryOptions
     /// </summary>
     internal Action? NativeSupportCloseCallback { get; set; } = null;
 
-    /// <summary>
-    /// Reports whether the network is usable on platforms where
-    /// <see cref="UnityEngine.Application.internetReachability"/> cannot be trusted.
-    /// </summary>
-    /// <remarks>
-    /// Must not block - the transport calls this on the main thread before each send.
-    /// </remarks>
     internal Func<bool>? NetworkAvailabilityProbe { get; set; } = null;
 
     internal List<string> SdkIntegrationNames { get; set; } = new();

--- a/src/Sentry.Unity/UnityWebRequestTransport.cs
+++ b/src/Sentry.Unity/UnityWebRequestTransport.cs
@@ -6,7 +6,11 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Sentry.Extensibility;
 using Sentry.Http;
+using Sentry.Internal;
+using Sentry.Internal.Extensions;
 using Sentry.Protocol.Envelopes;
+using Sentry.Unity.Integrations;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace Sentry.Unity;
@@ -51,13 +55,36 @@ internal class UnityWebRequestTransport : HttpTransportBase
 {
     private readonly SentryUnityOptions _options;
 
-    public UnityWebRequestTransport(SentryUnityOptions options)
+    // This transport opens a connection per envelope. On platforms that raise a system dialog
+    // when the game reaches for an unavailable network - Nintendo Switch prompts to connect to
+    // the internet - every attempt made while offline puts that dialog on screen. A game with
+    // logs and metrics enabled flushes an envelope every few seconds, so a blind retry per
+    // envelope turns into a steady stream of prompts. Two guards bound that: the reachability
+    // check skips sending altogether while the platform reports no network, and the backoff
+    // spaces out attempts on platforms where reachability cannot be trusted.
+    private const double InitialBackoffSeconds = 1.0;
+    private const double MaxBackoffSeconds = 60.0;
+
+    private readonly IApplication _application;
+
+    private int _consecutiveConnectionErrors;
+    private double _retryAfterRealtime;
+
+    public UnityWebRequestTransport(SentryUnityOptions options, IApplication? application = null)
         : base(options)
-        => _options = options;
+    {
+        _options = options;
+        _application = application ?? ApplicationAdapter.Instance;
+    }
 
     // adapted HttpTransport.SendEnvelopeAsync()
     internal IEnumerator SendEnvelopeAsync(Envelope envelope)
     {
+        if (!CanAttemptSend(envelope))
+        {
+            yield break;
+        }
+
         using var processedEnvelope = ProcessEnvelope(envelope);
         if (processedEnvelope.Items.Count > 0)
         {
@@ -66,12 +93,80 @@ internal class UnityWebRequestTransport : HttpTransportBase
             var www = CreateWebRequest(httpRequest);
             yield return www.SendWebRequest();
 
+            if (www.result == UnityWebRequest.Result.ConnectionError)
+            {
+                OnConnectionError(www, processedEnvelope);
+                yield break;
+            }
+
+            OnConnectionSucceeded();
+
             var response = GetResponse(www);
             if (response is not null)
             {
                 HandleResponse(response, processedEnvelope);
             }
         }
+    }
+
+    /// <summary>
+    /// Whether it is worth opening a connection for this envelope. Envelopes dropped here are
+    /// recorded as discarded so client reports still account for them.
+    /// </summary>
+    private bool CanAttemptSend(Envelope envelope)
+    {
+        if (_application.InternetReachability == NetworkReachability.NotReachable)
+        {
+            _options.LogDebug("No network available. Dropping envelope instead of attempting to send.");
+            _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
+            return false;
+        }
+
+        if (_consecutiveConnectionErrors > 0)
+        {
+            var remaining = _retryAfterRealtime - Time.realtimeSinceStartupAsDouble;
+            if (remaining > 0.0)
+            {
+                _options.LogDebug(
+                    "Backing off after {0} failed connection attempt(s). Dropping envelope, retrying in {1:F1}s.",
+                    _consecutiveConnectionErrors, remaining);
+                _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void OnConnectionError(UnityWebRequest www, Envelope envelope)
+    {
+        _consecutiveConnectionErrors++;
+
+        var backoff = Math.Min(
+            MaxBackoffSeconds,
+            InitialBackoffSeconds * Math.Pow(2, _consecutiveConnectionErrors - 1));
+        _retryAfterRealtime = Time.realtimeSinceStartupAsDouble + backoff;
+
+        // Reachability is logged here because a platform reporting itself reachable while the
+        // connection fails is exactly the case the backoff exists to cover.
+        var backoffDetail = $"{backoff:F1}s (consecutive failure #{_consecutiveConnectionErrors})";
+        _options.LogWarning(
+            "Failed to send request: {0}. Reachability reported as {1}. Backing off for {2}.",
+            www.error, _application.InternetReachability, backoffDetail);
+
+        _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
+    }
+
+    private void OnConnectionSucceeded()
+    {
+        if (_consecutiveConnectionErrors == 0)
+        {
+            return;
+        }
+
+        _options.LogDebug("Connection restored after {0} failed attempt(s).", _consecutiveConnectionErrors);
+        _consecutiveConnectionErrors = 0;
+        _retryAfterRealtime = 0.0;
     }
 
     private UnityWebRequest CreateWebRequest(HttpRequestMessage message)

--- a/src/Sentry.Unity/UnityWebRequestTransport.cs
+++ b/src/Sentry.Unity/UnityWebRequestTransport.cs
@@ -110,12 +110,27 @@ internal class UnityWebRequestTransport : HttpTransportBase
     }
 
     /// <summary>
+    /// Whether the platform reports a usable network. Prefers the platform's own probe where one
+    /// is available, because Unity's reachability cannot always be trusted - on Nintendo Switch it
+    /// reports the console as reachable while it is offline.
+    /// </summary>
+    private bool IsNetworkAvailable()
+    {
+        if (_options.NetworkAvailabilityProbe is { } probe)
+        {
+            return probe();
+        }
+
+        return _application.InternetReachability != NetworkReachability.NotReachable;
+    }
+
+    /// <summary>
     /// Whether it is worth opening a connection for this envelope. Envelopes dropped here are
     /// recorded as discarded so client reports still account for them.
     /// </summary>
     private bool CanAttemptSend(Envelope envelope)
     {
-        if (_application.InternetReachability == NetworkReachability.NotReachable)
+        if (!IsNetworkAvailable())
         {
             _options.LogDebug("No network available. Dropping envelope instead of attempting to send.");
             _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);

--- a/src/Sentry.Unity/UnityWebRequestTransport.cs
+++ b/src/Sentry.Unity/UnityWebRequestTransport.cs
@@ -94,6 +94,7 @@ internal class UnityWebRequestTransport : HttpTransportBase
 
                 _options.LogWarning("Failed to send request: {0}. Backing off for {1:F1}s.", www.error, _backoffSeconds);
                 _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, processedEnvelope);
+                RestoreClientReports(processedEnvelope);
                 yield break;
             }
 
@@ -104,6 +105,20 @@ internal class UnityWebRequestTransport : HttpTransportBase
             if (response is not null)
             {
                 HandleResponse(response, processedEnvelope);
+            }
+        }
+    }
+
+    // ProcessEnvelope drains the recorder into a client report item. Restore those counts instead of
+    // losing them along with the envelope we failed to send.
+    private void RestoreClientReports(Envelope envelope)
+    {
+        foreach (var item in envelope.Items)
+        {
+            if (item.TryGetType() == EnvelopeItem.TypeValueClientReport &&
+                item.Payload is JsonSerializable { Source: ClientReport report })
+            {
+                _options.ClientReportRecorder.Load(report);
             }
         }
     }

--- a/src/Sentry.Unity/UnityWebRequestTransport.cs
+++ b/src/Sentry.Unity/UnityWebRequestTransport.cs
@@ -55,13 +55,10 @@ internal class UnityWebRequestTransport : HttpTransportBase
 {
     private readonly SentryUnityOptions _options;
 
-    // This transport opens a connection per envelope. On platforms that raise a system dialog
-    // when the game reaches for an unavailable network - Nintendo Switch prompts to connect to
-    // the internet - every attempt made while offline puts that dialog on screen. A game with
-    // logs and metrics enabled flushes an envelope every few seconds, so a blind retry per
-    // envelope turns into a steady stream of prompts. Two guards bound that: the reachability
-    // check skips sending altogether while the platform reports no network, and the backoff
-    // spaces out attempts on platforms where reachability cannot be trusted.
+    // This transport opens a connection per envelope, and on Nintendo Switch every attempt made
+    // while offline raises the system's "connect to the internet" dialog. With logs or metrics
+    // enabled that is a prompt every few seconds, so sends are gated on network availability and
+    // spaced out by a backoff where availability cannot be trusted.
     private const double InitialBackoffSeconds = 1.0;
     private const double MaxBackoffSeconds = 60.0;
 
@@ -110,9 +107,8 @@ internal class UnityWebRequestTransport : HttpTransportBase
     }
 
     /// <summary>
-    /// Whether the platform reports a usable network. Prefers the platform's own probe where one
-    /// is available, because Unity's reachability cannot always be trusted - on Nintendo Switch it
-    /// reports the console as reachable while it is offline.
+    /// Whether the platform reports a usable network. The platform's own probe wins over
+    /// reachability, which on Nintendo Switch claims the console is reachable while it is offline.
     /// </summary>
     private bool IsNetworkAvailable()
     {
@@ -125,8 +121,8 @@ internal class UnityWebRequestTransport : HttpTransportBase
     }
 
     /// <summary>
-    /// Whether it is worth opening a connection for this envelope. Envelopes dropped here are
-    /// recorded as discarded so client reports still account for them.
+    /// Whether it is worth opening a connection for this envelope. Drops are recorded so client
+    /// reports still account for them.
     /// </summary>
     private bool CanAttemptSend(Envelope envelope)
     {
@@ -162,8 +158,8 @@ internal class UnityWebRequestTransport : HttpTransportBase
             InitialBackoffSeconds * Math.Pow(2, _consecutiveConnectionErrors - 1));
         _retryAfterRealtime = Time.realtimeSinceStartupAsDouble + backoff;
 
-        // Reachability is logged here because a platform reporting itself reachable while the
-        // connection fails is exactly the case the backoff exists to cover.
+        // Reachability is logged because a platform claiming to be reachable while the connection
+        // fails is the case the backoff exists to cover.
         var backoffDetail = $"{backoff:F1}s (consecutive failure #{_consecutiveConnectionErrors})";
         _options.LogWarning(
             "Failed to send request: {0}. Reachability reported as {1}. Backing off for {2}.",

--- a/src/Sentry.Unity/UnityWebRequestTransport.cs
+++ b/src/Sentry.Unity/UnityWebRequestTransport.cs
@@ -54,17 +54,10 @@ internal class WebBackgroundWorker : IBackgroundWorker
 internal class UnityWebRequestTransport : HttpTransportBase
 {
     private readonly SentryUnityOptions _options;
-
-    // This transport opens a connection per envelope, and on Nintendo Switch every attempt made
-    // while offline raises the system's "connect to the internet" dialog. With logs or metrics
-    // enabled that is a prompt every few seconds, so sends are gated on network availability and
-    // spaced out by a backoff where availability cannot be trusted.
-    private const double InitialBackoffSeconds = 1.0;
-    private const double MaxBackoffSeconds = 60.0;
-
     private readonly IApplication _application;
 
-    private int _consecutiveConnectionErrors;
+    private const double MaxBackoffSeconds = 300.0;
+    private double _backoffSeconds;
     private double _retryAfterRealtime;
 
     public UnityWebRequestTransport(SentryUnityOptions options, IApplication? application = null)
@@ -77,8 +70,12 @@ internal class UnityWebRequestTransport : HttpTransportBase
     // adapted HttpTransport.SendEnvelopeAsync()
     internal IEnumerator SendEnvelopeAsync(Envelope envelope)
     {
-        if (!CanAttemptSend(envelope))
+        // This transport opens a connection per envelope, causing a prompt to appear on platforms
+        // like Nintendo Switch while offline.
+        if (!IsNetworkAvailable() || Time.realtimeSinceStartupAsDouble < _retryAfterRealtime)
         {
+            _options.LogDebug("Network unavailable or backing off. Dropping envelope instead of attempting to send.");
+            _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
             yield break;
         }
 
@@ -92,11 +89,16 @@ internal class UnityWebRequestTransport : HttpTransportBase
 
             if (www.result == UnityWebRequest.Result.ConnectionError)
             {
-                OnConnectionError(www, processedEnvelope);
+                _backoffSeconds = Math.Min(MaxBackoffSeconds, _backoffSeconds > 0.0 ? _backoffSeconds * 2 : 1.0);
+                _retryAfterRealtime = Time.realtimeSinceStartupAsDouble + _backoffSeconds;
+
+                _options.LogWarning("Failed to send request: {0}. Backing off for {1:F1}s.", www.error, _backoffSeconds);
+                _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, processedEnvelope);
                 yield break;
             }
 
-            OnConnectionSucceeded();
+            _backoffSeconds = 0.0;
+            _retryAfterRealtime = 0.0;
 
             var response = GetResponse(www);
             if (response is not null)
@@ -106,10 +108,6 @@ internal class UnityWebRequestTransport : HttpTransportBase
         }
     }
 
-    /// <summary>
-    /// Whether the platform reports a usable network. The platform's own probe wins over
-    /// reachability, which on Nintendo Switch claims the console is reachable while it is offline.
-    /// </summary>
     private bool IsNetworkAvailable()
     {
         if (_options.NetworkAvailabilityProbe is { } probe)
@@ -118,66 +116,6 @@ internal class UnityWebRequestTransport : HttpTransportBase
         }
 
         return _application.InternetReachability != NetworkReachability.NotReachable;
-    }
-
-    /// <summary>
-    /// Whether it is worth opening a connection for this envelope. Drops are recorded so client
-    /// reports still account for them.
-    /// </summary>
-    private bool CanAttemptSend(Envelope envelope)
-    {
-        if (!IsNetworkAvailable())
-        {
-            _options.LogDebug("No network available. Dropping envelope instead of attempting to send.");
-            _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
-            return false;
-        }
-
-        if (_consecutiveConnectionErrors > 0)
-        {
-            var remaining = _retryAfterRealtime - Time.realtimeSinceStartupAsDouble;
-            if (remaining > 0.0)
-            {
-                _options.LogDebug(
-                    "Backing off after {0} failed connection attempt(s). Dropping envelope, retrying in {1:F1}s.",
-                    _consecutiveConnectionErrors, remaining);
-                _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private void OnConnectionError(UnityWebRequest www, Envelope envelope)
-    {
-        _consecutiveConnectionErrors++;
-
-        var backoff = Math.Min(
-            MaxBackoffSeconds,
-            InitialBackoffSeconds * Math.Pow(2, _consecutiveConnectionErrors - 1));
-        _retryAfterRealtime = Time.realtimeSinceStartupAsDouble + backoff;
-
-        // Reachability is logged because a platform claiming to be reachable while the connection
-        // fails is the case the backoff exists to cover.
-        var backoffDetail = $"{backoff:F1}s (consecutive failure #{_consecutiveConnectionErrors})";
-        _options.LogWarning(
-            "Failed to send request: {0}. Reachability reported as {1}. Backing off for {2}.",
-            www.error, _application.InternetReachability, backoffDetail);
-
-        _options.ClientReportRecorder.RecordDiscardedEvents(DiscardReason.NetworkError, envelope);
-    }
-
-    private void OnConnectionSucceeded()
-    {
-        if (_consecutiveConnectionErrors == 0)
-        {
-            return;
-        }
-
-        _options.LogDebug("Connection restored after {0} failed attempt(s).", _consecutiveConnectionErrors);
-        _consecutiveConnectionErrors = 0;
-        _retryAfterRealtime = 0.0;
     }
 
     private UnityWebRequest CreateWebRequest(HttpRequestMessage message)

--- a/test/Sentry.Unity.Tests/UnityWebRequestTransportTests.cs
+++ b/test/Sentry.Unity.Tests/UnityWebRequestTransportTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using Sentry.Protocol.Envelopes;
+using Sentry.Unity.Tests.Stubs;
+using UnityEngine;
+
+namespace Sentry.Unity.Tests;
+
+[TestFixture]
+public class UnityWebRequestTransportTests
+{
+    private static SentryUnityOptions CreateOptions() => new()
+    {
+        Dsn = SentryTests.TestDsn
+    };
+
+    private static Envelope CreateEnvelope() => Envelope.FromEvent(new SentryEvent());
+
+    /// <summary>
+    /// The coroutine has to bail before its first yield. Anything else means a
+    /// <see cref="UnityEngine.Networking.UnityWebRequest"/> got created, which is what raises the
+    /// system connection dialog on platforms like the Nintendo Switch.
+    /// </summary>
+    [Test]
+    public void SendEnvelopeAsync_NetworkNotReachable_DoesNotOpenAConnection()
+    {
+        var application = new TestApplication { InternetReachability = NetworkReachability.NotReachable };
+        var transport = new UnityWebRequestTransport(CreateOptions(), application);
+
+        var enumerator = transport.SendEnvelopeAsync(CreateEnvelope());
+
+        Assert.IsFalse(enumerator.MoveNext(), "The transport attempted to send while offline.");
+    }
+
+    [Test]
+    public void SendEnvelopeAsync_NetworkReachable_AttemptsToSend()
+    {
+        var application = new TestApplication
+        {
+            InternetReachability = NetworkReachability.ReachableViaLocalAreaNetwork
+        };
+        var transport = new UnityWebRequestTransport(CreateOptions(), application);
+
+        var enumerator = transport.SendEnvelopeAsync(CreateEnvelope());
+
+        Assert.IsTrue(enumerator.MoveNext(), "The transport did not attempt to send while online.");
+    }
+}

--- a/test/Sentry.Unity.Tests/UnityWebRequestTransportTests.cs
+++ b/test/Sentry.Unity.Tests/UnityWebRequestTransportTests.cs
@@ -16,9 +16,8 @@ public class UnityWebRequestTransportTests
     private static Envelope CreateEnvelope() => Envelope.FromEvent(new SentryEvent());
 
     /// <summary>
-    /// The coroutine has to bail before its first yield. Anything else means a
-    /// <see cref="UnityEngine.Networking.UnityWebRequest"/> got created, which is what raises the
-    /// system connection dialog on platforms like the Nintendo Switch.
+    /// A coroutine that yields has created a <see cref="UnityEngine.Networking.UnityWebRequest"/>,
+    /// which is what raises the system connection dialog on platforms like the Nintendo Switch.
     /// </summary>
     [Test]
     public void SendEnvelopeAsync_NetworkNotReachable_DoesNotOpenAConnection()
@@ -46,9 +45,8 @@ public class UnityWebRequestTransportTests
     }
 
     /// <summary>
-    /// The platform probe has the final say. On Nintendo Switch reachability reports the console as
-    /// reachable while it is offline, and attempting the send is what raises the system dialog - so
-    /// a probe saying "no network" has to win over reachability saying otherwise.
+    /// The probe has the final say: on Nintendo Switch reachability claims the console is reachable
+    /// while it is offline, which is the state the dialog gets raised in.
     /// </summary>
     [Test]
     public void SendEnvelopeAsync_ProbeReportsNoNetwork_OverridesReachability()

--- a/test/Sentry.Unity.Tests/UnityWebRequestTransportTests.cs
+++ b/test/Sentry.Unity.Tests/UnityWebRequestTransportTests.cs
@@ -44,4 +44,38 @@ public class UnityWebRequestTransportTests
 
         Assert.IsTrue(enumerator.MoveNext(), "The transport did not attempt to send while online.");
     }
+
+    /// <summary>
+    /// The platform probe has the final say. On Nintendo Switch reachability reports the console as
+    /// reachable while it is offline, and attempting the send is what raises the system dialog - so
+    /// a probe saying "no network" has to win over reachability saying otherwise.
+    /// </summary>
+    [Test]
+    public void SendEnvelopeAsync_ProbeReportsNoNetwork_OverridesReachability()
+    {
+        var application = new TestApplication
+        {
+            InternetReachability = NetworkReachability.ReachableViaLocalAreaNetwork
+        };
+        var options = CreateOptions();
+        options.NetworkAvailabilityProbe = () => false;
+        var transport = new UnityWebRequestTransport(options, application);
+
+        var enumerator = transport.SendEnvelopeAsync(CreateEnvelope());
+
+        Assert.IsFalse(enumerator.MoveNext(), "The transport ignored the platform's network probe.");
+    }
+
+    [Test]
+    public void SendEnvelopeAsync_ProbeReportsNetwork_OverridesReachability()
+    {
+        var application = new TestApplication { InternetReachability = NetworkReachability.NotReachable };
+        var options = CreateOptions();
+        options.NetworkAvailabilityProbe = () => true;
+        var transport = new UnityWebRequestTransport(options, application);
+
+        var enumerator = transport.SendEnvelopeAsync(CreateEnvelope());
+
+        Assert.IsTrue(enumerator.MoveNext(), "The transport ignored the platform's network probe.");
+    }
 }

--- a/test/SharedClasses/TestApplication.cs
+++ b/test/SharedClasses/TestApplication.cs
@@ -41,6 +41,7 @@ public sealed class TestApplication : IApplication
     public string UnityVersion { get; set; }
     public string PersistentDataPath { get; set; }
     public RuntimePlatform Platform { get; set; }
+    public NetworkReachability InternetReachability { get; set; } = NetworkReachability.ReachableViaLocalAreaNetwork;
 
     private void OnLogMessageReceived(string condition, string stacktrace, LogType type)
         => LogMessageReceived?.Invoke(condition, stacktrace, type);


### PR DESCRIPTION
## The bug

A Switch game that is offline showed the system "connect to the internet" dialog every couple of seconds, indefinitely.

`UnityWebRequestTransport` opens a connection per envelope, and on Switch the attempt itself is what raises the dialog. With logs and metrics both flushing on a 5s timer, that is a constant stream of popups. A connection error only logged a warning and returned `null`, which also skipped the rate-limit handling in `HttpTransportBase`. Nothing anywhere recorded that the network was down, and the next envelope tried again immediately.

## The what

**Back off after a connection error** — exponentially, 1s up to 300s, resetting on the first success. Envelopes turned away are recorded as `DiscardReason.NetworkError` so client reports still account for them instead of them vanishing. Reachability moves behind `IApplication` so the behaviour is testable.

**Ask sentry-switch whether the network is usable.** This is the part that actually removes the dialogs with the native support enabled. Asking Unity turned out to be untrustworthy here because `Application.internetReachability` reports a Switch console as reachable while it is offline. From the device:

```
Failed to send request: No Internet Connection.
Reachability reported as ReachableViaLocalAreaNetwork.
```

`sentry-switch` now exposes `sentry_switch_utils_is_network_available()`, see https://github.com/getsentry/sentry-switch/pull/188, which utilizes the console's network interface manager **without submitting a network request**. No request, not dialog. `SentryNativeSwitch` supplies it as `NetworkAvailabilityProbe` and the transport prefers it, falling back to reachability when no probe is set, which leaves WebGL and the unknown-platform path unchanged.

## Verified on a Switch 2 devkit

Offline, with the probe in place:

```
Sentry: (Debug) Using the native SDK to determine network availability.
Sentry: (Debug) No network available. Dropping envelope instead of attempting to send.
```

No `Failed to send request`, no backoff, **no dialogs** — no `UnityWebRequest` is ever constructed, so nothing can raise one.