### PR TITLE
fix(android): write lowercase `booleans` to the `AndroidManifest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed a `NoSuchFieldError` during initialization on Android when setting the `sample rate`. ([#2838](https://github.com/getsentry/sentry-unity/issues/2838))
+- Fixed a potential startup crash when targeting Android. The SDK would still set up native support even without a DSN provided. This would cause `sentry-java` to auto-initialize during startup via the `SentryInitProvider`. The SDK now verifies the presence of a DSN at build time, skipping native support when it's missing and logs accordingly. ([#2846](https://github.com/getsentry/sentry-unity/issues/2846))
 
 ## 4.10.0
 

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -114,10 +114,9 @@ public class AndroidManifestConfiguration
     }
 
     /// <summary>
-    /// Whether this build ships the Android SDK. Every build step that puts the SDK into the gradle project
-    /// shares this with <see cref="ModifyManifest"/>. They have to agree: an app that carries
-    /// `sentry-android-core` without the matching manifest entries lets `SentryInitProvider` auto-initialize
-    /// without a DSN, and sentry-java throws out of `ContentProvider.onCreate`, killing the app on startup.
+    /// Whether this build ships the Android SDK. Shared with <see cref="ModifyManifest"/> because an app that
+    /// carries `sentry-android-core` without the matching manifest entries auto-initializes without a DSN,
+    /// which crashes it on startup.
     /// </summary>
     private bool AndroidSdkEnabled => _androidSdkEnabled ??= EvaluateAndroidSdkEnabled();
 
@@ -160,8 +159,7 @@ public class AndroidManifestConfiguration
 
         if (!AndroidSdkEnabled)
         {
-            // The Android SDK gets removed from the gradle project further down. Should it end up in the app
-            // anyway, this keeps it from auto-initializing without a DSN and crashing on startup.
+            // Should the SDK end up in the app regardless, this keeps it from crashing on startup.
             _logger.LogDebug("Setting 'auto-init' to 'false'. The Android SDK is not part of this build.");
             androidManifest.SetAutoInit(false);
             _ = androidManifest.Save();
@@ -281,6 +279,13 @@ public class AndroidManifestConfiguration
         }
         else
         {
+            if (!Directory.Exists(androidSdkPath))
+            {
+                // A build that does not ship the SDK has no reason to fail over a missing SDK.
+                _logger.LogDebug("Failed to find the Android SDK at '{0}'. Nothing to remove.", androidSdkPath);
+                return;
+            }
+
             _logger.LogInfo("Removing the Android SDK from the output project.");
             foreach (var file in Directory.GetFiles(androidSdkPath))
             {

--- a/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
+++ b/src/Sentry.Unity.Editor/Android/AndroidManifestConfiguration.cs
@@ -48,6 +48,8 @@ public class AndroidManifestConfiguration
     private readonly bool _isDevelopmentBuild;
     private readonly ScriptingImplementation _scriptingImplementation;
 
+    private bool? _androidSdkEnabled;
+
     public AndroidManifestConfiguration()
         : this(
             SentryScriptableObject.LoadOptions,
@@ -111,6 +113,38 @@ public class AndroidManifestConfiguration
         SetupProguard(gradleProjectPath);
     }
 
+    /// <summary>
+    /// Whether this build ships the Android SDK. Every build step that puts the SDK into the gradle project
+    /// shares this with <see cref="ModifyManifest"/>. They have to agree: an app that carries
+    /// `sentry-android-core` without the matching manifest entries lets `SentryInitProvider` auto-initialize
+    /// without a DSN, and sentry-java throws out of `ContentProvider.onCreate`, killing the app on startup.
+    /// </summary>
+    private bool AndroidSdkEnabled => _androidSdkEnabled ??= EvaluateAndroidSdkEnabled();
+
+    private bool EvaluateAndroidSdkEnabled()
+    {
+        if (_options is null)
+        {
+            _logger.LogWarning("Android native support disabled because Sentry has not been configured. " +
+                               "You can do that through the editor: {0}", SentryWindow.EditorMenuPath);
+            return false;
+        }
+
+        if (!_options.IsValid())
+        {
+            _logger.LogDebug("Android native support disabled.");
+            return false;
+        }
+
+        if (!_options.AndroidNativeSupportEnabled)
+        {
+            _logger.LogDebug("Android native support disabled through the options.");
+            return false;
+        }
+
+        return true;
+    }
+
     internal void ModifyManifest(string basePath)
     {
         var manifestPath = GetManifestPath(basePath);
@@ -120,33 +154,20 @@ public class AndroidManifestConfiguration
                 manifestPath);
         }
 
-        var enableNativeSupport = true;
-        if (_options is null)
-        {
-            _logger.LogWarning("Android native support disabled because Sentry has not been configured. " +
-                               "You can do that through the editor: {0}", SentryWindow.EditorMenuPath);
-            enableNativeSupport = false;
-        }
-        else if (!_options.IsValid())
-        {
-            _logger.LogDebug("Android native support disabled.");
-            enableNativeSupport = false;
-        }
-        else if (!_options.AndroidNativeSupportEnabled)
-        {
-            _logger.LogDebug("Android native support disabled through the options.");
-            enableNativeSupport = false;
-        }
-
         var androidManifest = new AndroidManifest(manifestPath, _logger);
         androidManifest.RemovePreviousConfigurations();
+        androidManifest.AddDisclaimerComment();
 
-        if (!enableNativeSupport)
+        if (!AndroidSdkEnabled)
         {
+            // The Android SDK gets removed from the gradle project further down. Should it end up in the app
+            // anyway, this keeps it from auto-initializing without a DSN and crashing on startup.
+            _logger.LogDebug("Setting 'auto-init' to 'false'. The Android SDK is not part of this build.");
+            androidManifest.SetAutoInit(false);
+            _ = androidManifest.Save();
+
             return;
         }
-
-        androidManifest.AddDisclaimerComment();
 
         if (_options?.AndroidNativeInitializationType is NativeInitializationType.Runtime)
         {
@@ -239,7 +260,7 @@ public class AndroidManifestConfiguration
         var androidSdkPath = Path.Combine(unityProjectPath, "Packages", SentryPackageInfo.GetName(), "Plugins", "Android", "Sentry~");
         var targetPath = Path.Combine(gradlePath, "unityLibrary", "libs");
 
-        if (_options is { Enabled: true, AndroidNativeSupportEnabled: true })
+        if (AndroidSdkEnabled)
         {
             if (!Directory.Exists(androidSdkPath))
             {
@@ -275,7 +296,7 @@ public class AndroidManifestConfiguration
     internal void AddAndroidSdkDependencies(string gradleProjectPath)
     {
         var tool = new GradleSetup(_logger, gradleProjectPath);
-        var nativeSupportEnabled = _options is { Enabled: true, AndroidNativeSupportEnabled: true };
+        var nativeSupportEnabled = AndroidSdkEnabled;
 
         try
         {
@@ -358,7 +379,7 @@ public class AndroidManifestConfiguration
     private void SetupProguard(string gradleProjectPath)
     {
         var tool = new ProguardSetup(_logger, gradleProjectPath);
-        var nativeSupportEnabled = _options is { Enabled: true, AndroidNativeSupportEnabled: true };
+        var nativeSupportEnabled = AndroidSdkEnabled;
 
         try
         {

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -547,6 +547,25 @@ public class AndroidManifestTests
     }
 
     [Test]
+    public void CopyAndroidSdkToGradleProject_AndroidSdkDisabledAndSourceMissing_DoesNotThrow()
+    {
+        var fakeProjectPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var unityProjectPath = Path.Combine(fakeProjectPath, "UnityProject");
+        var gradleProjectPath = Path.Combine(fakeProjectPath, "GradleProject");
+        DebugSymbolUploadTests.SetupFakeProject(fakeProjectPath);
+        Directory.Delete(
+            Path.Combine(unityProjectPath, "Packages", SentryPackageInfo.GetName(), "Plugins", "Android", "Sentry~"),
+            true);
+
+        _fixture.SentryUnityOptions!.AndroidNativeSupportEnabled = false;
+        var sut = _fixture.GetSut();
+
+        Assert.DoesNotThrow(() => sut.CopyAndroidSdkToGradleProject(unityProjectPath, gradleProjectPath));
+
+        Directory.Delete(fakeProjectPath, true);
+    }
+
+    [Test]
     public void CopyAndroidSdkToGradleProject_SdkAlreadyExists_OverwritesExistingSdk()
     {
         var fakeProjectPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
+++ b/test/Sentry.Unity.Editor.Tests/Android/AndroidManifestConfigurationTests.cs
@@ -114,6 +114,38 @@ public class AndroidManifestTests
     }
 
     [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    public void ModifyManifest_AndroidSdkDisabled_SetsAutoInitToFalse(string? dsn)
+    {
+        _fixture.SentryUnityOptions!.Dsn = dsn;
+        var sut = _fixture.GetSut();
+        var manifest = WithAndroidManifest(basePath => sut.ModifyManifest(basePath));
+
+        StringAssert.Contains("<meta-data android:name=\"io.sentry.auto-init\" android:value=\"False\" />", manifest);
+    }
+
+    [Test]
+    public void CopyAndroidSdkToGradleProject_EnabledWithoutDsn_RemovesAndroidSdkFromGradleProject()
+    {
+        var fakeProjectPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var unityProjectPath = Path.Combine(fakeProjectPath, "UnityProject");
+        var gradleProjectPath = Path.Combine(fakeProjectPath, "GradleProject");
+        DebugSymbolUploadTests.SetupFakeProject(fakeProjectPath);
+        var androidSdk = Path.Combine(gradleProjectPath, "unityLibrary", "libs", "androidSdk.jar");
+        File.Create(androidSdk).Close();
+
+        _fixture.SentryUnityOptions!.Dsn = string.Empty;
+        var sut = _fixture.GetSut();
+
+        sut.CopyAndroidSdkToGradleProject(unityProjectPath, gradleProjectPath);
+
+        Assert.IsFalse(File.Exists(androidSdk));
+
+        Directory.Delete(fakeProjectPath, true);
+    }
+
+    [Test]
     public void ModifyManifest_UnityOptions_AndroidNativeSupportEnabledFalse_LogDebugAndDoesNotAddSentry()
     {
         _fixture.SentryUnityOptions!.AndroidNativeSupportEnabled = false;


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-unity/issues/2843
Works around https://github.com/getsentry/sentry-android-gradle-plugin/issues/1454

But is good cleanup, so, here we go.