### PR TITLE
fix: Invoke the option's setter on Android for `sampleRate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed a `NoSuchFieldError` during initialization on Android when setting the `sample rate`. ([#2838](https://github.com/getsentry/sentry-unity/issues/2838))
+
 ## 4.10.0
 
 ### Behavioural Changes and Deprecations

--- a/src/Sentry.Unity.Android/SentryJava.cs
+++ b/src/Sentry.Unity.Android/SentryJava.cs
@@ -131,7 +131,8 @@ internal class SentryJava : ISentryJava
 
                 if (options.SampleRate.HasValue)
                 {
-                    androidOptions.SetIfNotNull("setSampleRate", options.SampleRate.Value);
+                    using var sampleRate = new AndroidJavaObject("java.lang.Double", (double)options.SampleRate.Value);
+                    androidOptions.Call("setSampleRate", sampleRate);
                 }
 
                 androidOptions.Call("setMaxBreadcrumbs", options.MaxBreadcrumbs);


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2837

The sample rate was applied with `SetIfNotNull`, which calls Unity's `AndroidJavaObject.Set`. That writes a field over JNI, so it looked for a field literally named `setSampleRate`. But it's actually the setter's name we have to invoke.